### PR TITLE
Prevent same mainnet account saved multiple times - Closes #452

### DIFF
--- a/src/actions/peers.js
+++ b/src/actions/peers.js
@@ -18,22 +18,22 @@ const peerSet = (data, config) => ({
 
 const pickMainnetNode = () => {
   const nodes = [
-    'https://hub21.lisk.io',
-    'https://hub22.lisk.io',
-    'https://hub23.lisk.io',
-    'https://hub24.lisk.io',
-    'https://hub25.lisk.io',
-    'https://hub26.lisk.io',
-    'https://hub27.lisk.io',
-    'https://hub28.lisk.io',
-    'https://hub31.lisk.io',
-    'https://hub32.lisk.io',
-    'https://hub33.lisk.io',
-    'https://hub34.lisk.io',
-    'https://hub35.lisk.io',
-    'https://hub36.lisk.io',
-    'https://hub37.lisk.io',
-    'https://hub38.lisk.io',
+    'hub21.lisk.io',
+    'hub22.lisk.io',
+    'hub23.lisk.io',
+    'hub24.lisk.io',
+    'hub25.lisk.io',
+    'hub26.lisk.io',
+    'hub27.lisk.io',
+    'hub28.lisk.io',
+    'hub31.lisk.io',
+    'hub32.lisk.io',
+    'hub33.lisk.io',
+    'hub34.lisk.io',
+    'hub35.lisk.io',
+    'hub36.lisk.io',
+    'hub37.lisk.io',
+    'hub38.lisk.io',
   ];
   return nodes[Math.floor(Math.random() * nodes.length) % nodes.length];
 };
@@ -54,8 +54,9 @@ export const activePeerSet = data =>
     };
     const config = data.network || {};
     if (config.code === networks.mainnet.code) {
-      config.address = pickMainnetNode();
+      config.node = pickMainnetNode();
     }
+
 
     if (config.address) {
       const { hostname, port, protocol } = new URL(addHttp(config.address));

--- a/src/actions/peers.test.js
+++ b/src/actions/peers.test.js
@@ -67,14 +67,14 @@ describe('actions: peers', () => {
       expect(dispatch).to.have.been.calledWith(match.hasNested('data.activePeer.options.address', 'localhost:8000'));
     });
 
-    it('dispatch activePeerSet action with hubXX.lisk.io node address if mainnet', () => {
+    it('dispatch activePeerSet action with hubXX.lisk.io node if mainnet', () => {
       const network = networks.mainnet;
 
       activePeerSet({ passphrase, network })(dispatch);
 
       expect(dispatch).to.have.been.calledWith(match.hasNested(
-        'data.activePeer.options.address',
-        match(new RegExp('https://hub[23][1-8].lisk.io')),
+        'data.activePeer.options.node',
+        match(new RegExp('hub[23][1-8].lisk.io')),
       ));
     });
 


### PR DESCRIPTION
### What was the problem?
The problem was that we were setting address of mainnet node as hubXX.lisk.io
and saved accounts assume that different address are different accounts.

### How did I fix it?
The solution is to set node property instead of address property because
that is what lisk-js uses.

### How to test it?

- Login to mainnet
- refresh the page
- check saved accounts

### Review checklist
- The PR solves #452
- All new code is covered with unit tests
- All new features are covered with e2e tests
- All new code follows best practices
