### PR TITLE
Fix the misaligned productivity title on delegate page - Closes #2628

### DIFF
--- a/src/components/screens/monitor/delegates/delegates.css
+++ b/src/components/screens/monitor/delegates/delegates.css
@@ -26,6 +26,22 @@
   }
 }
 
+.approvalTitle {
+  padding-left: 0;
+
+  & > span {
+    margin-left: -27%;
+    width: 127%;
+    display: inline-block;
+  }
+}
+
+@media (--large-viewport) {
+  .statusTitle {
+    padding-right: 0;
+  }
+}
+
 .statusToolip {
   white-space: nowrap;
 }

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -72,7 +72,7 @@ const Delegates = ({
           </p>
         </Tooltip>
       ),
-      className: [grid['col-xs-2'], grid['col-md-1']].join(' '),
+      className: [grid['col-xs-2'], grid['col-md-1'], styles.statusTitle].join(' '),
     },
     ] : []),
     {
@@ -85,7 +85,7 @@ const Delegates = ({
       headerTooltip: t('Percentage of total supply voting for a delegate.'),
       /* eslint-disable-next-line react/display-name */
       getValue: ({ approval }) => <strong>{`${formatAmountBasedOnLocale({ value: approval })} %`}</strong>,
-      className: grid['col-xs-2'],
+      className: [grid['col-xs-2'], grid['col-md-1'], styles.approvalTitle].join(' '),
     },
   ];
 

--- a/src/components/shared/delegatesTable/index.js
+++ b/src/components/shared/delegatesTable/index.js
@@ -38,7 +38,7 @@ const DelegatesTable = ({
       header: t('Productivity'),
       headerTooltip: t('Percentage of successfully forged blocks in relation to all blocks (forged and missed).'),
       getValue: ({ productivity }) => `${formatAmountBasedOnLocale({ value: productivity })} %`,
-      className: [grid['col-xs-2'], grid['col-md-1']].join(' '),
+      className: [grid['col-xs-2'], grid['col-md-2'], grid['col-lg-2']].join(' '),
     },
   };
   columns = columns.map(column => ({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
#2628

### How have I implemented/fixed it?
The solution is temporary. ATM we're using two different grid systems:
1. flexboxgrid 
 - em based
 - Mobile first
 - npm dependency 

2. Custom
 - pixel based
 - Desktop first
 - inhause

We should remove the second one. but it's outside the scope of this PR. I'll revert my current changes after I removed the custom grid system.


### How has this been tested?
<!--- Please describe how you tested your changes. -->


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
