### PR TITLE
Limit window size to 768x576 - Closes #892

### DIFF
--- a/app/src/modules/win.js
+++ b/app/src/modules/win.js
@@ -11,7 +11,7 @@ const win = {
       width: width > 1680 ? 1680 : width,
       height: height > 1050 ? 1050 : height,
       minHeight: 576,
-      minWidth: 768,
+      minWidth: 769,
       center: true,
       webPreferences: {
         // Avoid app throttling when Electron is in background


### PR DESCRIPTION
### What was the problem?
no minimal size of window
### How did I fix it?
Added minWidth and minHeight
### How to test it?
Open Electron app and try to resize it untill you reach min values
### Review checklist
- The PR solves #892
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
