### PR TITLE
Fix the issue with sequence of missing words in Register page - Closes #398

### DIFF
--- a/src/components/passphrase/confirm/index.js
+++ b/src/components/passphrase/confirm/index.js
@@ -121,7 +121,7 @@ class Confirm extends React.Component {
       return missing.sort((a, b) => a > b);
     };
 
-    const missing = chooseRandomWords(2);
+    const missing = chooseRandomWords(2).sort();
     const wordOptions = this.assembleWordOptions(words, missing);
 
     this.setState({
@@ -149,7 +149,7 @@ class Confirm extends React.Component {
 
     const mixWithMissingWords = (options) => {
       options.forEach((list, listIndex) => {
-        const rand = Math.floor(Math.random() * list.length);
+        const rand = Math.floor(Math.random() * 0.99 * list.length);
         list[rand] = passphraseWords[missingWords[listIndex]];
       });
 


### PR DESCRIPTION
### What was the problem?
The generated random array was not sorted. Also it could be out of range.

### How did I fix it?
 - Excluded the ending number of the interval, changing from [0, 1] to [0, 1)
 - Sorted the generated array of missing indexes.

### How to test it?
Try the passphrase confirmation step multiple times

### Review checklist
- The PR solves #398 
- All new code follows best practices