### PR TITLE
Fix misdrawn BTC balance graph - Closes #2877 

### DIFF
--- a/src/components/screens/wallet/transactions/transactionRow.js
+++ b/src/components/screens/wallet/transactions/transactionRow.js
@@ -48,12 +48,12 @@ const TransactionRow = ({
       <span className={grid[isLSK ? 'col-xs-2' : 'col-xs-3']}>
         {
           isConfirmed
-            ? <DateTimeFromTimestamp time={data.timestamp} token={tokenMap.LSK.key} />
+            ? <DateTimeFromTimestamp time={data.timestamp} token={activeToken} />
             : <Spinner completed={isConfirmed} label={t('Pending...')} />
         }
       </span>
       <span className={grid['col-xs-2']}>
-        <LiskAmount val={data.fee} token={tokenMap[activeToken].key} />
+        <LiskAmount val={data.fee} token={activeToken} />
       </span>
       {
         isLSK


### PR DESCRIPTION
### What was the problem?
This PR resolves #2877

### How was it solved?
The BTC API returns transactions which might not be properly chronologically sorted. I fixed the issue by sorting the transactions before preparing the balance graph data.

### How was it tested?
The utilities are covered by unit tests and I tested the graph visually.
