### PR TITLE
 Fix monitor to work for Custom mainnet/testnet nodes - Closes #2664

### DIFF
--- a/src/components/screens/monitor/accounts/index.js
+++ b/src/components/screens/monitor/accounts/index.js
@@ -36,7 +36,7 @@ const AccountsMonitor = () => {
   const network = useSelector(state => state.network);
 
   return (
-    network.name === 'Custom Node'
+    liskServiceApi.getLiskServiceUrl(network) === null
       ? <NotAvailable />
       : <ComposedAccounts />
   );

--- a/src/components/screens/monitor/blockDetails/index.js
+++ b/src/components/screens/monitor/blockDetails/index.js
@@ -43,7 +43,7 @@ const BlockDetailsMonitor = () => {
   const network = useSelector(state => state.network);
 
   return (
-    network.name === 'Custom Node'
+    liskService.getLiskServiceUrl(network) === null
       ? <NotAvailable />
       : <ComposedBlockDetails />
   );

--- a/src/components/screens/monitor/blocks/index.js
+++ b/src/components/screens/monitor/blocks/index.js
@@ -31,7 +31,7 @@ const BlocksMonitor = () => {
   const network = useSelector(state => state.network);
 
   return (
-    network.name === 'Custom Node'
+    liskService.getLiskServiceUrl(network) === null
       ? <NotAvailable />
       : <ComposedBlocks />
   );

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -49,7 +49,7 @@ const DelegatesMonitor = () => {
   const network = useSelector(state => state.network);
 
   return (
-    network.name === 'Custom Node'
+    liskService.getLiskServiceUrl(network) === null
       ? <NotAvailable />
       : <ComposedDelegates />
   );

--- a/src/components/screens/monitor/transactions/index.js
+++ b/src/components/screens/monitor/transactions/index.js
@@ -29,7 +29,7 @@ const TransactionsMonitor = () => {
   const network = useSelector(state => state.network);
 
   return (
-    network.name === 'Custom Node'
+    liskServiceApi.getLiskServiceUrl(network) === null
       ? <NotAvailable />
       : <ComposedTransactions />
   );

--- a/src/components/screens/monitor/transactions/index.test.js
+++ b/src/components/screens/monitor/transactions/index.test.js
@@ -20,7 +20,7 @@ describe('Transactions monitor page', () => {
   it('should render Transactions when using testnet', () => {
     const store = fakeStore({
       network: {
-        name: 'testnet',
+        name: 'Testnet',
       },
     });
     const wrapper = mount(<Provider store={store}><TransactionsMonitor /></Provider>);

--- a/src/utils/api/lsk/liskService.js
+++ b/src/utils/api/lsk/liskService.js
@@ -125,6 +125,14 @@ const liskServiceApi = {
     return tabOptions[tab](network, rest);
   },
 
+  getLiskServiceUrl: (networkConfig) => {
+    try {
+      return getServerUrl(networkConfig);
+    } catch (e) {
+      return null;
+    }
+  },
+
   getNextForgers: async ({ networkConfig }, searchParams) => liskServiceGet({
     networkConfig,
     path: '/api/v1/delegates/next_forgers',

--- a/src/utils/api/lsk/liskService.js
+++ b/src/utils/api/lsk/liskService.js
@@ -125,6 +125,16 @@ const liskServiceApi = {
     return tabOptions[tab](network, rest);
   },
 
+  /**
+   * Returns lisk-service URL based on network name and nethash
+   *
+   * In particular it resolves mainnet/testnet nethash to coresponding lisk-service instance
+   *
+   * @param {Object} networkConfig  - structured as network store: src/store/reducers/network.js
+   * @param {String} networkConfig.name
+   * @param {String} networkConfig.networks.LSK.nethash - if name is "Custom node"
+   * @return {String} lisk-service URL
+   */
   getLiskServiceUrl: (networkConfig) => {
     try {
       return getServerUrl(networkConfig);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2664

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
Updated the monitor pages to reuse logic from `liskService.js` to check if lisk service is available or not. It is using `getNetworkNameBasedOnNethash`.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps to reproduce in #2664

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
