### PR TITLE
Fix the color of search bar results - Closes #2735

### DIFF
--- a/src/components/shared/searchBar/transactionsAndBlocks.css
+++ b/src/components/shared/searchBar/transactionsAndBlocks.css
@@ -59,6 +59,7 @@
     justify-content: flex-start;
     align-items: center;
     cursor: pointer;
+    color: var(--color-maastricht-blue);
 
     &:hover {
       background-color: var(--primary-background-color);


### PR DESCRIPTION
### What was the problem?
This PR resolves #2735

### How was it solved?
The color of the result value was not defined. so I used `maastricht-blue` which is used everywhere else.

### How was it tested?
Search for a block id in dark and light mode. the result should be readable.
