### PR TITLE
Prevent notifications on non-send transaction types - Closes #2779

### DIFF
--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -73,7 +73,9 @@ const votePlaced = (store, action) => {
 };
 
 const filterIncommingTransactions = (transactions, account) => transactions.filter(transaction => (
-  transaction && transaction.recipientId === account.address
+  transaction
+  && transaction.recipientId === account.address
+  && transaction.type === transactionTypes().send.code
 ));
 
 const showNotificationsForIncomingTransactions = (transactions, account, token) => {

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -40,12 +40,14 @@ describe('Account middleware', () => {
         recipientId: 'sample_address',
         asset: { data: 'Message' },
         amount: 10e8,
+        type: 0,
       },
       {
         senderId: 'some_address',
         recipientId: 'sample_address',
         asset: { data: '' },
         amount: 10e8,
+        type: 0,
       },
     ],
   };


### PR DESCRIPTION
### What was the problem?
This PR resolves #2779

### How was it solved?
<!--- Please describe your technical implementation -->

There was still the problem with showing the notification for other transaction types on Lisk Core 2.3. So I added an explicit condition for transaction type.

### How was it tested?
<!--- Please describe how you tested your changes -->
- Build the desktop app from this branch
- Open the app and connect to https://testnet.lisk.io and login to an account
- Send transactions to/from this account and see a notification is/isn't displayed as expected based on the transaction type

Try the above also with https://betanet.lisk.io 