### PR TITLE
Add geolocation data attribution - Closes #2848

### DIFF
--- a/src/components/screens/monitor/network/tableHeader.js
+++ b/src/components/screens/monitor/network/tableHeader.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import styles from './network.css';
 
@@ -13,6 +14,21 @@ export default (changeSort, t) => ([
   {
     title: t('Country'),
     classList: grid['col-xs-2'],
+    tooltip: {
+      title: t('Country'),
+      message: () => (
+        <p>
+          <span>
+            Lisk Desktop determines the country names using
+            GeoLite2 data created by
+          </span>
+          &nbsp;
+          <a href="http://www.maxmind.com">Maxmind</a>
+          .
+        </p>
+      ),
+      className: 'showOnBottom',
+    },
   },
   {
     title: t('Version'),

--- a/src/components/toolbox/table/header.js
+++ b/src/components/toolbox/table/header.js
@@ -4,13 +4,18 @@ import Tooltip from '../tooltip/tooltip';
 import styles from './table.css';
 import { isReactComponent } from '../../../utils/helpers';
 
-const Tip = ({ data }) => (
-  data ? (
+const Tip = ({ data }) => {
+  if (!data || !(typeof data === 'string' || isReactComponent(data.message))) return null;
+
+  const Message = typeof data === 'string'
+    ? () => <p>{data.message}</p>
+    : data.message;
+  return (
     <Tooltip {...data}>
-      <p>{data.message}</p>
+      <Message />
     </Tooltip>
-  ) : null
-);
+  );
+};
 
 const Sort = ({
   data, currentSort, children,


### PR DESCRIPTION
### What was the problem?
This PR resolves #2848

### How was it solved?
Added a tooltip to the country header above the nodes list. The tooltip reads
> Lisk Desktop determines the country names using GeoLite2 data created by Maxmind.

<img width="410" alt="Screenshot 2020-04-15 at 14 50 14" src="https://user-images.githubusercontent.com/666685/79338973-72395200-7f28-11ea-9ae7-c6dfda329218.png">


And is linked to Maxmind website.
