### PR TITLE
Fix transactions showing -0BTC for small values - Resolves #2882

### DIFF
--- a/src/components/screens/dashboard/recentTransactions/transactionList.js
+++ b/src/components/screens/dashboard/recentTransactions/transactionList.js
@@ -47,7 +47,7 @@ const TransactionList = ({
             sender={tx.senderId}
             type={tx.type}
             recipient={tx.recipientId || tx.asset.recipientId}
-            roundTo={2}
+            roundTo={4}
             amount={tx.amount || tx.asset.amount}
           />
         </Link>

--- a/src/components/screens/monitor/accounts/accountRow.js
+++ b/src/components/screens/monitor/accounts/accountRow.js
@@ -45,7 +45,7 @@ const AccountRow = ({ data, className, supply }) => (
       />
     </span>
     <span className={`${grid['col-xs-3']} ${grid['col-md-3']}`}>
-      <LiskAmount val={data.balance} roundTo={0} token={tokenMap.LSK.key} />
+      <LiskAmount val={data.balance} showInt token={tokenMap.LSK.key} />
     </span>
     <span className={`${grid['col-xs-2']} ${grid['col-md-1']}`}>
       <BalanceShare balance={data.balance} supply={supply} />

--- a/src/components/screens/wallet/transactions/transactionRow.js
+++ b/src/components/screens/wallet/transactions/transactionRow.js
@@ -68,6 +68,7 @@ const TransactionRow = ({
         <TransactionAmount
           host={host}
           token={activeToken}
+          showRounded
           sender={data.senderId}
           recipient={data.recipientId || data.asset.recipientId}
           type={data.type}

--- a/src/components/shared/liskAmount/index.js
+++ b/src/components/shared/liskAmount/index.js
@@ -2,24 +2,34 @@ import React from 'react';
 import { fromRawLsk } from '../../../utils/lsk';
 import FormattedNumber from '../formattedNumber';
 
-const roundToPlaces = (value, places) => {
-  if (!Number.isInteger(places)) {
-    return value;
-  }
-  const x = 10 ** places;
-  return Math.round(value * x) / x;
+const trimReg = /([0-9,]+\.(([0]{0,2})[1-9]{1,2})?)|-?(0\.([0]+)?[1-9]{1,2})/g;
+const IntegerReg = /\.([0-9]+)/g;
+
+const trim = (value) => {
+  const matched = value.match(trimReg);
+  const normalizedVal = matched && matched[0] !== '0.'
+    ? matched[0].replace(/\.$/, '')
+    : value;
+
+  return normalizedVal;
 };
 
-const LiskAmount = ({ val, roundTo, token }) => (
-  val !== undefined
-    ? (
-      <React.Fragment>
-        <FormattedNumber val={roundToPlaces(parseFloat(fromRawLsk(val)), roundTo)} />
-        {token && ` ${token}`}
-      </React.Fragment>
-    )
-    : <span />
-);
+const getInt = value => value.replace(IntegerReg, '');
+
+const LiskAmount = ({
+  val, showRounded, showInt, token,
+}) => {
+  if (val === undefined) return (<span />);
+  let value = fromRawLsk(val);
+  if (showInt) value = getInt(value);
+  else if (showRounded) value = trim(value);
+  return (
+    <React.Fragment>
+      <FormattedNumber val={value} />
+      {token && ` ${token}`}
+    </React.Fragment>
+  );
+};
 
 LiskAmount.defaultProps = {
   token: '',

--- a/src/components/shared/liskAmount/index.test.js
+++ b/src/components/shared/liskAmount/index.test.js
@@ -15,7 +15,7 @@ describe('LiskAmount', () => {
   it('should round to props.roundTo decimal places', () => {
     const inputValue = '12932689.64321' * normalizeNumber;
     const expectedValue = '12,932,689.64';
-    const wrapper = mount(<LiskAmount val={inputValue} roundTo={2} />);
+    const wrapper = mount(<LiskAmount val={inputValue} showRounded />);
     expect(wrapper.text()).to.be.equal(expectedValue);
   });
 });

--- a/src/components/shared/transactionAmount/index.js
+++ b/src/components/shared/transactionAmount/index.js
@@ -6,7 +6,7 @@ import styles from './transactionAmount.css';
 import transactionTypes from '../../../constants/transactionTypes';
 
 const TransactionAmount = ({
-  sender, recipient, type, token, roundTo, host, amount,
+  sender, recipient, type, token, showRounded, showInt, host, amount,
 }) => {
   const isIncoming = host === recipient && sender !== recipient;
   return (
@@ -16,7 +16,12 @@ const TransactionAmount = ({
           <DiscreetMode shouldEvaluateForOtherAccounts>
             <span className={isIncoming ? styles.receive : ''}>
               {isIncoming ? '' : '- '}
-              <LiskAmount val={amount} roundTo={roundTo} token={token} />
+              <LiskAmount
+                val={amount}
+                showRounded={showRounded}
+                showInt={showInt}
+                token={token}
+              />
             </span>
           </DiscreetMode>
         )

--- a/src/components/shared/transactionAmount/index.js
+++ b/src/components/shared/transactionAmount/index.js
@@ -38,11 +38,8 @@ TransactionAmount.propTypes = {
   token: PropTypes.string.isRequired,
   type: PropTypes.number.isRequired,
   amount: PropTypes.string,
-  roundTo: PropTypes.number,
-};
-
-TransactionAmount.defaultProps = {
-  roundTo: 8,
+  showInt: PropTypes.bool,
+  showRounded: PropTypes.bool,
 };
 
 export default TransactionAmount;

--- a/src/components/shared/voteWeight/index.js
+++ b/src/components/shared/voteWeight/index.js
@@ -13,8 +13,8 @@ const VoteWeight = ({ data }) => {
     <strong>
       <LiskAmount
         val={apiVersion === '2' ? data.vote : data.voteWeight}
-        roundTo={0}
         token={tokenMap.LSK.key}
+        showInt
       />
     </strong>
   );

--- a/src/components/shared/votes/voteRow.js
+++ b/src/components/shared/votes/voteRow.js
@@ -45,7 +45,11 @@ const VoteRow = ({
     </div>
     <div className={`${grid['col-sm-4']} ${grid['col-lg-2']}`}>
       <span className={styles.votes}>
-        <LiskAmount val={data.vote || data.voteWeight} token="LSK" roundTo={0} />
+        <LiskAmount
+          val={data.vote || data.voteWeight}
+          token="LSK"
+          showInt
+        />
       </span>
     </div>
   </div>


### PR DESCRIPTION
### What was the problem?
This PR resolves #2882

### How was it solved?
- Accepts `showInt` and `showRounded` parameters.
- If `showInt` passed, it shows only the integer value.
- If `showRounded` passed:
  - if the value is over 100, it shows only two digits if the floating part is not zero.
  - If the value is under 100, it displays at least one non-zero digit after the floating-point.

### How was it tested?
Visually and unit test
