### PR TITLE
Fix price chart in iOS safari - Closes #377

### DIFF
--- a/src/components/dashboard/currencyGraph.css
+++ b/src/components/dashboard/currencyGraph.css
@@ -2,6 +2,7 @@
 
 .wrapper {
   height: 100%;
+  min-height: 200px;
   position: relative;
 
   & h2 {
@@ -11,6 +12,7 @@
 
 .chartWrapper {
   height: calc(100% - 70px);
+  min-height: 130px;
   width: calc(100% + 50px);
   margin: 0 -25px;
   position: absolute;
@@ -19,7 +21,7 @@
 }
 
 .errorMessage {
-  margin-top: 70px;
+  margin-top: 60px;
 }
 
 .stepSwitchWrapper {
@@ -39,6 +41,20 @@
     background: var(--gradient-tertiary);
     border-radius: var(--border-radius-normal);
     font-weight: 300;
+  }
+}
+
+@media (--medium-viewport) {
+  .wrapper {
+    min-height: 300px;
+  }
+
+  .chartWrapper {
+    min-height: 230px;
+  }
+
+  .errorMessage {
+    margin-top: 30px;
   }
 }
 

--- a/src/components/dashboard/styles.css
+++ b/src/components/dashboard/styles.css
@@ -19,6 +19,7 @@
 
 .graph {
   height: calc(60% - 20px);
+  min-height: 200px;
   margin-bottom: 20px;
   overflow: hidden;
 }
@@ -37,6 +38,8 @@
   .wrapper {
     & .colHack {
       padding: 0;
+      max-width: 100%;
+      flex-basis: 100%;
     }
 
     margin: 0;
@@ -44,7 +47,7 @@
 
   .graph {
     height: 60%;
-    min-height: auto;
+    min-height: 300px;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
### What was the problem?
- css `calc` doesn't work in older iOS
- flexboxgrid has different breakpoints than we

### How did I fix it?
- used `min-height: 300px` for the chart
- overridden the flexboxgrid max-width in our class

### How to test it?
Open the app on iOS devices ;-)

### Review checklist
- The PR solves #377
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
