### PR TITLE
Remove www from help.lisk.io links

### DIFF
--- a/src/components/sidechains/index.js
+++ b/src/components/sidechains/index.js
@@ -24,7 +24,7 @@ class Sidechains extends React.Component {
         <div className={styles.subHeader}>
           {t('Sidechains will revolutionize the way decentralised apps are developed. Here you will be able to find hosts, and monitor your sidechains soon.')}
         </div>
-        <a target='_blank' href='http://www.help.lisk.io/faq#sidechains' rel='noopener noreferrer'>
+        <a target='_blank' href='http://help.lisk.io/faq#sidechains' rel='noopener noreferrer'>
           {t('Learn more about Lisk sidechains')}&nbsp;<FontIcon>arrow-right</FontIcon>
         </a>
         <img src={application} className={styles.smallGraphic}/>

--- a/src/components/votesPreview/index.js
+++ b/src/components/votesPreview/index.js
@@ -55,7 +55,7 @@ class VotesPreview extends React.Component {
         ${totalNewVotesCount > 0 ? styles.hasChanges : ''}`}>
         <header>
           <h2>{t('Votes')}</h2>
-          <a target='_blank' href='http://www.help.lisk.io/voting-and-delegates' rel='noopener noreferrer'>
+          <a target='_blank' href='http://help.lisk.io/voting-and-delegates' rel='noopener noreferrer'>
             {t('Learn how voting works')} <FontIcon>arrow-right</FontIcon>
           </a>
         </header>


### PR DESCRIPTION
### What was the problem?
there was some miscommunication between DevOps, Marketing, and Frontend about what should the links be.

### How did I fix it?
Removed www from www.help.lisk.io

