### PR TITLE
Fix BTC transaction details page - Closes #2799

### DIFF
--- a/src/components/screens/explorer/transactions/transactionDetailView/accountInfo.test.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/accountInfo.test.js
@@ -23,4 +23,10 @@ describe('TxDetail AccountInfo', () => {
     expect(wrapper.find('.label').text()).toEqual('Label test');
     expect(wrapper.find('.address').first().text()).toEqual('sdfsdf67565');
   });
+
+  it('Should render the name if passed', () => {
+    const namedProps = { ...props, address: 'sdfsdf67565', name: 'genesis' };
+    const wrapper = mount(<AccountInfo {...namedProps} />);
+    expect(wrapper.text().indexOf('genesis')).not.toEqual(-1);
+  });
 });

--- a/src/components/screens/explorer/transactions/transactionDetailView/accountInfo.test.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/accountInfo.test.js
@@ -18,8 +18,8 @@ describe('TxDetail AccountInfo', () => {
   });
 
   it('Should render with invalid address and label passed as props', () => {
-    const neweProps = { ...props, address: 'sdfsdf67565' };
-    const wrapper = mount(<AccountInfo {...neweProps} />);
+    const newProps = { ...props, address: 'sdfsdf67565' };
+    const wrapper = mount(<AccountInfo {...newProps} />);
     expect(wrapper.find('.label').text()).toEqual('Label test');
     expect(wrapper.find('.address').first().text()).toEqual('sdfsdf67565');
   });

--- a/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.js
@@ -9,8 +9,11 @@ import styles from './transactionDetailView.css';
 import transactionTypes from '../../../../../constants/transactionTypes';
 
 
-function getDelegateName(transaction) {
-  return transaction.asset && transaction.asset.delegate && transaction.asset.delegate.username;
+function getDelegateName(transaction, activeToken) {
+  return (activeToken === 'LSK'
+    && transaction.asset
+    && transaction.asset.delegate
+    && transaction.asset.delegate.username) ? transaction.asset.delegate.username : null;
 }
 
 const getTxAsset = (tx) => {
@@ -47,7 +50,7 @@ class TransactionDetailView extends React.Component {
         }
         <BoxRow className={styles.detailsWrapper}>
           <AccountInfo
-            name={getDelegateName(transaction)}
+            name={getDelegateName(transaction, activeToken)}
             token={activeToken}
             netCode={netCode}
             address={transaction.senderId}
@@ -70,7 +73,7 @@ class TransactionDetailView extends React.Component {
           : null
         }
         {children}
-        { isTransferTransaction
+        { isTransferTransaction && activeToken === 'LSK'
           ? (
             <BoxRow className={styles.message}>
               <div className={`${styles.detailsWrapper}`}>

--- a/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.test.js
+++ b/src/components/screens/explorer/transactions/transactionDetailView/transactionDetailView.test.js
@@ -22,12 +22,35 @@ describe('Transaction Detail View', () => {
       t: v => v,
     };
 
-    it('Should render transfer transaction with message', () => {
-      wrapper = mount(<TransactionDetailView {...props} />);
+    it('Should render transfer transaction with message (LSK)', () => {
+      wrapper = mount(<TransactionDetailView {...props} activeToken="LSK" />);
       expect(wrapper).toContainMatchingElements(2, '.accountInfo');
       expect(wrapper.find('.accountInfo .sender-address').text()).toBe(transaction.senderId);
       expect(wrapper.find('.accountInfo .receiver-address').text()).toBe(transaction.recipientId);
       expect(wrapper).toContainExactlyOneMatchingElement('.tx-reference');
+    });
+    it('Should not render transfer transaction with message (BTC)', () => {
+      wrapper = mount(<TransactionDetailView {...props} activeToken="BTC" />);
+      expect(wrapper).not.toContain('.tx-reference');
+    });
+    it('Should show the delegate name if the sender is a Lisk delegate', () => {
+      const delegateTransaction = {
+        type: 3,
+        senderId: accounts.genesis.address,
+        recipientId: '',
+        amount: 0,
+        id: 123,
+        asset: {
+          delegate: { username: 'genesis' },
+        },
+      };
+      const newProps = {
+        activeToken: 'BTC',
+        t: v => v,
+        transaction: delegateTransaction,
+      };
+      wrapper = mount(<TransactionDetailView {...newProps} />);
+      expect(wrapper).not.toContain('genesis');
     });
   });
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #2799

### How was it solved?
I look for the delegate details only if the active token is LSK.

### How was it tested?
Make sure you see all the details of the transaction correctly.
