### PR TITLE
sort nodes on Network Monitor page by height - Closes #2880

### DIFF
--- a/src/components/screens/monitor/network/index.js
+++ b/src/components/screens/monitor/network/index.js
@@ -65,7 +65,7 @@ const ComposedNetwork = compose(
       transformResponse: response => response.data,
     },
   }),
-  withLocalSort('peers', 'height:asc', { version: sortByVersion }),
+  withLocalSort('peers', 'height:desc', { version: sortByVersion }),
   withTranslation(),
 )(Network);
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #2880

### How was it solved?
The default sort was height:asc and I changed it to height:desc.
