### PR TITLE
Enable users to verify their address using hardware wallet - closes #2525

### DIFF
--- a/libs/hwManager/communication.js
+++ b/libs/hwManager/communication.js
@@ -39,6 +39,22 @@ const getPublicKey = async (data) => {
 };
 
 /**
+ * getAddress - Function.
+ * Use for get the Address from the account
+ * @param {object} data -> Object that contain the information about the device and data
+ * @param {string} data.deviceId -> Id of the hw device
+ * @param {number} data.index -> index of the account of wich will extact information
+ * @param {boolean} data.showOnDevice -> Boolean value to inform device if show or
+ * not information in screen
+ */
+const getAddress = async (data) => {
+  const response = await executeCommand(IPC_MESSAGES.HW_COMMAND, {
+    action: IPC_MESSAGES.GET_ADDRESS, data,
+  });
+  return response;
+};
+
+/**
  * signTransaction - Function.
  * Use for sign a transaction, this could be send or vote
  * @param {object} data -> Object that contain the information about the device and data
@@ -126,4 +142,5 @@ export {
   subscribeToDeviceDisonnceted,
   subscribeToDevicesList,
   validatePin,
+  getAddress,
 };

--- a/libs/hwManager/constants.js
+++ b/libs/hwManager/constants.js
@@ -11,16 +11,18 @@ export const IPC_MESSAGES = {
   DISCONNECT: 'disconnect',
   ERROR: 'error',
   EXIT: 'exit',
+  GET_ADDRESS: 'GET_ADDRESS',
   GET_CONNECTED_DEVICES_LIST: 'getConnectedDevicesList',
-  HW_COMMAND: 'hwCommand',
   GET_PUBLICK_KEY: 'GET_PUBLICKEY',
-  SIGN_TRANSACTION: 'SIGN_TX',
+  HW_COMMAND: 'hwCommand',
   HW_CONNECTED: 'hwConnected',
   HW_DISCONNECTED: 'hwDisconnected',
-  VALIDATE_PIN: 'validateTrezorPin',
   MISSING_PIN: 'pin_not_provided_from_ui',
+  SIGN_TRANSACTION: 'SIGN_TX',
+  VALIDATE_PIN: 'validateTrezorPin',
 };
 export const FUNCTION_TYPES = {
   [IPC_MESSAGES.GET_PUBLICK_KEY]: 'getPublicKey',
+  [IPC_MESSAGES.GET_ADDRESS]: 'getAddress',
   [IPC_MESSAGES.SIGN_TRANSACTION]: 'signTransaction',
 };

--- a/libs/hwManager/manufacturers/ledger/index.js
+++ b/libs/hwManager/manufacturers/ledger/index.js
@@ -120,6 +120,21 @@ const getPublicKey = async (transporter, { device, data }) => {
   }
 };
 
+const getAddress = async (transporter, { device, data }) => {
+  let transport = null;
+  try {
+    transport = await transporter.open(device.path);
+    const liskLedger = new DposLedger(transport);
+    const ledgerAccount = getLedgerAccount(data.index);
+    const { publicKey: res } = await liskLedger.getPubKey(ledgerAccount, data.showOnDevice);
+    transport.close();
+    return res;
+  } catch (error) {
+    if (transport) transport.close();
+    throw error;
+  }
+};
+
 const signTransaction = async (transporter, { device, data }) => {
   let transport = null;
   try {
@@ -137,6 +152,7 @@ const signTransaction = async (transporter, { device, data }) => {
 
 export default {
   checkIfInsideLiskApp,
+  getAddress,
   getPublicKey,
   listener,
   signTransaction,

--- a/src/assets/images/icons/verify-icon.svg
+++ b/src/assets/images/icons/verify-icon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="12px" height="19px" viewBox="0 0 12 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 58 (101010) - https://sketch.com -->
+    <title>DDA55F76-64C5-4EE2-807A-031CA7C8F2D2</title>
+    <desc>Created with sketchtool.</desc>
+    <g id="💰-My-Wallet" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Wallet----Lisk" transform="translate(-535.000000, -327.000000)">
+            <g id="verify-icon" transform="translate(536.000000, 328.000000)">
+                <rect id="Rectangle" stroke="#8A8CA2" x="0" y="5" width="10" height="12"></rect>
+                <rect id="Rectangle" stroke="#8A8CA2" x="2" y="0" width="6" height="5"></rect>
+                <path d="M4.5,0 L4.5,3 L3.5,3 L3.5,0 L4.5,0 Z M6.5,0 L6.5,3 L5.5,3 L5.5,0 L6.5,0 Z" id="Combined-Shape" fill="#8A8CA2"></path>
+                <rect id="Rectangle-Copy-2" stroke="#8A8CA2" x="2" y="7" width="6" height="7"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/screens/explorer/accounts/accounts.test.js
+++ b/src/components/screens/explorer/accounts/accounts.test.js
@@ -3,6 +3,11 @@ import { mount } from 'enzyme';
 import Accounts from './accounts';
 import accounts from '../../../../../test/constants/accounts';
 import routes from '../../../../constants/routes';
+import * as hwManager from '../../../../utils/hwManager';
+
+jest.mock('../../../../utils/hwManager.js', () => ({
+  getAddress: jest.fn(),
+}));
 
 describe('Accounts Component', () => {
   let wrapper;
@@ -26,7 +31,10 @@ describe('Accounts Component', () => {
       [accounts.genesis.address]: accounts.genesis,
     },
     address: accounts.genesis.address,
-    account: accounts.empty_account,
+    account: {
+      ...accounts.empty_account,
+      loginType: 0,
+    },
     match: { params: { address: accounts.genesis.address } },
     history: { push: jest.fn(), location: { search: ' ' } },
     bookmarks: {
@@ -91,6 +99,24 @@ describe('Accounts Component', () => {
       expect(wrapper).toContainMatchingElement('.transaction-filter-item');
       wrapper.find('.transaction-filter-item').at(1).simulate('click');
       expect(props.transactions.loadData).toBeCalled();
+    });
+
+    it('click verify address when user use hardware wallet', () => {
+      const newProps = {
+        ...props,
+        account: {
+          ...props.account,
+          loginType: 1,
+          hwInfo: {
+            deviceId: 'abc123',
+            derivationIndex: 1,
+          },
+        },
+      };
+      wrapper = mount(<Accounts {...newProps} />);
+      expect(wrapper).toContainMatchingElement('.verify-address');
+      wrapper.find('.verify-address').at(0).simulate('click');
+      expect(hwManager.getAddress).toBeCalled();
     });
   });
 

--- a/src/components/screens/wallet/walletDetails.css
+++ b/src/components/screens/wallet/walletDetails.css
@@ -3,6 +3,8 @@
 
 .wrapper {
   & .row {
+    position: relative;
+
     & > * {
       margin-right: 15px;
       margin-left: -2px;
@@ -28,4 +30,11 @@
   & .copyIcon {
     vertical-align: -2px;
   }
+}
+
+.verifyAddress {
+  position: absolute;
+  top: 45px;
+  right: 25px;
+  cursor: pointer;
 }

--- a/src/components/screens/wallet/walletDetails.css
+++ b/src/components/screens/wallet/walletDetails.css
@@ -4,6 +4,8 @@
 .wrapper {
   & .row {
     position: relative;
+    margin: 0;
+    padding: 20px;
 
     & > * {
       margin-right: 15px;
@@ -32,9 +34,19 @@
   }
 }
 
-.verifyAddress {
-  position: absolute;
-  top: 45px;
-  right: 25px;
+.addressIcons {
+  width: auto;
+  height: 100%;
+  max-width: 60px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
+  margin: 0 0 0 auto !important;
+  position: relative;
+}
+
+.helperIcon {
   cursor: pointer;
+  line-height: 0;
+  margin-left: 5px;
 }

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -8,12 +8,13 @@ import Icon from '../../toolbox/icon';
 import LiskAmount from '../../shared/liskAmount';
 import CopyToClipboard from '../../toolbox/copyToClipboard';
 import DiscreetMode from '../../shared/discreetMode';
+import { getAddress } from '../../../utils/hwManager';
 import styles from './walletDetails.css';
 
 class WalletDetails extends React.Component {
   render() {
     const {
-      balance, t, address, activeToken,
+      balance, t, address, activeToken, account,
     } = this.props;
 
     return (
@@ -27,7 +28,14 @@ class WalletDetails extends React.Component {
             size={40}
           />
           <div>
-            <label>{t('Address')}</label>
+            <label onClick={() => getAddress({
+              deviceId: account.hwInfo.deviceId,
+              index: account.hwInfo.derivationIndex,
+              showOnDevice: true,
+            })}
+            >
+              {t('Address')}
+            </label>
             <div className={styles.value}>
               <CopyToClipboard
                 value={address}

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -40,7 +40,7 @@ class WalletDetails extends React.Component {
             account.loginType !== 0
               ? (
                 <div
-                  className={styles.verifyAddress}
+                  className={`${styles.verifyAddress} verify-address`}
                   onClick={() => getAddress({
                     deviceId: account.hwInfo.deviceId,
                     index: account.hwInfo.derivationIndex,

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -36,22 +36,24 @@ class WalletDetails extends React.Component {
               />
             </div>
           </div>
-          {
-            account.loginType !== 0
-              ? (
-                <div
-                  className={`${styles.verifyAddress} verify-address`}
-                  onClick={() => getAddress({
-                    deviceId: account.hwInfo.deviceId,
-                    index: account.hwInfo.derivationIndex,
-                    showOnDevice: true,
-                  })}
-                >
-                  <Icon name="verifyWalletAddress" alt="verifyWalletAddress" title="Verify address" />
-                </div>
-              )
-              : null
-          }
+          <div className={styles.addressIcons}>
+            {
+              account.loginType !== 0
+                ? (
+                  <div
+                    className={`${styles.helperIcon} verify-address`}
+                    onClick={() => getAddress({
+                      deviceId: account.hwInfo.deviceId,
+                      index: account.hwInfo.derivationIndex,
+                      showOnDevice: true,
+                    })}
+                  >
+                    <Icon name="verifyWalletAddress" alt="verifyWalletAddress" title="Verify address" />
+                  </div>
+                )
+                : null
+            }
+          </div>
         </BoxRow>
         <BoxRow className={styles.row}>
           <Icon name="balance" />

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -28,14 +28,7 @@ class WalletDetails extends React.Component {
             size={40}
           />
           <div>
-            <label onClick={() => getAddress({
-              deviceId: account.hwInfo.deviceId,
-              index: account.hwInfo.derivationIndex,
-              showOnDevice: true,
-            })}
-            >
-              {t('Address')}
-            </label>
+            <label>{t('Address')}</label>
             <div className={styles.value}>
               <CopyToClipboard
                 value={address}
@@ -43,6 +36,22 @@ class WalletDetails extends React.Component {
               />
             </div>
           </div>
+          {
+            account.loginType !== 0
+              ? (
+                <div
+                  className={styles.verifyAddress}
+                  onClick={() => getAddress({
+                    deviceId: account.hwInfo.deviceId,
+                    index: account.hwInfo.derivationIndex,
+                    showOnDevice: true,
+                  })}
+                >
+                  <Icon name="verifyWalletAddress" alt="verifyWalletAddress" title="Verify address" />
+                </div>
+              )
+              : null
+          }
         </BoxRow>
         <BoxRow className={styles.row}>
           <Icon name="balance" />

--- a/src/components/screens/wallet/walletTab.js
+++ b/src/components/screens/wallet/walletTab.js
@@ -12,6 +12,7 @@ const WalletTab = ({ ...props }) => (
           balance={props.balance}
           address={props.address}
           activeToken={props.activeToken}
+          account={props.account}
         />
       </div>
       <div className={`${grid['col-xs-5']} ${grid['col-md-6']} ${grid['col-lg-7']}`}>

--- a/src/components/toolbox/icon/index.js
+++ b/src/components/toolbox/icon/index.js
@@ -76,6 +76,7 @@ import verifyMessageInputsView from '../../../assets/images/icons/verify-message
 import verifyMessageInputsViewActive from '../../../assets/images/icons/verify-message-inputs-view-active.svg';
 import verifyMessageTextareaView from '../../../assets/images/icons/verify-message-textarea-view.svg';
 import verifyMessageTextareaViewActive from '../../../assets/images/icons/verify-message-textarea-view-active.svg';
+import verifyWalletAddress from '../../../assets/images/icons/verify-icon.svg';
 import walletIcon from '../../../assets/images/icons/wallet.svg';
 import walletIconActive from '../../../assets/images/icons/wallet-active.svg';
 import warningIcon from '../../../assets/images/icons/warning-icon.svg';
@@ -157,6 +158,7 @@ export const icons = {
   verifyMessageInputsViewActive,
   verifyMessageTextareaView,
   verifyMessageTextareaViewActive,
+  verifyWalletAddress,
   walletIcon,
   walletIconActive,
   warningIcon,

--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -2,9 +2,10 @@ import { castVotes, transfer, utils } from '@liskhq/lisk-transactions';
 import i18next from 'i18next';
 import { getAccount } from './api/lsk/account';
 import {
+  checkIfInsideLiskApp,
+  getAddress,
   getPublicKey,
   signTransaction,
-  checkIfInsideLiskApp,
   subscribeToDeviceConnceted,
   subscribeToDeviceDisonnceted,
   subscribeToDevicesList,
@@ -102,11 +103,12 @@ const signVoteTransaction = async (
 };
 
 export {
-  getPublicKey,
+  checkIfInsideLiskApp,
   getAccountsFromDevice,
+  getAddress,
+  getPublicKey,
   signSendTransaction,
   signVoteTransaction,
-  checkIfInsideLiskApp,
   subscribeToDeviceConnceted,
   subscribeToDeviceDisonnceted,
   subscribeToDevicesList,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
-- #2525

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
This PR includes the hardware wallet address verification when the user use HW for login, then a usb icon is display in the Wallet details container in the Wallet page where thee user can verify the current address, the validation is done in the hw device.

### How has this been tested?
<!--- Please describe how you tested your changes. -->

1. Login to the app using a ledger hw (work for trezor too).
2. Go to wallet page.
3. In the Wallet details container should show up a usb icon next to the address.
4. click the usb icon to verify the address.
5. In the ledger device you can verify it.

**NOTE:** As this is just for verification the accept or reject action from the device doesn't do anything is more information for the user and be sure that everything is correct.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-hub/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-hub/blob/development/docs/CSS_GUIDE.md)
