### PR TITLE
Fix invisible markers on the map - Closes #2832 

### DIFF
--- a/src/components/screens/monitor/network/map.js
+++ b/src/components/screens/monitor/network/map.js
@@ -2,10 +2,11 @@ import React, { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import styles from './network.css';
 import 'leaflet.markercluster/dist/leaflet.markercluster';
+import markerIcon from '../../../../assets/images/marker.svg';
 
 const createMarkers = (peers) => {
   const icon = L.icon({
-    iconUrl: '/assets/images/marker.svg',
+    iconUrl: markerIcon,
     iconSize: [42, 42],
   });
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #2832

### How was it solved?
Markers were not visible on the map due to some style conflict. I fixed them by defining specific styles rules for them.
