### PR TITLE
Fix randomly breaking unit test of passphrase - Closes #197

### DIFF
--- a/src/components/passphrase/confirm/index.test.js
+++ b/src/components/passphrase/confirm/index.test.js
@@ -101,7 +101,7 @@ describe('Passphrase: Confirm', () => {
     // for each fieldset, checks the input if its value exist in passphrase
     wrapper.find('fieldset').forEach((fieldset) => {
       fieldset.find('input').forEach((input) => {
-        if (account.passphrase.indexOf(input.props().value) > 0) {
+        if (account.passphrase.indexOf(input.props().value) > -1) {
           input.simulate('change', { target: { checked: true } });
         }
       });


### PR DESCRIPTION
### What was the problem?
The problem was that it didn't allow the missing word to be index 0
### How did I fix it?
changing 0 to -1
### How to test it?
I recommend wrapping `should enable Next button if answer is correct` in `src/components/passphrase/confirm/index.test.js` with

```
for (let i = 0; i <= 100; i++) {
  it.only('should enable Next button if answer is correct', () => {
```

### Review checklist
- The PR solves #197
- All new code follows best practices
