### PR TITLE
Fix the aggregated delegate registration graph - Closes #2773

### DIFF
--- a/src/components/screens/monitor/delegates/overview.js
+++ b/src/components/screens/monitor/delegates/overview.js
@@ -31,14 +31,16 @@ const Overview = ({
   const getAmountOfDelegatesInTime = () => {
     const totalDelegates = chartActiveAndStandby.data;
     const final = [totalDelegates];
+    let allPositiveValues = true;
     chartRegisteredDelegates.data
       .map(delegate => (delegate.y))
       .reduce((amountOfDelegates, amountOfDelegatesByMonth) => {
         final.unshift(amountOfDelegates - amountOfDelegatesByMonth);
+        allPositiveValues = allPositiveValues && amountOfDelegates - amountOfDelegatesByMonth > 0;
         return amountOfDelegates - amountOfDelegatesByMonth;
       }, totalDelegates);
 
-    return final;
+    return allPositiveValues ? final : [];
   };
 
   const getAmountOfDelegatesLabels = () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #2773 

### How was it solved?
Based on my limited observation, this issue occurs when the total number of delegate registration transaction is (zero) less than the aggregation of values return by `/api/v1/transactions`, hence the calculation of `amountOfDelegates - amountOfDelegatesByMonth` yields a negative value.
This must be an issue with the endpoints. I prevent returning any negative value.

### How was it tested?
Connect to different networks, this graph should always show positive values.
