### PR TITLE
Remove send method from api utils - Closes #2046

### DIFF
--- a/src/actions/transactions.test.js
+++ b/src/actions/transactions.test.js
@@ -150,7 +150,6 @@ describe('actions: transactions', () => {
     });
 
     it('should dispatch addNewPendingTransaction action if resolved', async () => {
-      transactionsApi.send.mockResolvedValue({ id: '15626650747375562521' });
       const expectedAction = {
         id: '15626650747375562521',
         senderPublicKey: 'test_public-key',

--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -6,34 +6,6 @@ import txFilters from '../../../constants/transactionFilters';
 import transactionTypes from '../../../constants/transactionTypes';
 import { adaptTransactions, adaptTransaction } from './adapters';
 
-
-// TODO remove this function as is replaced right now by Create and Broadcast functions
-// Issue ticket #2046
-export const send = (
-  amount,
-  data,
-  networkConfig,
-  passphrase,
-  recipientId,
-  secondPassphrase = null,
-  timeOffset,
-) =>
-  new Promise((resolve, reject) => {
-    const Lisk = liskClient();
-    const txId = Lisk.transaction.transfer({
-      amount,
-      data,
-      passphrase,
-      recipientId,
-      secondPassphrase,
-      timeOffset,
-    });
-
-    getAPIClient(networkConfig).transactions.broadcast(txId)
-      .then(resolve(txId))
-      .catch(reject);
-  });
-
 const parseTxFilters = (filter = txFilters.all, address) => ({
   [txFilters.incoming]: { recipientId: address, type: transactionTypes().send.outgoingCode },
   [txFilters.outgoing]: { senderId: address, type: transactionTypes().send.outgoingCode },

--- a/src/utils/api/lsk/transactions.test.js
+++ b/src/utils/api/lsk/transactions.test.js
@@ -1,13 +1,11 @@
 import { to } from 'await-to-js';
 import Lisk from '@liskhq/lisk-client-old';
 import {
-  send,
   getTransactions,
   getSingleTransaction,
   create,
   broadcast,
 } from './transactions';
-import accounts from '../../../../test/constants/accounts';
 import networks from '../../../constants/networks';
 import { getAPIClient } from './network';
 import txFilters from '../../../constants/transactionFilters';
@@ -44,17 +42,6 @@ describe('Utils: Transactions API', () => {
     apiClient.node.getTransactions.mockResolvedValue({ data: [] });
 
     getAPIClient.mockReturnValue(apiClient);
-  });
-
-  // TODO: fix these tests for assert more than just a promise is returned
-  describe('send', () => {
-    it.skip('should broadcast a transaction and return a promise', async () => {
-      await send(amount, {}, apiClient, accounts.genesis.passphrase, recipientId, null, 0);
-      expect(apiClient.transactions.broadcast).toHaveBeenCalledWith(expect.objectContaining({
-        amount,
-        recipientId,
-      }));
-    });
   });
 
   describe('getTransactions', () => {

--- a/src/utils/api/transactions.js
+++ b/src/utils/api/transactions.js
@@ -3,11 +3,6 @@ import { tokenMap, tokenKeys } from '../../constants/tokens';
 import api from '.';
 import networks from '../../constants/networks';
 
-// TODO these imports are temporary until api is implemented for them
-import { send as ss } from './lsk/transactions';
-
-export const send = ss;
-
 export const getTokenFromAddress = address => (
   [networks.mainnet.code, networks.testnet.code]
     .map(code => tokenKeys.find(tokenKey => validateAddress(tokenKey, address, code) === 0))
@@ -57,5 +52,4 @@ export default {
   getSingleTransaction,
   getTokenFromAddress,
   getTransactions,
-  send,
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #2046.

### How was it solved?
- remove unused send method in transaction api util
- update some unit test scenario to work with the changes
### How was it tested?
Make sure the send process works for all tokens
