### PR TITLE
Fix initialize account which fails if account does not have publicKey - Closes #2816

### DIFF
--- a/src/utils/hwManager.js
+++ b/src/utils/hwManager.js
@@ -39,7 +39,7 @@ const getAccountsFromDevice = async ({ device: { deviceId }, networkConfig }) =>
 const signSendTransaction = async (account, data) => {
   const transactionObject = {
     ...transfer(data),
-    senderPublicKey: account.info.LSK.publicKey,
+    senderPublicKey: account.info.LSK ? account.info.LSK.publicKey : null,
   };
 
   const transaction = {


### PR DESCRIPTION
### What was the problem?
This PR resolves #2816

### How was it solved?
The problem was that the utility function required `account.info.LSK.publicKey` to exist. but when the account is not initialized, this value is undefined.

### How was it tested?
- Create a new account.
- Transfer over 25 LSK to it.
- As the first outgoing transaction, register a delegate.
The above process should work fine and you should see the confirmed type transaction type 10/2 in your wallet.
