### PR TITLE
Update project dependencies - Closes #2858

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14659,19 +14659,19 @@
       }
     },
     "http-server": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.1.tgz",
-      "integrity": "sha512-T0jB+7J7GJ2Vo+a4/T7P7SbQ3x2GPDnqRqQXdfEuPuUOmES/9NBxPnDm7dh1HGEeUWqUmLUNtGV63ZC5Uy3tGA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-0.12.3.tgz",
+      "integrity": "sha512-be0dKG6pni92bRjq0kvExtj/NrrAd28/8fCXkaI/4piTwQMSDSLMhWyW0NI1V+DBI3aa1HMlQu46/HjVLfmugA==",
       "dev": true,
       "requires": {
         "basic-auth": "^1.0.3",
-        "colors": "^1.3.3",
+        "colors": "^1.4.0",
         "corser": "^2.0.1",
         "ecstatic": "^3.3.2",
-        "http-proxy": "^1.17.0",
+        "http-proxy": "^1.18.0",
+        "minimist": "^1.2.5",
         "opener": "^1.5.1",
-        "optimist": "~0.6.1",
-        "portfinder": "^1.0.20",
+        "portfinder": "^1.0.25",
         "secure-compare": "3.0.1",
         "union": "~0.5.0"
       }
@@ -19514,24 +19514,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -29231,12 +29213,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "glob": "7.1.3",
     "html-webpack-inline-source-plugin": "0.0.10",
     "html-webpack-plugin": "3.2.0",
-    "http-server": "0.12.1",
+    "http-server": "0.12.3",
     "i18next-scanner": "2.9.0",
     "identity-obj-proxy": "3.0.0",
     "imports-loader": "0.8.0",


### PR DESCRIPTION
### What was the problem?
This PR resolves #2858 

### How was it solved?
Updated all dependencies. Most issues are resolved. Currently `npm audit` only shows 4 vulnerabilities, 3 low, 1 moderate:

| Issue (Criticality) | Package | Dependency of |
| ----------------- | -------- |  ---------------- |
| Prototype Pollution (Low) |  minimist |  Cyprerss |
| Prototype Pollution (Low) |  minimist |  mkdirp |
| Regular Expression (Low) | Denial of Service | braces | cpx
| Denial of Service (Moderate) | axios | @liskhq/lisk-client |

None of which are direct dependency of Lisk Desktop and these issue won't get fixed unless the direct Lisk Desktop dependencies which require them update these modules.


