### PR TITLE
Logout when the last saved account is removed - Closes #281

### DIFF
--- a/src/store/middlewares/savedAccounts.js
+++ b/src/store/middlewares/savedAccounts.js
@@ -1,5 +1,5 @@
 import actionTypes from '../../constants/actions';
-import { accountLoading } from '../../actions/account';
+import { accountLoading, accountLoggedOut } from '../../actions/account';
 import { accountsRetrieved, accountSaved } from '../../actions/savedAccounts';
 import { activePeerSet } from '../../actions/peers';
 import getNetwork from '../../utils/getNetwork';
@@ -27,7 +27,7 @@ const savedAccountsMiddleware = (store) => {
 
   return next => (action) => {
     next(action);
-    const { peers, account } = store.getState();
+    const { peers, account, savedAccounts } = store.getState();
     switch (action.type) {
       case actionTypes.accountSwitched:
         store.dispatch(accountLoading());
@@ -56,6 +56,11 @@ const savedAccountsMiddleware = (store) => {
           network: peers.options.code,
           address: peers.options.address,
         }));
+        break;
+      case actionTypes.accountRemoved:
+        if (savedAccounts.accounts.length === 0) {
+          store.dispatch(accountLoggedOut());
+        }
         break;
       default:
         break;

--- a/src/store/reducers/peers.js
+++ b/src/store/reducers/peers.js
@@ -18,8 +18,6 @@ const peers = (state = { status: {}, options: {} }, action) => {
       });
     case actionTypes.activePeerUpdate:
       return Object.assign({}, state, { status: action.data });
-    case actionTypes.accountLoggedOut:
-      return Object.assign({}, state, { data: {}, status: {}, options: {} });
     default:
       return state;
   }

--- a/src/store/reducers/peers.test.js
+++ b/src/store/reducers/peers.test.js
@@ -33,25 +33,5 @@ describe('Reducer: peers(state, action)', () => {
     const changedState = peers(state, action);
     expect(changedState).to.deep.equal(newState);
   });
-
-  it('should return and empty state object if action is accountLoggedOut', () => {
-    const state = {
-      data: {
-        currentPeer: 'localhost',
-        port: 4000,
-        options: {
-          name: 'Custom Node',
-        },
-      },
-      status: { online: true },
-    };
-    const action = {
-      type: actionTypes.accountLoggedOut,
-    };
-
-    const newState = { status: {}, data: {}, options: {} };
-    const changedState = peers(state, action);
-    expect(changedState).to.deep.equal(newState);
-  });
 });
 


### PR DESCRIPTION
### What was the problem?
After removing the last account, user was still logged into the account

### How did I fix it?
Logout user when "Done" is clicked after removing all accounts

### How to test it?
- log in to an account 
- remove the account from saved accounts

### Review checklist
- The PR solves #281
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
