### PR TITLE
 Fix the remaining issues caused by core 3.x adaption - Resolves #2746 

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -11,6 +11,7 @@ import { networkStatusUpdated } from './network';
 import accountConfig from '../constants/account';
 import actionTypes from '../constants/actions';
 import { tokenMap } from '../constants/tokens';
+import { txAdapter } from '../utils/api/lsk/adapters';
 
 /**
  * Trigger this action to remove passphrase from account object
@@ -87,10 +88,10 @@ export const secondPassphraseRegistered = ({
     ).then((transaction) => {
       dispatch({
         type: actionTypes.addNewPendingTransaction,
-        data: {
+        data: txAdapter({
           ...transaction,
           senderId: extractAddress(transaction.senderPublicKey),
-        },
+        }),
       });
       callback({
         success: true,

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -12,6 +12,7 @@ import { getTimeOffset } from '../utils/hacks';
 import { loginType } from '../constants/hwConstants';
 import { transactions as transactionsAPI } from '../utils/api';
 import { signSendTransaction } from '../utils/hwManager';
+import { txAdapter } from '../utils/api/lsk/adapters';
 
 // ========================================= //
 //            ACTION CREATORS
@@ -32,10 +33,10 @@ export const emptyTransactionsData = () => ({ type: actionTypes.emptyTransaction
  */
 export const addNewPendingTransaction = data => ({
   type: actionTypes.addNewPendingTransaction,
-  data: {
+  data: txAdapter({
     ...data,
     senderId: extractAddress(data.senderPublicKey),
-  },
+  }),
 });
 
 // ========================================= //

--- a/src/actions/voting.js
+++ b/src/actions/voting.js
@@ -13,6 +13,7 @@ import { addNewPendingTransaction } from './transactions';
 import actionTypes from '../constants/actions';
 import { getAPIClient } from '../utils/api/network';
 import { tokenMap } from '../constants/tokens';
+import { txAdapter } from '../utils/api/lsk/adapters';
 
 /**
  * Add data to the list of all delegates
@@ -76,7 +77,8 @@ export const votePlaced = ({
       });
     } else {
       dispatch({ type: actionTypes.pendingVotesAdded });
-      callResult.map(transaction => dispatch(addNewPendingTransaction(transaction)));
+      callResult.map(transaction =>
+        dispatch(addNewPendingTransaction(txAdapter(transaction))));
       dispatch(passphraseUsed(account.passphrase));
       callback({ success: true });
     }

--- a/src/components/screens/dashboard/recentTransactions/transactionList.js
+++ b/src/components/screens/dashboard/recentTransactions/transactionList.js
@@ -41,10 +41,14 @@ const TransactionList = ({
             />
           </div>
           <TransactionAmount
-            address={account.address}
+            host={account.address}
             token={activeToken}
             transaction={tx}
+            sender={tx.senderId}
+            type={tx.type}
+            recipient={tx.recipientId || tx.asset.recipientId}
             roundTo={2}
+            amount={tx.amount || tx.asset.amount}
           />
         </Link>
       ))

--- a/src/components/screens/delegates/delegatesTable/delegateRow.js
+++ b/src/components/screens/delegates/delegatesTable/delegateRow.js
@@ -21,9 +21,7 @@ const AddressWrapper = ({ votingModeEnabled, address, children }) => {
   return (
     <Link
       className={styles.delegateLink}
-      to={votingModeEnabled
-        ? routes.delegates.path
-        : `${routes.accounts.pathPrefix}${routes.accounts.path}/${address}`}
+      to={`${routes.accounts.pathPrefix}${routes.accounts.path}/${address}`}
     >
       {children}
     </Link>

--- a/src/components/screens/delegates/delegatesTable/delegateRow.js
+++ b/src/components/screens/delegates/delegatesTable/delegateRow.js
@@ -14,6 +14,22 @@ import VoteWeight from './voteWeight';
 import { formatAmountBasedOnLocale } from '../../../../utils/formattedNumber';
 import { voteToggled } from '../../../../actions/voting';
 
+const AddressWrapper = ({ votingModeEnabled, address, children }) => {
+  if (votingModeEnabled) {
+    return (<div className={styles.delegateLink}>{children}</div>);
+  }
+  return (
+    <Link
+      className={styles.delegateLink}
+      to={votingModeEnabled
+        ? routes.delegates.path
+        : `${routes.accounts.pathPrefix}${routes.accounts.path}/${address}`}
+    >
+      {children}
+    </Link>
+  );
+};
+
 const DelegateRow = (props) => {
   const {
     data, className, shouldShowVoteColumn, firstTimeVotingActive,
@@ -45,14 +61,12 @@ const DelegateRow = (props) => {
         <RankOrStatus data={data} />
       </span>
       <span className={`${shouldShowVoteColumn ? grid['col-xs-4'] : grid['col-xs-5']}`}>
-        <Link
-          className={styles.delegateLink}
-          to={shouldShowVoteColumn
-            ? routes.delegates.path
-            : `${routes.accounts.pathPrefix}${routes.accounts.path}/${data.account.address}`}
+        <AddressWrapper
+          address={data.account.address}
+          votingModeEnabled={votingModeEnabled}
         >
           <AvatarWithNameAndAddress {...data} />
-        </Link>
+        </AddressWrapper>
       </span>
       <span className={apiVersion === '3' ? grid['col-md-3'] : grid['col-md-2']}>
         <LiskAmount val={data.rewards} token={tokenMap.LSK.key} />

--- a/src/components/screens/delegates/delegatesTable/delegateRow.test.js
+++ b/src/components/screens/delegates/delegatesTable/delegateRow.test.js
@@ -20,7 +20,7 @@ describe('DelegateRow', () => {
       account: {
         address: '6356913781456505636L',
         publicKey: 'b3953cb16e2457b9be78ad8c8a2985435dedaed5f0dd63443bdfbccc92d09f2d',
-        secondPublicKey: '69c9c77e900320dae8efc1396b97206ba7bec409f9a83c765f62ac40f58768bd'
+        secondPublicKey: '69c9c77e900320dae8efc1396b97206ba7bec409f9a83c765f62ac40f58768bd',
       },
       approval: 46.33,
     },

--- a/src/components/screens/monitor/delegates/delegateRow.js
+++ b/src/components/screens/monitor/delegates/delegateRow.js
@@ -27,61 +27,65 @@ const getForgingTime = (data) => {
 };
 
 const DelegateRow = ({
-  data, className, forgingTime, t,
-}) => (
-  <Link
-    className={`${grid.row} ${className} delegate-row`}
-    to={`${routes.accounts.path}/${data.address}`}
-  >
-    <span className={grid['col-md-1']}>
-      {`#${data.rank}`}
-    </span>
-    <span className={grid['col-md-2']}>
-      {data.username}
-    </span>
-    <span className={data.rank > 101 ? `${grid['col-xs-5']} ${grid['col-md-6']}` : grid['col-md-3']}>
-      <AccountVisualWithAddress address={data.address} />
-    </span>
-    {
-      data.rank <= 101 ? (
-        <Fragment>
-          <span className={grid['col-md-2']}>
-            {getForgingTime(forgingTime)}
-          </span>
-          <span className={`${grid['col-xs-2']} ${grid['col-md-1']}`}>
-            <Tooltip
-              title={forgingTime
-                ? t(statuses[forgingTime.status])
-                : t(statuses.notForging)}
-              className="showOnBottom"
-              size="s"
-              content={(
-                <div className={`${styles.status} ${
-                  styles[forgingTime
-                    ? forgingTime.status
-                    : 'notForging']}`
-                  }
-                />
-              )}
-              footer={(
-                <p>{getForgingTime(forgingTime)}</p>
-              )}
-            >
-              <p className={styles.statusToolip}>
-                {data.lastBlock && `Last block forged ${data.lastBlock}`}
-              </p>
-            </Tooltip>
-          </span>
-        </Fragment>
-      ) : null
-    }
-    <span className={`${grid['col-xs-2']} ${grid['col-md-2']} ${grid['col-lg-2']}`}>
-      {`${formatAmountBasedOnLocale({ value: data.productivity })} %`}
-    </span>
-    <span className={`${grid['col-xs-2']} ${grid['col-md-1']}`}>
-      {data.productivity}
-    </span>
-  </Link>
-);
+  data, className, forgingTimes, t,
+}) => {
+  const forgingTime = forgingTimes[data.publicKey];
+  const formattedForgingTime = getForgingTime(forgingTime);
+  return (
+    <Link
+      className={`${grid.row} ${className} delegate-row`}
+      to={`${routes.accounts.path}/${data.address}`}
+    >
+      <span className={grid['col-md-1']}>
+        {`#${data.rank}`}
+      </span>
+      <span className={grid['col-md-2']}>
+        {data.username}
+      </span>
+      <span className={data.rank > 101 ? `${grid['col-xs-5']} ${grid['col-md-6']}` : grid['col-md-3']}>
+        <AccountVisualWithAddress address={data.address} />
+      </span>
+      {
+        data.rank <= 101 ? (
+          <Fragment>
+            <span className={grid['col-md-2']}>
+              {formattedForgingTime}
+            </span>
+            <span className={`${grid['col-xs-2']} ${grid['col-md-1']}`}>
+              <Tooltip
+                title={forgingTime
+                  ? t(statuses[forgingTime.status])
+                  : t(statuses.notForging)}
+                className="showOnBottom"
+                size="s"
+                content={(
+                  <div className={`${styles.status} ${
+                    styles[forgingTime
+                      ? forgingTime.status
+                      : 'notForging']}`
+                    }
+                  />
+                )}
+                footer={(
+                  <p>{formattedForgingTime}</p>
+                )}
+              >
+                <p className={styles.statusToolip}>
+                  {data.lastBlock && `Last block forged ${data.lastBlock}`}
+                </p>
+              </Tooltip>
+            </span>
+          </Fragment>
+        ) : null
+      }
+      <span className={`${grid['col-xs-2']} ${grid['col-md-2']} ${grid['col-lg-2']}`}>
+        {`${formatAmountBasedOnLocale({ value: data.productivity })} %`}
+      </span>
+      <span className={`${grid['col-xs-2']} ${grid['col-md-1']}`}>
+        {data.productivity}
+      </span>
+    </Link>
+  );
+};
 
 export default React.memo(DelegateRow);

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -117,9 +117,12 @@ const DelegatesTable = ({
           <Table
             data={delegates.data}
             isLoading={delegates.isLoading}
-            row={props =>
-              <DelegateRow {...props} t={t} forgingTime={forgingTimes[props.data.publicKey]} />}
+            row={DelegateRow}
             loadData={handleLoadMore}
+            additionalRowProps={{
+              t,
+              forgingTimes,
+            }}
             header={header(activeTab, changeSort, t)}
             currentSort={sort}
             canLoadMore={canLoadMore}

--- a/src/components/screens/wallet/transactions/amount/TransactionAmount.js
+++ b/src/components/screens/wallet/transactions/amount/TransactionAmount.js
@@ -6,23 +6,17 @@ import styles from './transactionAmount.css';
 import transactionTypes from '../../../../../constants/transactionTypes';
 
 const TransactionAmount = ({
-  address, transaction, token, roundTo,
+  sender, recipient, type, token, roundTo, host, amount,
 }) => {
-  const isRecieve = address === transaction.recipientId;
-  // e.g. account initialization
-  const isSentToSelf = transaction.recipientId === transaction.senderId
-    && transaction.type === transactionTypes().send.code;
-
+  const isIncoming = host === recipient && sender !== recipient;
   return (
     <div className={`${styles.wrapper} transaction-amount`}>
-      { transaction.type === transactionTypes().send.code
+      { type === transactionTypes().send.code
         ? (
           <DiscreetMode shouldEvaluateForOtherAccounts>
-            <span className={isRecieve && !isSentToSelf ? styles.recieve : ''}>
-              {isRecieve ? '' : '- '}
-              <LiskAmount val={transaction.amount} roundTo={roundTo} />
-              {' '}
-              {token}
+            <span className={isIncoming ? styles.receive : ''}>
+              {isIncoming ? '' : '- '}
+              <LiskAmount val={amount} roundTo={roundTo} token={token} />
             </span>
           </DiscreetMode>
         )
@@ -33,13 +27,12 @@ const TransactionAmount = ({
 };
 
 TransactionAmount.propTypes = {
-  address: PropTypes.string.isRequired,
+  host: PropTypes.string,
+  sender: PropTypes.string.isRequired,
+  recipient: PropTypes.string,
   token: PropTypes.string.isRequired,
-  transaction: PropTypes.shape({
-    type: PropTypes.number.isRequired,
-    amount: PropTypes.string.isRequired,
-    recipientId: PropTypes.string.isRequired,
-  }),
+  type: PropTypes.number.isRequired,
+  amount: PropTypes.string,
   roundTo: PropTypes.number,
 };
 

--- a/src/components/screens/wallet/transactions/amount/transactionAmount.css
+++ b/src/components/screens/wallet/transactions/amount/transactionAmount.css
@@ -7,7 +7,7 @@
   margin-left: 8px;
   font-weight: var(--font-weight-bold);
 
-  & .recieve {
+  & .receive {
     border-radius: var(--border-radius-standard);
     display: inline-block;
     padding: 6px 12px;

--- a/src/components/screens/wallet/transactions/transactionRow.js
+++ b/src/components/screens/wallet/transactions/transactionRow.js
@@ -97,9 +97,12 @@ class TransactionRow extends React.Component {
         </div>
         <div className={`${columnClassNames.amount} transactions-cell`}>
           <TransactionAmount
-            address={address}
+            host={address}
             token={token}
-            transaction={value}
+            sender={value.senderId}
+            recipient={value.recipientId || value.asset.recipientId}
+            type={value.type}
+            amount={value.amount || value.asset.amount}
           />
         </div>
       </div>

--- a/src/components/shared/transactionsTable/index.js
+++ b/src/components/shared/transactionsTable/index.js
@@ -72,8 +72,9 @@ const TransactionsTable = ({
         <Table
           data={transactions.data}
           isLoading={transactions.isLoading}
-          row={props => <TransactionRow t={t} {...props} />}
+          row={TransactionRow}
           loadData={handleLoadMore}
+          additionalRowProps={{ t }}
           header={header(changeSort, t)}
           currentSort={sort}
           canLoadMore

--- a/src/components/shared/votes/voteRow.js
+++ b/src/components/shared/votes/voteRow.js
@@ -65,6 +65,7 @@ const VoteRow = ({
 
 /* istanbul ignore next */
 const areEqual = (prevProps, nextProps) =>
-  (prevProps.data.address === nextProps.data.address);
+  (prevProps.data.address === nextProps.data.address
+    && prevProps.data.rewards === nextProps.data.rewards);
 
 export default React.memo(VoteRow, areEqual);

--- a/src/components/shared/votes/votesTab.js
+++ b/src/components/shared/votes/votesTab.js
@@ -102,8 +102,12 @@ const VotesTab = ({
           canLoadMore={canLoadMore}
           isLoading={areLoading}
           iterationKey="address"
-          row={props =>
-            <VoteRow {...props} t={t} onRowClick={onRowClick} apiVersion={apiVersion} />}
+          row={VoteRow}
+          additionalRowProps={{
+            t,
+            apiVersion,
+            onRowClick,
+          }}
           loadData={onShowMore}
           header={header(t, apiVersion)}
         />

--- a/src/components/toolbox/table/loadMoreButton.js
+++ b/src/components/toolbox/table/loadMoreButton.js
@@ -7,7 +7,8 @@ const LoadMoreButton = ({
 }) => {
   if (
     error
-    || dataLength === 0
+    || dataLength < 30
+    || dataLength % 30 === 0
     || !canLoadMore
   ) return null;
   return (<FooterButton className="load-more" onClick={onClick}>{t('Load more')}</FooterButton>);

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -113,7 +113,6 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
     // https://github.com/LiskHQ/lisk-desktop/pull/1609
     setTimeout(() => {
       updateAccountData(store);
-
       store.dispatch(updateTransactions({
         pendingTransactions: transactions.pending,
         address: account.address,
@@ -136,7 +135,7 @@ const getNetworkFromLocalStorage = () => {
 };
 
 // eslint-disable-next-line max-statements
-const checkNetworkToConnet = (storeSettings) => {
+const checkNetworkToConnect = (storeSettings) => {
   const autologinData = getAutoLogInData();
   let loginNetwork = findMatchingLoginNetwork();
 
@@ -190,7 +189,7 @@ const autoLogInIfNecessary = async (store) => {
   const actualSettings = store && store.getState().settings;
   const autologinData = getAutoLogInData();
 
-  const loginNetwork = checkNetworkToConnet(actualSettings);
+  const loginNetwork = checkNetworkToConnect(actualSettings);
 
   store.dispatch(await networkSet(loginNetwork));
   store.dispatch(networkStatusUpdated({ online: true }));

--- a/src/utils/api/lsk/adapters.js
+++ b/src/utils/api/lsk/adapters.js
@@ -15,13 +15,15 @@ export const txAdapter = (data) => { // eslint-disable-line import/prefer-defaul
   const apiVersion = store.getState().network.apiVersion;
   if (apiVersion === defaultApiVersion) return data;
   const morphedData = { ...data };
+  const { type } = data;
 
-  if (data.type === 8) {
+  if (type === 8) {
     morphedData.recipientId = data.asset.recipientId;
     morphedData.amount = data.asset.amount;
   }
-
-  morphedData.type -= 8;
+  if (type >= 8) {
+    morphedData.type -= 8;
+  }
   return morphedData;
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2746

### How have I implemented/fixed it?
- Refactored the Transaction amount. Removed the extra logic. Added adaption to Core 3.x.
- Adapted the pending transactions to both versions of API.
- Refactored the delegates and transactions tables to prevent extra render rounds.
- Show the loadMore button only if we load 30 items each time. 
- Render a link for delegates on the delegates page, only when voting is not active.


### How has this been tested?
In progress. Must be visually tested.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
