### PR TITLE
Fix delegates voting issues - Closes #2722

### DIFF
--- a/src/components/screens/delegates/delegates.js
+++ b/src/components/screens/delegates/delegates.js
@@ -23,7 +23,7 @@ class Delegates extends React.Component {
     this.setState({ votingModeEnabled: !this.state.votingModeEnabled });
   }
 
-  obBoardingDiscarded = () => {
+  onBoardingDiscarded = () => {
     this.setState({ onBoardingDiscarded: true });
   }
 
@@ -52,7 +52,6 @@ class Delegates extends React.Component {
     const {
       account,
       loadDelegates,
-      loadVotes,
       t,
       votes,
     } = this.props;
@@ -64,7 +63,7 @@ class Delegates extends React.Component {
             <Onboarding
               slides={this.getOnboardingSlides()}
               finalCallback={this.toggleVotingMode}
-              onDiscard={this.obBoardingDiscarded}
+              onDiscard={this.onBoardingDiscarded}
               actionButtonLabel={t('Start voting')}
               name="delegateOnboarding"
             />
@@ -82,7 +81,6 @@ class Delegates extends React.Component {
         <section className={`${grid['col-sm-12']} ${grid['col-md-12']} ${styles.votingBox} ${styles.votes}`}>
           <DelegatesTable
             account={account}
-            loadVotes={loadVotes}
             loadDelegates={loadDelegates}
             votingModeEnabled={votingModeEnabled}
           />

--- a/src/components/screens/delegates/delegatesTable/withDelegatesData.js
+++ b/src/components/screens/delegates/delegatesTable/withDelegatesData.js
@@ -51,9 +51,8 @@ const withDelegatesData = () => (ChildComponent) => {
           offset,
           q: '',
           refresh: false,
-          callback: (...rest) => {
+          callback: () => {
             this.isFillingDelegates = false;
-            this.getDelegatesData.bind(this, ...rest);
           },
         });
       }

--- a/src/components/screens/delegates/delegatesTable/withDelegatesData.js
+++ b/src/components/screens/delegates/delegatesTable/withDelegatesData.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { getPendingVotesList } from '../../../../utils/voting';
 import voteFilters from '../../../../constants/voteFilters';
 
 const withDelegatesData = () => (ChildComponent) => {
@@ -17,26 +16,48 @@ const withDelegatesData = () => (ChildComponent) => {
       this.loadDelegates = this.loadDelegates.bind(this);
       this.loadDelegatesFinished = this.loadDelegatesFinished.bind(this);
       this.applyFilters = this.applyFilters.bind(this);
+      this.tabFilters = {
+        [voteFilters.all]: () => true,
+        [voteFilters.voted]: ({ voteStatus }) => voteStatus && voteStatus.confirmed,
+        [voteFilters.notVoted]: ({ voteStatus }) => !voteStatus || !voteStatus.confirmed,
+      };
     }
 
     componentDidMount() {
+      this.mounted = true;
       const { account: { serverPublicKey, address }, votes, loadVotes } = this.props;
-      if (serverPublicKey && getPendingVotesList(votes).length === 0) {
+      if (serverPublicKey && Object.keys(votes).length === 0) {
         loadVotes({ address });
       }
       this.loadDelegates({});
     }
 
+    componentWillUnmount() {
+      this.mounted = false;
+    }
+
     getDelegatesData() {
-      const tabFilters = {
-        [voteFilters.all]: () => true,
-        [voteFilters.voted]: ({ voteStatus }) => voteStatus && voteStatus.confirmed,
-        [voteFilters.notVoted]: ({ voteStatus }) => !voteStatus || !voteStatus.confirmed,
-      };
-      return this.props.delegates.map(delegate => ({
+      const filteredDelegates = this.props.delegates.map(delegate => ({
         ...delegate,
         voteStatus: this.props.votes[delegate.username],
-      })).filter(tabFilters[this.state.filters.tab]);
+      })).filter(this.tabFilters[this.state.filters.tab]);
+
+      if (filteredDelegates.length < Object.keys(this.props.votes).length
+        && !this.isFillingDelegates) {
+        this.isFillingDelegates = true;
+        const offset = this.props.delegates.length;
+        // this.props.delegates.loadData({ offset, limit: 101 });
+        this.props.loadDelegates({
+          offset,
+          q: '',
+          refresh: false,
+          callback: (...rest) => {
+            this.isFillingDelegates = false;
+            this.getDelegatesData.bind(this, ...rest);
+          },
+        });
+      }
+      return filteredDelegates;
     }
 
     loadDelegates({ q = '', offset = 0 }) {
@@ -51,7 +72,7 @@ const withDelegatesData = () => (ChildComponent) => {
     }
 
     loadDelegatesFinished() {
-      if (this.state.isLoading) {
+      if (this.state.isLoading && this.mounted) {
         this.setState({ isLoading: false });
       }
     }

--- a/src/components/screens/delegates/index.js
+++ b/src/components/screens/delegates/index.js
@@ -4,7 +4,6 @@ import { withTranslation } from 'react-i18next';
 import { getActiveTokenAccount } from '../../../utils/account';
 import {
   voteToggled,
-  loadVotes,
   loadDelegates,
   clearVotes,
 } from '../../../actions/voting';
@@ -19,7 +18,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   clearVotes,
   voteToggled,
-  loadVotes,
   loadDelegates,
 };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### What issue have I solved?
<!--- Complementary description if needed -->
Resolves #2722

### How have I implemented/fixed it?
 - Removed unused parameters
 - Here I need to merge votes and delegates lists to create the rich list of votes-delegates which I need. If the result list is shorter than the votes list, I fetch more delegates and do the same.
 - If the delegates list is previously fetched and satisfies the needs, I don't fetch it again.

### How has this been tested?
- If you press on edit votes button on the summary page and return to the delegates page, you should see your previously selected unconfirmed votes.
- If you vote to some active delegates and some standby delegates and then select the Voted tab. you should see all your votes.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
