### PR TITLE
Transaction detail page doesn't show votes - Closes #2770

### DIFF
--- a/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.js
@@ -88,7 +88,7 @@ class TransactionDetailView extends React.Component {
             </BoxRow>
           ) : null
         }
-        { isTransferTransaction && transaction.votesName ? (
+        { !isTransferTransaction && transaction.votesName ? (
           <TransactionVotes votes={transaction.votesName} />
         ) : null
         }

--- a/src/components/screens/explorer/transactions/transactionDetailView/transactionVotes.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/transactionVotes.js
@@ -10,7 +10,7 @@ const transactionVotes = ({ votes, t }) => {
   const accountPath = `${routes.accounts.pathPrefix}${routes.accounts.path}`;
   return (
     <React.Fragment>
-      {votes.added
+      {votes.added && votes.added.length > 0
         ? (
           <BoxRow>
             <div className={styles.detailsWrapper}>
@@ -32,7 +32,7 @@ const transactionVotes = ({ votes, t }) => {
             </div>
           </BoxRow>
         ) : null}
-      {votes.deleted
+      {votes.deleted && votes.deleted.length > 0
         ? (
           <BoxRow>
             <div className={styles.detailsWrapper}>


### PR DESCRIPTION
### What issue have I solved?
Resolves #2770

### How to test it?
Make sure added and removed votes list should are present in the transaction detail of a vote transaction.


### Review checklist
- The PR follows our [Test guide](/LiskHQ/lisk-desktop/blob/development/docs/TEST_GUIDE.md)
- The PR follows our [CSS guide](/LiskHQ/lisk-desktop/blob/development/docs/CSS_GUIDE.md)
