### PR TITLE
Fix the problem that doesn't let saveAccount to be open in no result page - Closes #325

### DIFF
--- a/src/utils/routes.js
+++ b/src/utils/routes.js
@@ -42,6 +42,11 @@ export default [
     params: 'address',
     name: 'accounts',
   }, {
+    regex: /\/explorer\/result\/([0-9]+|[a-z]+)(?:\/[^/]*)?$/,
+    path: new RegExp(`${routes.searchResult.long}/([0-9]+|[a-z]+)/`),
+    params: 'query',
+    name: 'result',
+  }, {
     regex: /\/explorer\/search(?:\/[^/]*)?$/,
     path: `${routes.search.long}/`,
     name: 'explorer',


### PR DESCRIPTION
### What was the problem?
Account switcher didn't work on search result pages as on any other page

### Review checklist
- The PR solves #325 
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
