### PR TITLE
Show transaction type on non-send transaction page - Closes #302

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -200,6 +200,7 @@
   "Transaction is being processed and will be confirmed. It may take up to 15 minutes to be secured in the blockchain.": "Transaction is being processed and will be confirmed. It may take up to 15 minutes to be secured in the blockchain.",
   "Transactions can’t be reversed": "Transactions can’t be reversed",
   "Try using menu for navigation.": "Try using menu for navigation.",
+  "Type": "Type",
   "URL is invalid": "URL is invalid",
   "Unable to connect to the node": "Unable to connect to the node",
   "Undo": "Undo",

--- a/src/components/transactions/transactionDetailView.js
+++ b/src/components/transactions/transactionDetailView.js
@@ -8,6 +8,7 @@ import CopyToClipboard from '../copyToClipboard';
 import AccountVisual from '../accountVisual';
 import styles from './transactions.css';
 import { FontIcon } from '../fontIcon';
+import TransactionType from './transactionType';
 import LiskAmount from '../liskAmount';
 import Amount from './amount';
 import routes from './../../constants/routes';
@@ -72,8 +73,16 @@ class TransactionsDetailView extends React.Component {
               </div>
             </div>
             <div className={`${grid['col-xs-12']} ${grid['col-sm-6']} ${grid['col-md-6']} ${styles.column}`}>
-              <div className={styles.label}>{this.props.t('Amount (LSK)')}</div>
-              <div className={styles.value}><Amount {...this.props}></Amount></div>
+              {this.props.value.type === 0
+                ? <div><div className={styles.label}>{this.props.t('Amount (LSK)')}</div>
+                  <div className={styles.value}><Amount {...this.props}></Amount></div>
+                </div>
+                : <div><div className={styles.label}>{this.props.t('Type')}</div>
+                  <div className={styles.value}>
+                    <TransactionType {...this.props.value} address={this.props.value.senderId} />
+                  </div>
+                </div>
+              }
             </div>
           </div>
           <div className={`${grid.row} ${styles.row}`}>


### PR DESCRIPTION
### What was the problem?
Amount "0" was shown in transaction details that were of type non-send

### How did I fix it?
By now showing the type instead of amount if type is not send

### How to test it?
Visit a transaction of other kinds than send and check that the type and not amount is displayed, also check that the amount is displayed for "send transactions"

<img width="643" alt="screen shot 2018-02-11 at 22 49 41" src="https://user-images.githubusercontent.com/9592216/36078964-f5371b32-0f7d-11e8-93fb-a2e57a9940d8.png">

### Review checklist
- The PR solves #302
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
