### PR TITLE
Use next_forgers to fetch the list of active delegates - Closes #2800

### DIFF
--- a/src/utils/api/lsk/liskService.js
+++ b/src/utils/api/lsk/liskService.js
@@ -124,7 +124,7 @@ const liskServiceApi = {
 
   getActiveDelegates: async ({ networkConfig }, { search = '', tab, ...searchParams }) => liskServiceGet({
     networkConfig,
-    path: '/api/v1/delegates/active',
+    path: '/api/v1/delegates/next_forgers',
     transformResponse: response => response.data.filter(
       delegate => delegate.username.includes(search),
     ),


### PR DESCRIPTION
### What was the problem?
This PR resolves #2800

### How was it solved?
We used the `/delegates` endpoint to fetch the first 101 items using `limit=101` parameter. but we should have used `/delegates/next_forgers`.

Note:
At the moment this endpoint limits the number of delegates to 100, while we need 101. @MichalTuleja will update the Service endpoint to accept 101.

### How was it tested?
Make sure the active delegates list on the monitor section has 101 items and it matches the output of `/delegates/next_forgers`.
