### PR TITLE
Fix HW Address verification icon is visible at all times - Closes #2660

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -457,6 +457,7 @@
   "Use this tool to verify the validity of a signed message. This allows you to ensure that the person who signed the message was in fact the account owner": "Use this tool to verify the validity of a signed message. This allows you to ensure that the person who signed the message was in fact the account owner",
   "Verify address": "Verify address",
   "Verify message": "Verify message",
+  "Verify the address in your hardware wallet device.": "Verify the address in your hardware wallet device.",
   "Version": "Version",
   "View": "View",
   "View All": "View All",

--- a/src/components/screens/wallet/walletDetails.js
+++ b/src/components/screens/wallet/walletDetails.js
@@ -54,7 +54,7 @@ class WalletDetails extends React.Component {
               </Tooltip>
             </div>
             {
-              account.loginType !== 0
+              (typeof account.loginType === 'number' && account.loginType !== 0)
                 ? (
                   <div
                     className={`${styles.helperIcon} verify-address`}
@@ -69,7 +69,7 @@ class WalletDetails extends React.Component {
                       title={t('Verify address')}
                       content={<Icon name="verifyWalletAddressActive" className={styles.qrCodeIcon} />}
                     >
-                      <span>Verify the address in your hardware wallet device.</span>
+                      <span>{t('Verify the address in your hardware wallet device.')}</span>
                     </Tooltip>
                   </div>
                 )

--- a/src/components/toolbox/copyToClipboard/index.js
+++ b/src/components/toolbox/copyToClipboard/index.js
@@ -34,7 +34,7 @@ const IconOnly = ({
   copied,
 }) => (
   <ReactCopyToClipboard text={value} onCopy={onCopy}>
-    <Icon name={copied ? 'transaction-status-approved' : 'copy'} className={`${styles.icon} ${copyClassName}`} />
+    <Icon name={copied ? 'transactionApproved' : 'copy'} className={`${styles.icon} ${copyClassName}`} />
   </ReactCopyToClipboard>
 );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2660 

### How have I implemented/fixed it?
The logic only tested the ideal login type. so in all other cases, the condition was unintentionally true.

### How has this been tested?
- Signed in using passphrase and HW, tested the wallet page and other accounts.
- Explored as guest and did the same.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
