### PR TITLE
Describe project layout in README file - Closes 2807

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
 
 ### Setup environemnt
 
-#### Clone and install depdendencies
-
 ```
 git clone https://github.com/LiskHQ/lisk-desktop.git
 cd lisk-desktop
@@ -24,7 +22,7 @@ npm install
 npm run dev
 ```
 
-#### Run on Browser
+### Run on browser
 
 Open http://localhost:8080
 
@@ -33,17 +31,25 @@ For ease of development, you can set the following query string to see network o
 http://localhost:8080/#/?showNetwork=true
 ```
 
-If you are actively developing in a specific route, and want to be autologged in everytime you reload the page, please add the following to localStorage:
+If you are actively developing in a specific route, and want to be automatically signed in every time you reload the page, please add the following input pairs to your localStorage:
+
+_loginKey_: _a valid passphrase_
+
+Add the above pair using the storage tab in your dev tools or via JavaScript command: 
 
 ```
-localStorage.setItem('liskCoreUrl', 'http://localhost:4000') // desired node to log in into
 localStorage.setItem('loginKey', 'wagon stock borrow episode laundry kitten salute link globe zero feed marble') // desired account passphrase
 ```
 
-When developing with hardware wallet, this will log you into to first account on the first connected hardware wallet:
+
+When developing with hardware wallet, this will sign you in using the first account on the first connected hardware wallet:
+```
+localStorage.setItem('hwWalletAutoLogin', true);
+```
+You can use the same approach to define a desired network to which Lisk Desktop connects:
+
 ```
 localStorage.setItem('liskCoreUrl', 'http://localhost:4000') // desired node to log in into
-localStorage.setItem('hwWalletAutoLogin', true);
 ```
 
 ### Build
@@ -55,48 +61,47 @@ To build the project simply run
 ```
 npm run build
 ```
-
-##### Using Commercial Fonts
-Since some of the fonts used in the production version are commercial, this repository only contains open source fonts and uses `Open Sans` as a replacement for the commercial ones.
-
-If you have licensed copies of `Basier Circle` and `Gilroy`, you can add them to [fonts folder](./src/assets/fonts) to replace the empty files that are there so that webpack build doesn't fail if the fonts are not present.
-
-#### Electron
-
-##### Run using Electron
-
-
-Start the Electron client. Before staring you need to make sure the application is built. If you need to build the entire application, run
+Under the hood, this script runs
 
 ```
-npm run build
+npm run build-prod
 ```
-
-as mentioned before. And if you want to solely build electron app, run
-
-##### Build the electron app
+to build the React app under `src/` and
 
 ```
 npm run build-electron
 ```
+to build the electron app under `app/` using webpack. You can run the above scripts individually if you're looking to see the changes solely on one of the two said applications.
 
-Then, in order to launch electron, you can run
+
+#### Using Commercial Fonts
+`Basier Circle` and `Gilroy` used in the production version are commercial fonts. This repository only contains open fonts and uses `Open Sans` as a replacement for the commercial ones.
+
+If you have licensed copies of `Basier Circle` and `Gilroy`, you can add them to [fonts folder](./src/assets/fonts) to replace the empty files that are there so that webpack build doesn't fail if the fonts are not present.
+
+### Run Electron
+If you have already built the application as described above, you can launch Electron using
 
 ```
 npm run start
 ```
 
-Then, in order to launch version with hardware wallet, you can run
+#### Run with parameters
+
+To launch a version which supports hardware wallets, you can run
 
 ```
 npm run dev-hardware-wallet
 ```
 
-In order to launch electron that gets live updates from already running webpack-dev-server on port 8080 and with react/redux dev tools, you can run
+or to launch electron and receive live updates from already running `webpack-dev-server` on port `8080` and you can run
 
 ```
 LISK_HUB_URL="http://localhost:8080" DEBUG=true npm run start
 ```
+This comes with Redux dev tools.
+
+### Distribution
 
 #### Windows
 

--- a/README.md
+++ b/README.md
@@ -11,39 +11,11 @@
 ## For Contributors
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
 
-#### Directory Layout
-
-```
-├── __mocks__/                     # Modules used to mock dependencies for testing purpose.
-├── .storybook/                    # React storybooks reside here.
-├── app/                           # Electron based application that launces the react app.
-├── build/                         # Build specific materials.
-├── config/                        # Automation scripts (Webpack configurations, i18n scanner, etc)
-├── coverage/                      # Results of Jest test coverage.
-├── dist/                          # Platform specific built outputs.
-├── docs/                          # Project documentations such as contribution guides and development guidelines.
-├── i18n/                          # Localization files inluding setup scripts and translation json files.
-├── libs/                          # Modules which can be consumed individually in other projects.
-├── node_modules/                  # 3rd-party libraries and utilities.
-├── src/                           # Application source code.
-│   ├── actions/                   # Store actions reside here and are broken into script files dedicated to each system entity.
-│   ├── app/                       # The bootstrap React application
-│   ├── assets/                    # Static files (images, fonts, etc)
-│   ├── components/                # React presentational components are located here.
-│   │   ├── screens/               # These are the component that represent screens with dedicated URL.
-│   │   ├── shared/                # These are the React components used at least in 2 other components (calendar, liskAmount, etc)
-│   │   └── toolbox/               # Basic elements with basic styles and functionality which are used in numerous places (button, input, etc)
-│   ├── constants/                 # Names, addresses, static configurations and other values used throughout the application
-│   ├── context/                   # React context configuration files
-│   ├── hooks/                     # React custom hooks
-│   ├── store/                     # Redux store resides here.
-│   │   ├── middlewares/           # All the Redux middlewares are places here and have their dedicated script files based on the system entities.
-│   │   ├── reducers/              # Redux reducers are located here. similar to actions and reducers, they are placed in script files named after the entity they represent.
-│   ├── utils/                     # Utility functions
-└──test/                           # E2E tests written with Cypress.io and Cucumber; also some helpers used by unit test that live in /src
-```
-
 ## Development
+
+### Setup environemnt
+
+#### Clone and install depdendencies
 
 ```
 git clone https://github.com/LiskHQ/lisk-desktop.git
@@ -51,6 +23,8 @@ cd lisk-desktop
 npm install
 npm run dev
 ```
+
+#### Run on Browser
 
 Open http://localhost:8080
 
@@ -72,20 +46,24 @@ localStorage.setItem('liskCoreUrl', 'http://localhost:4000') // desired node to 
 localStorage.setItem('hwWalletAutoLogin', true);
 ```
 
-#### Build
+### Build
+
+#### Production build
+
+To build the project simply run
 
 ```
 npm run build
 ```
 
-#### Using Commercial Fonts
+##### Using Commercial Fonts
 Since some of the fonts used in the production version are commercial, this repository only contains open source fonts and uses `Open Sans` as a replacement for the commercial ones.
 
 If you have licensed copies of `Basier Circle` and `Gilroy`, you can add them to [fonts folder](./src/assets/fonts) to replace the empty files that are there so that webpack build doesn't fail if the fonts are not present.
 
-## Electron
+#### Electron
 
-#### Start
+##### Run using Electron
 
 
 Start the Electron client. Before staring you need to make sure the application is built. If you need to build the entire application, run
@@ -95,6 +73,8 @@ npm run build
 ```
 
 as mentioned before. And if you want to solely build electron app, run
+
+##### Build the electron app
 
 ```
 npm run build-electron
@@ -142,7 +122,9 @@ Build package for Linux (on Linux).
 npm run pack 
 ```
 
-## Run unit tests
+## Testing
+
+### Unit tests
 
 #### Single run
 ```
@@ -154,7 +136,7 @@ npm run test
 npm run test-live
 ```
 
-## Run end-to-end tests
+### E2E tests
 In order to run e2e tests you need to install [lisk-core](https://github.com/LiskHQ/lisk)
 
 #### Setup core
@@ -182,7 +164,7 @@ Run e2e tests
 npm run cypress:run
 ```
 
-## Launch React Storybook
+### React Storybook
 
 To launch storybook sandbox with components run
 ```
@@ -192,6 +174,37 @@ and navigate to
 
 http://localhost:6006/
 
+## Directory Layout
+
+```
+├── __mocks__/                     # Modules used to mock dependencies for testing purpose.
+├── .storybook/                    # React storybooks reside here.
+├── app/                           # Electron based application that launces the react app.
+├── build/                         # Build specific materials.
+├── config/                        # Automation scripts (Webpack configurations, i18n scanner, etc)
+├── coverage/                      # Results of Jest test coverage.
+├── dist/                          # Platform specific built outputs.
+├── docs/                          # Project documentations such as contribution guides and development guidelines.
+├── i18n/                          # Localization files inluding setup scripts and translation json files.
+├── libs/                          # Modules which can be consumed individually in other projects.
+├── node_modules/                  # 3rd-party libraries and utilities.
+├── src/                           # Application source code.
+│   ├── actions/                   # Store actions reside here and are broken into script files dedicated to each system entity.
+│   ├── app/                       # The bootstrap React application
+│   ├── assets/                    # Static files (images, fonts, etc)
+│   ├── components/                # React presentational components are located here.
+│   │   ├── screens/               # These are the component that represent screens with dedicated URL.
+│   │   ├── shared/                # These are the React components used at least in 2 other components (calendar, liskAmount, etc)
+│   │   └── toolbox/               # Basic elements with basic styles and functionality which are used in numerous places (button, input, etc)
+│   ├── constants/                 # Names, addresses, static configurations and other values used throughout the application
+│   ├── context/                   # React context configuration files
+│   ├── hooks/                     # React custom hooks
+│   ├── store/                     # Redux store resides here.
+│   │   ├── middlewares/           # All the Redux middlewares are places here and have their dedicated script files based on the system entities.
+│   │   ├── reducers/              # Redux reducers are located here. similar to actions and reducers, they are placed in script files named after the entity they represent.
+│   ├── utils/                     # Utility functions
+└──test/                           # E2E tests written with Cypress.io and Cucumber; also some helpers used by unit test that live in /src
+```
 
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -10,6 +10,39 @@
 
 ## For Contributors
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
+
+## Directory Layout
+
+```
+├── __mocks__/                     # Modules used to mock dependencies for testing purpose.
+├── .storybook/                    # React storybooks reside here.
+├── app/                           # Electron based application that launces the react app.
+├── build/                         # Build specific materials.
+├── config/                        # Automation scripts (Webpack configurations, i18n scanner, etc)
+├── coverage/                      # Results of Jest test coverage.
+├── dist/                          # Platform specific built outputs.
+├── docs/                          # Project documentations such as contribution guides and development guidelines.
+├── i18n/                          # Localization files inluding setup scripts and translation json files.
+├── libs/                          # Modules which can be consumed individually in other projects.
+├── node_modules/                  # 3rd-party libraries and utilities.
+├── src/                           # Application source code.
+│   ├── actions/                   # Store actions reside here and are broken into script files dedicated to each system entity.
+│   ├── app/                       # The bootstrap React application
+│   ├── assets/                    # Static files (images, fonts, etc)
+│   ├── components/                # React presentational components are located here.
+│   │   ├── screens/               # These are the component that represent screens with dedicated URL.
+│   │   ├── shared/                # These are the React components used at least in 2 other components (calendar, liskAmount, etc)
+│   │   └── toolbox/               # Basic elements with basic styles and functionality which are used in numerous places (button, input, etc)
+│   ├── constants/                 # Names, addresses, static configurations and other values used throughout the application
+│   ├── context/                   # React context configuration files
+│   ├── hooks/                     # React custom hooks
+│   ├── store/                     # Redux store resides here.
+│   │   ├── middlewares/           # All the Redux middlewares are places here and have their dedicated script files based on the system entities.
+│   │   ├── reducers/              # Redux reducers are located here. similar to actions and reducers, they are placed in script files named after the entity they represent.
+│   ├── utils/                     # Utility functions
+└──test/                           # SSL certificates for connecting to Cloud SQL instance
+```
+
 ## Development
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## For Contributors
 Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
 
-## Directory Layout
+#### Directory Layout
 
 ```
 ├── __mocks__/                     # Modules used to mock dependencies for testing purpose.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
 │   │   ├── middlewares/           # All the Redux middlewares are places here and have their dedicated script files based on the system entities.
 │   │   ├── reducers/              # Redux reducers are located here. similar to actions and reducers, they are placed in script files named after the entity they represent.
 │   ├── utils/                     # Utility functions
-└──test/                           # SSL certificates for connecting to Cloud SQL instance
+└──test/                           # E2E tests written with Cypress.io and Cucumber; also some helpers used by unit test that live in /src
 ```
 
 ## Development
@@ -206,4 +206,3 @@ This program is free software: you can redistribute it and/or modify it under th
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-desktop/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
-


### PR DESCRIPTION
### What was the problem?
This PR resolves #2807

### How was it solved?
the only issues remaining from #2807 was _There are 2 catalogs app and src which should be unified to one catalog_. Here I've described the entire project layout in README file, including `app` and `src` directories requested in said ticket.

### How to test it
Review the project layout [here](https://github.com/LiskHQ/lisk-desktop/tree/2807-code-improvements)
