### PR TITLE
Fix unstable Utils: Delegate unit test - Closes #106

### DIFF
--- a/src/components/registerDelegate/registerDelegate.test.js
+++ b/src/components/registerDelegate/registerDelegate.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
-import Lisk from 'lisk-js';
 import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
 import i18n from '../../i18n'; // initialized i18next instance
@@ -40,13 +39,7 @@ const withSecondSecretAccount = {
 
 const props = {
   peers: {
-    data: Lisk.api({
-      name: 'Custom Node',
-      custom: true,
-      address: 'http://localhost:4000',
-      testnet: true,
-      nethash: '198f2b61a8eb95fbeed58b8216780b68f697f26b849acf00c8c93bb9b24f783d',
-    }),
+    data: {},
   },
   closeDialog: () => {},
   delegateRegistered: sinon.spy(),


### PR DESCRIPTION
### What was the problem?
The problem was that login middleware uses two nested
async calls: `getAccount` and `getDelegate`. One test was not mocking
those calls, so it sometimes happened in Jenkins that the `getDelegate`
got executed in middle of `Utils: Delegate` unit tests.
And those unit test are mocking peers and checking what gets called, so
they fail when some extra call is called

### How did I fix it?
Removed use of lisk-js from unit tests and mocked api calls properly

### How to test it?
Run tests with slow network connection (e.g. in Jenkins)

### Review checklist
- The PR solves #106 
- All new code is covered with unit tests
- All new code follows best practices
