### PR TITLE
Navigate to the wallet page when clicking on asset from menu - Closes #2723

### DIFF
--- a/src/components/shared/customRoute/customRoute.js
+++ b/src/components/shared/customRoute/customRoute.js
@@ -20,7 +20,7 @@ const CustomRoute = ({
   Piwik.tracking(rest.history, settings);
 
   if (forbiddenTokens.indexOf(settings.token.active) !== -1) {
-    return <Redirect to={`${routes.dashboard.path}`} />;
+    return <Redirect to={`${routes.wallet.path}`} />;
   }
 
   return ((isPrivate && isAuthenticated) || !isPrivate

--- a/src/components/shared/header/topBar/accountMenu/userAccount.js
+++ b/src/components/shared/header/topBar/accountMenu/userAccount.js
@@ -25,6 +25,10 @@ class UserAccount extends React.Component {
   handleTokenSelect(token) {
     this.props.settingsUpdated({ token: { active: token } });
     this.toggleDropdown();
+    const { location, push } = this.props.history;
+    if (location.pathname !== routes.wallet.path) {
+      push(routes.wallet.path);
+    }
   }
 
   handleLogout() {

--- a/src/components/shared/header/topBar/accountMenu/userAccount.test.js
+++ b/src/components/shared/header/topBar/accountMenu/userAccount.test.js
@@ -30,7 +30,7 @@ describe('UserAccount', () => {
     history: {
       location: { path: '/wallet' },
       push: jest.fn(),
-    }
+    },
   };
 
   it('renders <UserAccount /> component', () => {

--- a/src/components/shared/header/topBar/accountMenu/userAccount.test.js
+++ b/src/components/shared/header/topBar/accountMenu/userAccount.test.js
@@ -27,6 +27,10 @@ describe('UserAccount', () => {
     settingsUpdated: jest.fn(),
     setDropdownRef: () => {},
     t: val => val,
+    history: {
+      location: { path: '/wallet' },
+      push: jest.fn(),
+    }
   };
 
   it('renders <UserAccount /> component', () => {

--- a/src/components/shared/header/topBar/topBar.js
+++ b/src/components/shared/header/topBar/topBar.js
@@ -129,6 +129,7 @@ class TopBar extends React.Component {
             onLogout={this.onLogout}
             settingsUpdated={settingsUpdated}
             isUserLogout={isUserLogout}
+            history={this.props.history}
             t={t}
           />
 

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -154,6 +154,10 @@ Then(/^I should be on (.*?) page of (.*?)$/, function (pageName, identifier) {
   }
 });
 
+Then(/^I click on send$/, function () {
+  cy.get(ss.transactionSendButton).eq(0).click();
+});
+
 Then(/^I click on recent transaction$/, function () {
   cy.get(ss.transactionRow).eq(0).click();
 });

--- a/test/cypress/features/sendBtc.feature
+++ b/test/cypress/features/sendBtc.feature
@@ -3,8 +3,7 @@ Feature: Send Btc
   Scenario: Enable and Transfer btc
     Given I autologin as genesis to testnet
     And I change active token to BTC
-    Given I am on wallet page
-    And I click on Send
+    And I click on send
     And I fill mkakDp2f31btaXdATtAogoqwXcdx1PqqFo in recipient
     And I fill 0.00000001 in amount
     And I go to transfer confirmation

--- a/test/cypress/features/sendBtc.feature
+++ b/test/cypress/features/sendBtc.feature
@@ -2,6 +2,7 @@ Feature: Send Btc
 
   Scenario: Enable and Transfer btc
     Given I autologin as genesis to testnet
+    Given I am on wallet page
     And I change active token to BTC
     And I click on send
     And I fill mkakDp2f31btaXdATtAogoqwXcdx1PqqFo in recipient

--- a/test/cypress/features/sendBtc.feature
+++ b/test/cypress/features/sendBtc.feature
@@ -2,8 +2,8 @@ Feature: Send Btc
 
   Scenario: Enable and Transfer btc
     Given I autologin as genesis to testnet
-    Given I am on Send page
-    When I change active token to BTC
+    And I change active token to BTC
+    And I go to send
     And I fill mkakDp2f31btaXdATtAogoqwXcdx1PqqFo in recipient
     And I fill 0.00000001 in amount
     And I go to transfer confirmation

--- a/test/cypress/features/sendBtc.feature
+++ b/test/cypress/features/sendBtc.feature
@@ -3,7 +3,8 @@ Feature: Send Btc
   Scenario: Enable and Transfer btc
     Given I autologin as genesis to testnet
     And I change active token to BTC
-    And I go to send
+    Given I am on wallet page
+    And I click on Send
     And I fill mkakDp2f31btaXdATtAogoqwXcdx1PqqFo in recipient
     And I fill 0.00000001 in amount
     And I go to transfer confirmation


### PR DESCRIPTION
### What was the problem?
This PR resolves #2723

### How was it solved?
1. I navigate to Wallet right after the token change.
2. For the sake of consistency, if the user tries to navigate to a path which is not available for the active token, say if clicked on a Vote launch protocol while BTC is active, I make it fall back to Wallet.

### How was it tested?
Change the token, it should redirect you to Wallet.
