### PR TITLE
Prevent Testnet info from showing on loading

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -94,7 +94,9 @@ class Header extends React.Component {
         </div>
         <div className={`${styles.searchBar}`}>
           {this.shouldShowSearchBar() && <SearchBar/>}
-          <Account peers={this.props.peers} t={this.props.t}/>
+          {this.props.account.loading ?
+            null :
+            <Account peers={this.props.peers} t={this.props.t}/>}
         </div>
       </header>
     );


### PR DESCRIPTION
### What was the problem?
Testnet info was displayed when loading
<img width="1172" alt="screen shot 2018-02-18 at 08 04 09" src="https://user-images.githubusercontent.com/1254342/36349301-ab308644-1483-11e8-975b-88fbb5e9bd96.png">

### How did I fix it?
Set the network info to hide if `account.loading`.

### How to test it?
Switch testnet accounts with the slow network set in dev tools.


