### PR TITLE
Fix balance tooltip values and lables - Closes #2871

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -14,7 +14,7 @@
   "Accept": "Accept",
   "Access your account by scanning the QR code below with the Lisk Mobile App:": "Access your account by scanning the QR code below with the Lisk Mobile App:",
   "Account": "Account",
-  "Account Balance:          {{balance}} {{token}}": "Account Balance:          {{balance}} {{token}}",
+  "Account Balance": "Account Balance",
   "Account name": "Account name",
   "Account nickname": "Account nickname",
   "Accounts": "Accounts",

--- a/src/utils/balanceChart.js
+++ b/src/utils/balanceChart.js
@@ -112,11 +112,10 @@ export const graphOptions = ({
     callbacks: {
       title(tooltipItem) {
         moment.locale(locale);
-        return moment(tooltipItem[0].xLabel, 'MMMM DD YYYY h:mm:ss A')
-          .format(format);
+        return moment(tooltipItem[0].xLabel).format(i18n.t('MMM DD YYYY'));
       },
       label(tooltipItem) {
-        return i18n.t('Account Balance:          {{balance}} {{token}}', { balance: tooltipItem.yLabel, token });
+        return `${i18n.t('Account Balance')}:          ${tooltipItem.yLabel} ${token}`;
       },
     },
     mode: 'index',

--- a/src/utils/balanceChart.js
+++ b/src/utils/balanceChart.js
@@ -10,7 +10,8 @@ const formats = {
   minute: i18n.t('MMM DD YYYY hh:mm'),
   hour: i18n.t('MMM DD YYYY hh[h]'),
   day: i18n.t('MMM DD YYYY'),
-  month: i18n.t('MMM YYYY'),
+  month: i18n.t('MMM DD YYYY'),
+  quarter: i18n.t('MMM YYYY'),
   year: i18n.t('YYYY'),
 };
 
@@ -54,7 +55,6 @@ export const graphOptions = ({
       type: 'time',
       time: {
         unit: getUnitFromFormat(format),
-        displayFormats: formats,
         parser: (value) => {
           moment.locale(locale);
           return moment(value);
@@ -64,16 +64,7 @@ export const graphOptions = ({
       gridLines: {
         display: false,
       },
-      distribution: 'linear',
       ticks: {
-        callback: (value) => {
-          moment.locale(locale);
-          return moment(value, format).format('MMM YYYY');
-        },
-        fontColor: styles.slateGray,
-        fontSize: styles.fontSize,
-        fontFamily: styles.contentFontFamily,
-        maxRotation: 0,
         autoSkip: true,
         maxTicksLimit: 5,
       },
@@ -84,9 +75,6 @@ export const graphOptions = ({
       ticks: {
         display: !isDiscreetMode,
         maxTicksLimit: 5,
-        fontColor: styles.slateGray,
-        fontSize: styles.fontSize,
-        fontFamily: styles.contentFontFamily,
       },
     }],
   },
@@ -100,8 +88,8 @@ export const graphOptions = ({
   elements: {
     point: {
       radius: 2,
-      hoverRadius: 2,
-      hitRadius: 1,
+      hoverRadius: 3,
+      hitRadius: 3,
     },
     line: {
       tension: 0,
@@ -196,14 +184,8 @@ export const getBalanceData = ({
   return {
     datasets: [{
       data,
-      backgroundColor: styles.transparent,
       borderColor: styles.borderColor,
       pointBorderColor: styles.borderColor,
-      pointBackgroundColor: styles.whiteColor,
-      pointHoverBackgroundColor: styles.whiteColor,
-      pointHoverBorderColor: styles.ultramarineBlue,
-      pointHoverBorderWidth: 4,
-      borderWidth: 2,
     }],
   };
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #2871

### How was it solved?
- The tooltip only showed dates in January. We have updated the data and forgot to update the moment format parameters. I fixed it by updating the format string.
- Some xAxis labels are skipped. I fixed by removing redundant options that caused this problem.
- @sridharmeganathan Since we talked about using k and M signs for numbers in thousand and million range, this is not possible. Because most transaction values are significantly lower than account balances, such formatting would make the Y axis labels confusing. Assume an account has 7,987500 LSK, and the last 30 transaction are all under 100 LSK. If I shorten the balance to show 7.9k, then the graph looks like:

7.9k |...x.....................................................
7.9k |................x................................x......
7.9k |...........................x............x................
7.9k |_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.........Mon......Tue.......Wed.......Thu....Fri.....

As you can see the yAxis gives us nothing.

### How was it tested?
Visually by comparing several accounts.
