### PR TITLE
Fix flaky new account e2e test - Closes #135

### DIFF
--- a/src/components/passphrase/confirm/index.js
+++ b/src/components/passphrase/confirm/index.js
@@ -204,7 +204,7 @@ class Confirm extends React.Component {
             <PrimaryButton
               theme={styles}
               label={this.props.t('Get to your Dashboard')}
-              className="next-button"
+              className="get-to-your-dashboard-button"
               onClick={() => this.props.finalCallback({ passphrase: words.join(' ') })}
             />
           </div>

--- a/src/components/passphrase/confirm/index.test.js
+++ b/src/components/passphrase/confirm/index.test.js
@@ -65,7 +65,7 @@ describe('Passphrase: Confirm', () => {
     });
     wrapper.update();
 
-    const wrapperProps = wrapper.find('button.next-button').props();
+    const wrapperProps = wrapper.find('button.get-to-your-dashboard-button').props();
     expect(wrapperProps.disabled).to.be.equal(true);
   });
 
@@ -83,7 +83,7 @@ describe('Passphrase: Confirm', () => {
     });
     wrapper.update();
 
-    const wrapperProps = wrapper.find('button.next-button').props();
+    const wrapperProps = wrapper.find('button.get-to-your-dashboard-button').props();
     expect(wrapperProps.disabled).to.not.be.equal(true);
   });
 });

--- a/src/components/passphrase/create/index.js
+++ b/src/components/passphrase/create/index.js
@@ -222,7 +222,7 @@ class Create extends React.Component {
               <PrimaryButton
                 theme={styles}
                 label='Get passphrase'
-                className="next-button"
+                className="get-passphrase-button"
                 onClick={() => nextStep({ passphrase: this.state.passphrase })}
               />
             </div>

--- a/src/components/passphrase/safekeeping/index.js
+++ b/src/components/passphrase/safekeeping/index.js
@@ -73,7 +73,7 @@ class PassphraseShow extends React.Component {
               }}
               primaryButton={{
                 label: t('Yes! It\'s safe'),
-                className: 'next-button',
+                className: 'yes-its-safe-button',
                 onClick: () => nextStep({ passphrase }),
               }} />
           </div>

--- a/src/components/passphrase/safekeeping/index.test.js
+++ b/src/components/passphrase/safekeeping/index.test.js
@@ -68,7 +68,7 @@ describe('Passphrase: Safekeeping', () => {
   });
 
   it('should call nextStep if Next button clicked', () => {
-    wrapper.find('button.next-button').simulate('click');
+    wrapper.find('button.yes-its-safe-button').simulate('click');
     expect(props.nextStep).to.have.been.calledWith();
   });
 });

--- a/test/e2e/login.feature
+++ b/test/e2e/login.feature
@@ -31,9 +31,9 @@ Feature: Login page
     And I wait 1 seconds
     And I 250 times move mouse randomly
     And I wait 2 seconds
-    And I click "next button"
+    And I click "get passphrase button"
     And I swipe "i understand checkbox" to right
     And I swipe "reveal checkbox" to right
-    And I remember passphrase, click "next button", choose missing words
-    And I click "next button"
+    And I remember passphrase, click "yes its safe button", choose missing words
+    And I click "get to your dashboard button"
     Then I should be logged in

--- a/test/e2e/registerSecondPassphrase.feature
+++ b/test/e2e/registerSecondPassphrase.feature
@@ -4,9 +4,11 @@ Feature: Register second passphrase
     When I click "register second passphrase" in main menu
     And I click "next button"
     And I 250 times move mouse randomly
-    And I click "next button"
-    And I remember passphrase, click "next button", fill in missing word
-    And I click "next button"
+    And I click "get passphrase button"
+    And I swipe "i understand checkbox" to right
+    And I swipe "reveal checkbox" to right
+    And I remember passphrase, click "yes its safe button", choose missing words
+    And I click "get to your dashboard button"
     Then I should see alert dialog with title "Success" and text "Second passphrase registration was successfully submitted. It can take several seconds before it is processed."
 
   Scenario: should not allow to set 2nd passphrase again


### PR DESCRIPTION
### What was the problem?
the problem was that the same class name (.next-button) was used for multiple buttons
in different steps and e2e tests were getting the button from the
previous step, because it was still in the DOM because of hiding animation

### How did I fix it?
Used different class names

### How to test it?
Run e2e tests multiple times, namely:
`npm run e2e-test -s -- --specs test/e2e/registerSecondPassphrase.feature:2`
`npm run e2e-test -s -- --specs test/e2e/login.feature:28`

### Review checklist
- The PR solves #135 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
