### PR TITLE
Correct the conditions of showing the initialization warning - closes #2529

### DIFF
--- a/src/components/screens/settings/index.js
+++ b/src/components/screens/settings/index.js
@@ -8,10 +8,8 @@ import { networkSet } from '../../../actions/network';
 import { getActiveTokenAccount } from '../../../utils/account';
 
 const mapStateToProps = state => ({
-  hasSecondPassphrase: !!(state.account.info && state.account.info.LSK.secondPublicKey),
   settings: state.settings,
   account: getActiveTokenAccount(state),
-  isAuthenticated: !!state.account.info,
   transactions: state.transactions,
 });
 

--- a/src/components/screens/settings/secondPassphrase.js
+++ b/src/components/screens/settings/secondPassphrase.js
@@ -10,10 +10,10 @@ import Icon from '../../toolbox/icon';
 const fee = utils.convertBeddowsToLSK(`${Fees.setSecondPassphrase}`);
 
 const SecondPassphraseSetting = ({
-  account, hasSecondPassphrase, isHwWalletClass, t, hasPendingSecondPassphrase,
+  account, isHwWalletClass, t, hasPendingSecondPassphrase,
 }) => (
   <div className={`${styles.fieldGroup} ${styles.checkboxField} second-passphrase`}>
-    {hasSecondPassphrase
+    {account.secondPublicKey !== ''
       ? (
         <Icon
           className={`${styles.checkmark} second-passphrase-registered`}
@@ -27,7 +27,7 @@ const SecondPassphraseSetting = ({
       <p>
         {t('Every time you make a transaction you’ll need to enter your second passphrase in order to confirm it.')}
       </p>
-      {!hasSecondPassphrase
+      {account.secondPublicKey === ''
         ? (
           <React.Fragment>
             {account.balance < Fees.setSecondPassphrase

--- a/src/components/screens/settings/secondPassphrase.js
+++ b/src/components/screens/settings/secondPassphrase.js
@@ -10,10 +10,10 @@ import Icon from '../../toolbox/icon';
 const fee = utils.convertBeddowsToLSK(`${Fees.setSecondPassphrase}`);
 
 const SecondPassphraseSetting = ({
-  account, isHwWalletClass, t, hasPendingSecondPassphrase,
+  account, t, hasPendingSecondPassphrase, isHardwareWalletAccount,
 }) => (
   <div className={`${styles.fieldGroup} ${styles.checkboxField} second-passphrase`}>
-    {account.secondPublicKey !== ''
+    {account.secondPublicKey
       ? (
         <Icon
           className={`${styles.checkmark} second-passphrase-registered`}
@@ -22,12 +22,12 @@ const SecondPassphraseSetting = ({
       )
       : null
     }
-    <div className={isHwWalletClass}>
+    <div className={isHardwareWalletAccount ? `${styles.disabled} disabled` : ''}>
       <span className={styles.labelName}>{t('Second passphrase')}</span>
       <p>
         {t('Every time you make a transaction you’ll need to enter your second passphrase in order to confirm it.')}
       </p>
-      {account.secondPublicKey === ''
+      {!account.secondPublicKey
         ? (
           <React.Fragment>
             {account.balance < Fees.setSecondPassphrase

--- a/src/components/screens/settings/settings.js
+++ b/src/components/screens/settings/settings.js
@@ -69,8 +69,6 @@ class Settings extends React.Component {
   render() {
     const {
       t, settings,
-      hasSecondPassphrase,
-      isAuthenticated,
       transactions: { pending },
       account,
     } = this.props;
@@ -133,11 +131,11 @@ class Settings extends React.Component {
                   <p>{t('Log out automatically after 10 minutes.')}</p>
                 </div>
               </label>
-              {isAuthenticated && settings.token.active !== tokenMap.BTC.key
+              {!account.afterLogout && account.token === tokenMap.LSK.key
                 ? (
                   <SecondPassphraseSetting
                     {...{
-                      account, hasSecondPassphrase, isHwWalletClass, t, hasPendingSecondPassphrase,
+                      account, isHwWalletClass, t, hasPendingSecondPassphrase,
                     }}
                   />
                 )

--- a/src/components/screens/settings/settings.js
+++ b/src/components/screens/settings/settings.js
@@ -74,8 +74,7 @@ class Settings extends React.Component {
     } = this.props;
     const { currencies } = this.state;
 
-    const isHardwareWalletAccount = account.hwInfo && account.hwInfo.deviceId;
-    const isHwWalletClass = isHardwareWalletAccount ? `${styles.disabled} disabled` : '';
+    const isHardwareWalletAccount = account.hwInfo && !!account.hwInfo.deviceId;
     const activeCurrency = currencies.indexOf(settings.currency || settingsConst.currencies[0]);
     const hasPendingSecondPassphrase = pending.find(element =>
       element.type === txTypes.setSecondPassphrase) !== undefined;
@@ -134,9 +133,10 @@ class Settings extends React.Component {
               {!account.afterLogout && account.token === tokenMap.LSK.key
                 ? (
                   <SecondPassphraseSetting
-                    {...{
-                      account, isHwWalletClass, t, hasPendingSecondPassphrase,
-                    }}
+                    account={account}
+                    t={t}
+                    isHardwareWalletAccount={isHardwareWalletAccount}
+                    hasPendingSecondPassphrase={hasPendingSecondPassphrase}
                   />
                 )
                 : null}

--- a/src/components/screens/settings/settings.test.js
+++ b/src/components/screens/settings/settings.test.js
@@ -36,7 +36,7 @@ describe('Setting', () => {
 
   const props = {
     transactions: { pending: [] },
-    account: {},
+    account: { token: 'LSK' },
     settingsUpdated: jest.fn(),
     accountUpdated: jest.fn(),
     settings,
@@ -104,7 +104,7 @@ describe('Setting', () => {
 
   describe('With specific properties', () => {
     it('should disable 2nd passphrase when hardwareWallet', () => {
-      const newProps = { ...props, account: { hwInfo: { deviceId: '123' } } };
+      const newProps = { ...props, account: { hwInfo: { deviceId: '123' }, token: 'LSK' } };
       wrapper = mount(
         <Settings {...newProps} />,
       );
@@ -118,7 +118,7 @@ describe('Setting', () => {
     });
 
     it('should render 2nd passphrase as active', () => {
-      const account2ndPassphrase = { info: { LSK: accounts.second_passphrase_account } };
+      const account2ndPassphrase = { secondPublicKey: 'sample_public_key', token: 'LSK' };
       const newProps = { ...props, account: account2ndPassphrase, hasSecondPassphrase: true };
       wrapper = mount(
         <Settings {...newProps} />,

--- a/src/components/shared/initializationMessage/initializationMessage.js
+++ b/src/components/shared/initializationMessage/initializationMessage.js
@@ -13,12 +13,12 @@ export const InitializationMessageRenderer = ({
   pendingTransactions,
 }) => {
   const shouldShowInitialization = (
-    !!(account.info
-      && !(account.info.LSK.serverPublicKey
+    settings.token.active === 'LSK'
+    && account.info
+    && account.info.LSK
+    && !(account.info.LSK.serverPublicKey
       || account.info.LSK.balance === 0
-      || pendingTransactions.length > 0
-      || settings.token.active === 'BTC')
-    )
+      || pendingTransactions.length > 0)
   );
 
   const onButtonClick = () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2529 

### How have I implemented/fixed it?
There are two issues
1. The initialization banner utility assumes we always have the LSK object in accounts. while if the user is not signed in, we don't.
2. The settings page assumes we never have a BTC active when the user has not signed in, which is wrong. cause this option is available in the settings page even when the user is not signed in.

### How has this been tested?
- Sign out.
- Navigate to the settings page.
 - Toggle the LSK options a serveral times.
The app shouldn't crash.

### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
