### PR TITLE
Align the colors of request form with the design guides - Closes #2726

### DIFF
--- a/src/app/variables.css
+++ b/src/app/variables.css
@@ -141,7 +141,7 @@ or "warn/action" ineastd of "red/green"
   --color-strong-mystic: var(--color-mystic);
   --color-passphrase-bg: var(--color-white);
   --color-shadow-word-option: var(--color-ultramarine-blue);
-  --color-request-textarea: transparent;
+  --color-request-textarea: var(--color-white-smoke);
 
   /*************************
         Box
@@ -214,5 +214,5 @@ or "warn/action" ineastd of "red/green"
   --color-passphrase-bg: #000;
   --color-dark-blue: var(--color-ultramarine-blue);
   --color-shadow-word-option: var(--color-strong-white);
-  --color-request-extarea: #2e2e30;
+  --color-request-textarea: #2e2e30;
 }

--- a/src/components/screens/wallet/transactions/request/request.css
+++ b/src/components/screens/wallet/transactions/request/request.css
@@ -144,7 +144,7 @@
   }
 
   & .sharingLink {
-    background-color: var(--color-request-extarea);
+    background-color: var(--color-request-textarea);
   }
 
   & .sectionFooter {


### PR DESCRIPTION
### What was the problem?
This PR resolves #2726

### How was it solved?
The background color of the testarea in light mode was defined `transparent`. I used `white-smoke` as requested.

### How was it tested?
Make sure the background color of the textarea on the request panel aligns with the design guides.
