### PR TITLE
Hide the filter button when there's no field defined - Closes #2639

### DIFF
--- a/src/components/shared/filterDropdownButton/index.js
+++ b/src/components/shared/filterDropdownButton/index.js
@@ -135,7 +135,7 @@ class FilterDropdownButton extends React.Component {
     const { t, fields } = this.props;
     const { areFiltersExtended } = this.state;
 
-    return (
+    return fields.length === 0 ? null : (
       <DropdownButton
         buttonClassName={`${styles.filterTransactionsButton} filterTransactions filter`}
         buttonLabel={(


### PR DESCRIPTION
### What issue have I solved?
<!--- Complementary description if needed -->
Described in #2639 

### How have I implemented/fixed it?
According to @slaweet 's suggestion, I hide the filter button when there's no field defined based on which we can filter the results.

### How has this been tested?
The filter button is working fine on pages which have filter fields defined, but not on the block details page.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
