### PR TITLE
Fix desktop notifications to work with Lisk Core 3.0 - Closes #2779

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -95,11 +95,10 @@ const checkTransactionsAndUpdateAccount = (store, action) => {
   const { transactions, settings: { token } } = state;
   const account = getActiveTokenAccount(store.getState());
 
-  const txs = action.data.block.transactions || [];
+  const txs = (action.data.block.transactions || []).map(txAdapter);
   const blockContainsRelevantTransaction = txs.filter((transaction) => {
-    const morphedTx = txAdapter(transaction);
-    const sender = morphedTx ? morphedTx.senderId : null;
-    const recipient = morphedTx ? morphedTx.recipientId : null;
+    const sender = transaction ? transaction.senderId : null;
+    const recipient = transaction ? transaction.recipientId : null;
     return account.address === recipient || account.address === sender;
   }).length > 0;
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #2779 

The problem was that the transactions were not transformed by `txAdapter`.

### How was it solved?
<!--- Please describe your technical implementation -->

Ensure that the logic for notification uses transaction object transformed by `txAdapter` from `/src/utils/api/lsk/adapters`

### How was it tested?
<!--- Please describe how you tested your changes -->

- Build the desktop app from this branch
- Open the app and connect to https://betanet.lisk.io and login to an account
- Send transactions to/from this account and see a notification is/isn't displayed as expected based on the transaction type