### PR TITLE
Fix account info in Wallet to display votes - #1057

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -68,10 +68,10 @@ export const passphraseUsed = data => ({
  */
 export const accountVotesFetched = ({ activePeer, address }) =>
   dispatch =>
-    getVotes(activePeer, address).then(({ delegates }) => {
+    getVotes(activePeer, address).then(({ data }) => {
       dispatch({
         type: actionTypes.accountAddVotes,
-        votes: delegates,
+        votes: data.votes,
       });
     });
 

--- a/src/components/transactions/walletTransactions/walletTransactions.js
+++ b/src/components/transactions/walletTransactions/walletTransactions.js
@@ -24,11 +24,11 @@ class WalletTransactions extends React.Component {
         activePeer: this.props.activePeer,
         publicKey: this.props.account.delegate.publicKey,
       });
-      this.props.accountVotesFetched({
-        activePeer: this.props.activePeer,
-        address: this.props.address,
-      });
     }
+    this.props.accountVotesFetched({
+      activePeer: this.props.activePeer,
+      address: this.props.address,
+    });
 
     this.props.addFilter({
       filterName: 'wallet',


### PR DESCRIPTION
### What was the problem?
See #1057
The cause was:
- The votes were fetched only if the account was a delegate. 
- The action was not updated to expect the data structure of 1.0 Lisk Core API.

### How did I fix it?
I fixed the two points listed above.

### How to test it?
Follow steps in #1057

### Review checklist
- The PR solves #1057
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
