### PR TITLE
Fix: Register delegate causes an infinite loop - Closes #128

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,5 +1,5 @@
 import { getAccount, transactions as getTransactions } from '../../utils/api/account';
-import { accountUpdated, accountLoggedIn } from '../../actions/account';
+import { accountUpdated } from '../../actions/account';
 import { transactionsUpdated } from '../../actions/transactions';
 import { activePeerUpdate } from '../../actions/peers';
 import { votesFetched } from '../../actions/voting';
@@ -65,7 +65,7 @@ const delegateRegistration = (store, action) => {
   if (delegateRegistrationTx) {
     getDelegate(state.peers.data, { publicKey: state.account.publicKey })
       .then((delegateData) => {
-        store.dispatch(accountLoggedIn(Object.assign({},
+        store.dispatch(accountUpdated(Object.assign({},
           { delegate: delegateData.delegate, isDelegate: true })));
       });
   }


### PR DESCRIPTION
### What was the problem?
See #128

### How did I fix it?
Dispatch accountUpdated instead of accountLoggedIn on delegate registration

### How to test it?
Follow steps in #128

### Review checklist
- The PR solves #128
- All new code is covered with unit tests
- All new code follows best practices
