### PR TITLE
Update Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,27 +1,15 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+title: ''
+labels: 'type: bug'
+assignees: ''
 ---
 
+### Expected behavior
+
+### Actual behavior
+
 ### Steps to reproduce
-<!-- Provide an unambiguous set of steps to reproduce the bug -->
 
-1. 
-1. 
-1. 
-
-### Actual result
-<!--- Tell us what happens -->
-
-
-### Expected result
-<!--- Tell us what should happen -->
-
-
-### Version
-<!--- Version and client OS / Branch version -->
-
-
-### Screenshot (if appropriate)
-<!--- Please include screenshot capturing UI and open developer tools console -->
+### Which version(s) does this affect? (Environment, OS, etc...)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,13 +1,21 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
-
+about: Propose an idea for new improvements/features
+title: ''
+labels: ''
+assignees: ''
 ---
 
-<!--- Provide a descriptive summary in the Title above -->
-### Description of the problem
-<!-- A description of the problem you want to solve, including why you think this is a problem -->
+### Description
 
+Please describe what functionality is needed
 
-### Suggested solution
-<!--- An overview of the suggested solution -->
+### Motivation
+
+Please describe why it is needed
+
+### Acceptance Criteria
+
+Please describe the conditions which must be met for this issue to close
+
+### Additional Information

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 ### What issue have I solved?
 <!--- Complementary description if needed -->
-#INSERT_ISSUE_NUMBER
+Resolves #INSERT_ISSUE_NUMBER
 
 ### How have I implemented/fixed it?
 <!--- Describe your technical implementation -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
To bring development standards across the departments , we would like to change the bug report template and feature request template for UI department. This template was already followed by the SDK team.

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Used the templates from lisk-sdk

Bug report
https://github.com/LiskHQ/lisk-sdk/blob/development/.github/ISSUE_TEMPLATE/bug-report.md
Feature request
https://github.com/LiskHQ/lisk-sdk/blob/development/.github/ISSUE_TEMPLATE/feature-request.md

Also used the `resolves` [keyword](https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords) to enable automatic linking of PRs and issues (keyword in PR title is not enough).

### How has this been tested?
<!--- Please describe how you tested your changes. -->


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
