### PR TITLE
Fix the crashing bug in BTC settings option in guest mode - Closes #2668

### DIFF
--- a/src/components/screens/settings/settings.js
+++ b/src/components/screens/settings/settings.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { tokenMap } from '../../../constants/tokens';
+import { isEmpty } from '../../../utils/helpers';
 import Box from '../../toolbox/box';
 import BoxHeader from '../../toolbox/box/header';
 import BoxContent from '../../toolbox/box/content';
@@ -168,7 +169,7 @@ class Settings extends React.Component {
                 </div>
               </label>
               {
-                !isHardwareWalletAccount
+                !isHardwareWalletAccount && !isEmpty(account)
                   ? (
                     <label className={`${styles.fieldGroup} ${styles.checkboxField} enableBTC`}>
                       <CheckBox

--- a/src/components/screens/settings/settings.test.js
+++ b/src/components/screens/settings/settings.test.js
@@ -48,115 +48,123 @@ describe('Setting', () => {
     toastDisplayed: jest.fn(),
   };
 
-  beforeEach(() => {
-    localStorage.setItem('feature-flag-language', true); // TODO: Remove when i18n epic #2301 is finished
-    localStorage.setItem('discreet', true); // TODO: Remove when discreet mode is concluded
-    wrapper = mount(
-      <Settings {...props} />,
-    );
+  describe('With no transaction in guest mode', () => {
+    beforeEach(() => {
+      wrapper = mount(
+        <Settings {...props} />,
+      );
+    });
+
+    it('should change autolog setting when clicking on checkbox', () => {
+      wrapper.find('.autoLog input').at(0).simulate('change', { target: { name: 'autoLog' } });
+      const expectedCallToSettingsUpdated = {
+        autoLog: !settings.autoLog,
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
+
+    it('should change discreet mode setting when clicking on checkbox', () => {
+      wrapper.find('.discreetMode input').at(0).simulate('change', { target: { name: 'discreetMode' } });
+      const expectedCallToSettingsUpdated = {
+        discreetMode: !settings.discreetMode,
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
+
+    it('should change showNetwork setting when clicking on checkbox', () => {
+      wrapper.find('.showNetwork input').at(0).simulate('change', { target: { name: 'showNetwork' } });
+      const expectedCallToSettingsUpdated = {
+        showNetwork: !settings.showNetwork,
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
+
+    it('should change usage statistics when clicking on checkbox', () => {
+      wrapper.find('.statistics input').at(0).simulate('change', { target: { name: 'statistics' } });
+      const expectedCallToSettingsUpdated = {
+        statistics: !settings.statistics,
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
+
+    it('should change active currency setting to EUR', () => {
+      wrapper.find('.currency input').simulate('focus');
+      wrapper.find('.currency .options span').at(1).simulate('click', { target: { dataset: { index: 1 } } });
+      const expectedCallToSettingsUpdated = {
+        currency: settingsConst.currencies[1],
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
+
+    it('should allow to change active language setting to German', () => {
+      wrapper.find('.language input').simulate('focus');
+      wrapper.find('.language .options span').at(1).simulate('click', { target: { dataset: { index: 1 } } });
+      expect(i18n.changeLanguage).toBeCalledWith('de');
+    });
   });
 
-  it('should disable 2nd passphrase when hardwareWallet', () => {
-    const newProps = { ...props, account: { hwInfo: { deviceId: '123' } } };
-    wrapper = mount(
-      <Settings {...newProps} />,
-    );
-    expect(wrapper).toContainMatchingElements(1, '.disabled');
-  });
+  describe('With specific properties', () => {
+    it('should disable 2nd passphrase when hardwareWallet', () => {
+      const newProps = { ...props, account: { hwInfo: { deviceId: '123' } } };
+      wrapper = mount(
+        <Settings {...newProps} />,
+      );
+      expect(wrapper).toContainMatchingElements(1, '.disabled');
+    });
 
-  it('should show 2nd passphrase as processing', () => {
-    const newProps = { ...props, transactions: { pending: [{ type: 1 }] } };
-    wrapper = mount(<Settings {...newProps} />);
-    expect(wrapper.find('.second-passphrase')).toContainMatchingElement('.loading');
-  });
+    it('should show 2nd passphrase as processing', () => {
+      const newProps = { ...props, transactions: { pending: [{ type: 1 }] } };
+      wrapper = mount(<Settings {...newProps} />);
+      expect(wrapper.find('.second-passphrase')).toContainMatchingElement('.loading');
+    });
 
-  it('should render 2nd passphrase as active', () => {
-    const account2ndPassphrase = { info: { LSK: accounts.second_passphrase_account } };
-    const newProps = { ...props, account: account2ndPassphrase, hasSecondPassphrase: true };
-    wrapper = mount(
-      <Settings {...newProps} />,
-    );
-    expect(wrapper.find('.second-passphrase')).not.toContainMatchingElement('.link');
-    expect(wrapper.find('.second-passphrase')).toContainMatchingElement('.second-passphrase-registered');
-  });
+    it('should render 2nd passphrase as active', () => {
+      const account2ndPassphrase = { info: { LSK: accounts.second_passphrase_account } };
+      const newProps = { ...props, account: account2ndPassphrase, hasSecondPassphrase: true };
+      wrapper = mount(
+        <Settings {...newProps} />,
+      );
+      expect(wrapper.find('.second-passphrase')).not.toContainMatchingElement('.link');
+      expect(wrapper.find('.second-passphrase')).toContainMatchingElement('.second-passphrase-registered');
+    });
 
-  it('should change autolog setting when clicking on checkbox', () => {
-    wrapper.find('.autoLog input').at(0).simulate('change', { target: { name: 'autoLog' } });
-    const expectedCallToSettingsUpdated = {
-      autoLog: !settings.autoLog,
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
-  });
+    it('should update expireTime when updating autolog', () => {
+      const accountToExpireTime = { ...account };
+      const settingsToExpireTime = { ...settings };
+      settingsToExpireTime.autoLog = false;
+      accountToExpireTime.passphrase = accounts.genesis.passphrase;
+      wrapper = mount(
+        <Settings
+          {...props}
+          account={accountToExpireTime}
+          settings={settingsToExpireTime}
+        />,
+      );
+  
+      wrapper.find('.autoLog input').at(0).simulate('change', { target: { name: 'autoLog' } });
+  
+      const timeNow = Date.now();
+      const expectedCallToAccountUpdated = {
+        expireTime: timeNow,
+      };
+      expect(props.accountUpdated).toBeCalled();
+      expect(props.accountUpdated.mock.calls[0][0].expireTime)
+        .toBeGreaterThan(expectedCallToAccountUpdated.expireTime);
+    });
 
-  it('should change discreet mode setting when clicking on checkbox', () => {
-    wrapper.find('.discreetMode input').at(0).simulate('change', { target: { name: 'discreetMode' } });
-    const expectedCallToSettingsUpdated = {
-      discreetMode: !settings.discreetMode,
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
-  });
-
-  it('should change showNetwork setting when clicking on checkbox', () => {
-    wrapper.find('.showNetwork input').at(0).simulate('change', { target: { name: 'showNetwork' } });
-    const expectedCallToSettingsUpdated = {
-      showNetwork: !settings.showNetwork,
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
-  });
-
-  it('should change usage statistics when clicking on checkbox', () => {
-    wrapper.find('.statistics input').at(0).simulate('change', { target: { name: 'statistics' } });
-    const expectedCallToSettingsUpdated = {
-      statistics: !settings.statistics,
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
-  });
-
-  it('should change active currency setting to EUR', () => {
-    wrapper.find('.currency input').simulate('focus');
-    wrapper.find('.currency .options span').at(1).simulate('click', { target: { dataset: { index: 1 } } });
-    const expectedCallToSettingsUpdated = {
-      currency: settingsConst.currencies[1],
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
-  });
-
-  it('should allow to change active language setting to German', () => {
-    wrapper.find('.language input').simulate('focus');
-    wrapper.find('.language .options span').at(1).simulate('click', { target: { dataset: { index: 1 } } });
-    expect(i18n.changeLanguage).toBeCalledWith('de');
-  });
-
-  it('should update expireTime when updating autolog', () => {
-    const accountToExpireTime = { ...account };
-    const settingsToExpireTime = { ...settings };
-    settingsToExpireTime.autoLog = false;
-    accountToExpireTime.passphrase = accounts.genesis.passphrase;
-    wrapper = mount(
-      <Settings
-        {...props}
-        account={accountToExpireTime}
-        settings={settingsToExpireTime}
-      />,
-    );
-
-    wrapper.find('.autoLog input').at(0).simulate('change', { target: { name: 'autoLog' } });
-
-    const timeNow = Date.now();
-    const expectedCallToAccountUpdated = {
-      expireTime: timeNow,
-    };
-    expect(props.accountUpdated).toBeCalled();
-    expect(props.accountUpdated.mock.calls[0][0].expireTime)
-      .toBeGreaterThan(expectedCallToAccountUpdated.expireTime);
-  });
-
-  it('should enable and disable BTC token', () => {
-    localStorage.setItem('btc', true);
-    wrapper.find('.enableBTC input').at(0).simulate('change', { target: { name: 'BTC' } });
-    const expectedCallToSettingsUpdated = {
-      token: { list: { BTC: !settings.token.list.BTC } },
-    };
-    expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    it('should enable and disable BTC token', () => {
+      localStorage.setItem('btc', true);
+      wrapper = mount(
+        <Settings
+          {...props}
+          account={account}
+        />,
+      );
+      wrapper.find('.enableBTC input').at(0).simulate('change', { target: { name: 'BTC' } });
+      const expectedCallToSettingsUpdated = {
+        token: { list: { BTC: !settings.token.list.BTC } },
+      };
+      expect(props.settingsUpdated).toBeCalledWith(expectedCallToSettingsUpdated);
+    });
   });
 });

--- a/src/components/screens/settings/settings.test.js
+++ b/src/components/screens/settings/settings.test.js
@@ -140,9 +140,9 @@ describe('Setting', () => {
           settings={settingsToExpireTime}
         />,
       );
-  
+
       wrapper.find('.autoLog input').at(0).simulate('change', { target: { name: 'autoLog' } });
-  
+
       const timeNow = Date.now();
       const expectedCallToAccountUpdated = {
         expireTime: timeNow,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2668

### How have I implemented/fixed it?
The guest mode is to help users benefit the monitoring features of Lisk. Since even search is not available for BTC, having this option in guest mode is completely redundant.
I hide the option is guest mode.
We were mounting the settings component twice for each test, once in `before` method and once in `it`. I removed the extra mounted component instances to speed up the tests. 

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
