### PR TITLE
Change styles of the network indicator - Closes #192

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -132,7 +132,6 @@
   "Passphrase should have 12 words, entered passphrase has {{length}}": "Passphrase should have 12 words, entered passphrase has {{length}}",
   "Password": "Password",
   "Paste": "Paste",
-  "Peer": "Peer",
   "Please check the highlighted words": "Please check the highlighted words",
   "Please click Next, then move around your mouse randomly to generate a random passphrase.": "Please click Next, then move around your mouse randomly to generate a random passphrase.",
   "Please go back and check your passphrase again.": "Please go back and check your passphrase again.",

--- a/src/components/account/account.css
+++ b/src/components/account/account.css
@@ -1,4 +1,4 @@
-@import '../app/variables';
+@import './../app/variables.css';
 
 :root {
   --online: #73cba9;
@@ -78,31 +78,25 @@
 }
 
 .title {
-  font-size: 20px;
-  font-weight: 500;
-  letter-spacing: 0;
-  margin-top: 0;
-  margin-top: 20px;
-  margin-bottom: 16px;
-  text-align: center;
+  color: white;
 }
 
-/* @todo please remove .temp by #13 */
-.temp {
-  width: 350px;
-  float: right;
-  position: relative;
-  bottom: -100px;
+.status {
+  vertical-align: sub;
+}
+
+.current {
+  color: var(--color-grayscale-medium);
+}
+
+.peer {
+  font-size: 16px;
+  float: left;
+  margin: 50px 0px;
 }
 
 @media (--medium-viewport) {
-  .temp {
+  .peer {
     display: none;
-  }
-}
-
-@media only screen and (min-width: 48em) {
-  .title {
-    margin-top: 0;
   }
 }

--- a/src/components/account/account.js
+++ b/src/components/account/account.js
@@ -14,19 +14,13 @@ const Account = ({ peers, t }) => {
     <i className="material-icons offline">error</i>;
 
   return (peers.data.options.code !== networks.mainnet.code ?
-    <section className={styles.temp}>
-      <span className={styles.title}>
-        {t('Peer')}
-      </span>
-      <span id="accountStatus" className="status">
-        {status}
-      </span>
-      <span className="inner primary peer-network">
-        {t(peers.data.options.name)}
-      </span>
-      <span className="inner secondary peer">
+    <section className={styles.peer}>
+      <div className={`${styles.title} inner primary peer-network`}>{t(peers.data.options.name)} <span id="accountStatus" className={`${styles.status} status`}>{status}</span>
+      </div>
+
+      <span className={`${styles.current} inner secondary peer`}>
         {peers.data.currentPeer}
-        <span> : {peers.data.port}</span>
+        <span>:{peers.data.port}</span>
       </span>
     </section> :
     null


### PR DESCRIPTION
### What was the problem?
The network info still had the old style

### How did I fix it?
Came up with a more consistent style

### What it looks like now:
<img width="1056" alt="screen shot 2018-01-11 at 16 30 26" src="https://user-images.githubusercontent.com/9592216/34833485-d08453b4-f6ef-11e7-9657-9f7e93706aa9.png">

### Review checklist
- The PR solves https://github.com/LiskHQ/lisk-wallet/issues/192

