### PR TITLE
Use bigger window dimensions the of electron app - Closes #276

### DIFF
--- a/app/src/modules/win.js
+++ b/app/src/modules/win.js
@@ -8,8 +8,8 @@ const win = {
     const { width, height } = electron.screen.getPrimaryDisplay().workAreaSize;
     const { BrowserWindow } = electron;
     win.browser = new BrowserWindow({
-      width: width > 2000 ? Math.floor(width * 0.5) : width - 250,
-      height: height > 1000 ? Math.floor(height * 0.7) : height - 150,
+      width: width > 1680 ? 1680 : width,
+      height: height > 1050 ? 1050 : height,
       center: true,
       webPreferences: {
         // Avoid app throttling when Electron is in background

--- a/app/src/modules/win.test.js
+++ b/app/src/modules/win.test.js
@@ -5,7 +5,7 @@ import win from './win';
 describe('Electron Browser Window Wrapper', () => {
   let electron;
   electron = {
-    screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 2000, height: 1000 } }) },
+    screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 1400, height: 900 } }) },
     BrowserWindow: ({ width, height, center, webPreferences }) =>
       ({
         width,
@@ -45,17 +45,17 @@ describe('Electron Browser Window Wrapper', () => {
       expect(win.browser.loadURL).to.have.been.calledWith(`file://${__dirname}/index.html`);
     });
 
-    it('Creates the window and knows how to adjust the size', () => {
+    it('Creates the window of maximum size possible size on < 1680X1050 display', () => {
       win.init({ electron, path, electronLocalshortcut });
-      expect(win.browser.height).to.equal(850);
-      expect(win.browser.width).to.equal(1750);
+      expect(win.browser.height).to.equal(900);
+      expect(win.browser.width).to.equal(1400);
     });
 
-    it('Creates the window and knows how to adjust the size', () => {
-      electron.screen.getPrimaryDisplay = () => ({ workAreaSize: { width: 2001, height: 1001 } });
+    it('Creates the window of maximum 1680X1050 on a bigger than that display', () => {
+      electron.screen.getPrimaryDisplay = () => ({ workAreaSize: { width: 2001, height: 1051 } });
       win.init({ electron, path, electronLocalshortcut });
-      expect(win.browser.height).to.equal(700);
-      expect(win.browser.width).to.equal(1000);
+      expect(win.browser.height).to.equal(1050);
+      expect(win.browser.width).to.equal(1680);
     });
   });
 
@@ -88,7 +88,7 @@ describe('Electron Browser Window Wrapper', () => {
     };
 
     electron = {
-      screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 2000, height: 1000 } }) },
+      screen: { getPrimaryDisplay: () => ({ workAreaSize: { width: 1400, height: 900 } }) },
       BrowserWindow: ({ width, height, center, webPreferences }) =>
         ({
           width,


### PR DESCRIPTION
### What was the problem?
The window was too small and the designs didn't look best.

### How did I fix it?
Used 1680x1050 or as much as possible

### How to test it?
```
npm run build && npm run start
```
### Review checklist
- The PR solves #276
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
