### PR TITLE
Fix flaky Account switch integration test - Closes #165

### DIFF
--- a/src/components/savedAccounts/savedAccounts.js
+++ b/src/components/savedAccounts/savedAccounts.js
@@ -41,7 +41,10 @@ class SavedAccounts extends React.Component {
   }
 
   isSelectedForRemove(account) {
-    return account === this.state.accountSelectedForRemove;
+    const { publicKey, network, address } = this.state.accountSelectedForRemove || {};
+    return (account.publicKey === publicKey &&
+      account.network === network &&
+      account.address === address);
   }
 
   handleRemove(account, e) {


### PR DESCRIPTION
### What was the problem?
The problem was that sometimes compared accounts were not the same
objects in memory.

### How did I fix it?
By not comparing the objects

### How to test it?
I recommend wrapping `Scenario: should allow to remove a saved account` in `test/integration/accountSwitch.test.js` with

```
for (let i = 0; i <= 100; i++) {
  describe.only('Scenario: should allow to remove a saved account', () => {
```


### Review checklist
- The PR solves #165 
- All new code is covered with unit tests
- All new code follows best practices

  