### PR TITLE
Fix the unVoted filter - Closes #405

### DIFF
--- a/src/components/delegateList/delegateList.js
+++ b/src/components/delegateList/delegateList.js
@@ -109,7 +109,7 @@ class DelegateList extends React.Component {
       case voteFilters.voted:
         return delegates.filter(delegate =>
           (votes[delegate.username] && votes[delegate.username].confirmed));
-      case voteFilters.unvoted:
+      case voteFilters.notVoted:
         return delegates.filter(delegate =>
           (!votes[delegate.username] || !votes[delegate.username].confirmed));
       default:


### PR DESCRIPTION
### What was the problem?
unVoted filter didn't work in delegateList.

### How did I fix it?
The name of the variable was used mistakenly.

### How to test it?
Make sure the filters work as expected.

### Review checklist
- The PR solves #405 
- All new code follows best practices