### PR TITLE
Fix sorting block transactions - Closes #2717

### DIFF
--- a/src/components/screens/monitor/blockDetails/index.js
+++ b/src/components/screens/monitor/blockDetails/index.js
@@ -28,11 +28,12 @@ const ComposedBlockDetails = compose(
       defaultData: [],
       autoload: true,
       getApiParams: (state, ownProps) => ({ id: ownProps.id }),
-      transformResponse: (response, oldData) => [
-        ...oldData,
-        ...response.data.filter(transaction =>
-          !oldData.find(({ id }) => id === transaction.id)),
-      ],
+      transformResponse: (response, oldData, urlSearchParams) => (
+        urlSearchParams.offset
+          ? [...oldData, ...response.data.filter(block =>
+            !oldData.find(({ id }) => id === block.id))]
+          : response.data
+      ),
     },
   }),
   withTranslation(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2717

### How have I implemented/fixed it?
<!--- Describe your technical implementation -->
The problem was that the code was trying to merge previous and newly fetched transactions, but this should happen only if `offset` is specified.

### How has this been tested?
<!--- Please describe how you tested your changes. -->
Follow steps to reproduce in #2717

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
