### PR TITLE
Prevent loading bar from showing on every new block - Closes #375

### DIFF
--- a/src/store/middlewares/loadingBar.js
+++ b/src/store/middlewares/loadingBar.js
@@ -1,6 +1,8 @@
 import actionsType from '../../constants/actions';
 
-const ignoredLoadingActionKeys = ['loader/status'];
+const ignoredLoadingActionKeys = [
+  'transactions', // because this is called every 10 seconds and the app doesn't look good with so much loading going on.
+];
 
 const loadingBarMiddleware = () => next => (action) => {
   switch (action.type) {

--- a/src/store/middlewares/loadingBar.test.js
+++ b/src/store/middlewares/loadingBar.test.js
@@ -7,7 +7,7 @@ import actionType from '../../constants/actions';
 describe('LoadingBar middleware', () => {
   let store;
   let next;
-  const ignoredLoadingActionKeys = ['loader/status'];
+  const ignoredLoadingActionKeys = ['transactions'];
 
   beforeEach(() => {
     store = stub();


### PR DESCRIPTION
### What was the problem?
Loading bar was showing every 10 seconds when there was any transaction with < 1000 confirmations.

### How did I fix it?
Added `transactions` to the loading state ignore list.

### How to test it?
Open wallet with an account with any transaction with < 1000 confirmations.

### Review checklist
- The PR solves #375
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
