### PR TITLE
Fix the total forged value on Delegates Monitor - Closes #2884

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -461,6 +461,7 @@
   "This avatar will then be linked to your new Lisk address": "This avatar will then be linked to your new Lisk address",
   "This feature can be accessed through Mainet and Testnet.": "This feature can be accessed through Mainet and Testnet.",
   "This helps to keep the network fair, open and honest.": "This helps to keep the network fair, open and honest.",
+  "This is an estimated value.": "This is an estimated value.",
   "This is not a valid public key. Please enter the correct public key.": "This is not a valid public key. Please enter the correct public key.",
   "Time until next forging slot of a delegate.": "Time until next forging slot of a delegate.",
   "Timeout soon": "Timeout soon",

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -31,6 +31,7 @@ const DelegatesMonitor = ({
   const [activeTab, setActiveTab] = useState('active');
   const dispatch = useDispatch();
   const forgingTimes = useSelector(state => state.blocks.forgingTimes);
+  const network = useSelector(state => state.network);
 
   const handleFilter = ({ target: { value } }) => {
     applyFilters({
@@ -75,7 +76,11 @@ const DelegatesMonitor = ({
         chartRegisteredDelegates={chartRegisteredDelegatesData}
         t={t}
       />
-      <ForgingDetails t={t} networkStatus={networkStatus} />
+      <ForgingDetails
+        t={t}
+        networkStatus={networkStatus}
+        network={network}
+      />
       <Box main isLoading={delegates.isLoading || standByDelegates.isLoading || votes.isLoading}>
         <BoxHeader className="delegates-table">
           {tabs.tabs.length === 1

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -19,6 +19,7 @@ const DelegatesMonitor = ({
   chartActiveAndStandbyData,
   chartRegisteredDelegatesData,
   standByDelegates,
+  networkStatus,
   applyFilters,
   changeSort,
   delegates,
@@ -74,7 +75,7 @@ const DelegatesMonitor = ({
         chartRegisteredDelegates={chartRegisteredDelegatesData}
         t={t}
       />
-      <ForgingDetails t={t} />
+      <ForgingDetails t={t} networkStatus={networkStatus} />
       <Box main isLoading={delegates.isLoading || standByDelegates.isLoading || votes.isLoading}>
         <BoxHeader className="delegates-table">
           {tabs.tabs.length === 1

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -86,6 +86,11 @@ describe('Delegates monitor page', () => {
         tab: 'active',
       },
       applyFilters: jest.fn(filters => wrapper.setProps({ filters })),
+      networkStatus: {
+        data: {
+          supply: 13963011200000000,
+        },
+      },
     };
   });
 

--- a/src/components/screens/monitor/delegates/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/forgingDetails.js
@@ -7,6 +7,7 @@ import routes from '../../../../constants/routes';
 import Box from '../../../toolbox/box';
 import BoxHeader from '../../../toolbox/box/header';
 import styles from './overview.css';
+import LiskAmount from '../../../shared/liskAmount';
 
 const Forger = ({ forger }) => (
   <div className={`${styles.forger} forger-item`}>
@@ -22,8 +23,11 @@ const Forger = ({ forger }) => (
 );
 
 const ForgingDetails = ({
-  t,
+  t, networkStatus,
 }) => {
+  const initialSupply = 10000000000000000;
+  const supply = networkStatus.data.supply;
+  const totalForged = supply - initialSupply;
   const awaitingForgers = useSelector(state => state.blocks.awaitingForgers);
   const latestBlocks = useSelector(state => state.blocks.latestBlocks);
   const lastForger = awaitingForgers
@@ -53,7 +57,9 @@ const ForgingDetails = ({
         <div className={styles.column}>
           <h2 className={styles.title}>{t('Total forged')}</h2>
           <div className={styles.list}>
-            <span className={styles.totalForged}>31,122,324</span>
+            <span className={styles.totalForged}>
+              <LiskAmount token="LSK" val={totalForged} />
+            </span>
           </div>
         </div>
         <div className={`${styles.column} ${styles.nextForgers}`}>

--- a/src/components/screens/monitor/delegates/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/forgingDetails.js
@@ -28,7 +28,8 @@ const ForgingDetails = ({
   t, networkStatus, network,
 }) => {
   const supply = networkStatus.data.supply;
-  const totalForged = supply - networks[network.name.toLowerCase()].initialSupply;
+  const { initialSupply } = Object.values(networks).find(item => (item.name === network.name));
+  const totalForged = supply - initialSupply;
   const awaitingForgers = useSelector(state => state.blocks.awaitingForgers);
   const latestBlocks = useSelector(state => state.blocks.latestBlocks);
   const lastForger = awaitingForgers

--- a/src/components/screens/monitor/delegates/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/forgingDetails.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import AccountVisual from '../../../toolbox/accountVisual';
+import Tooltip from '../../../toolbox/tooltip/tooltip';
 import routes from '../../../../constants/routes';
 import Box from '../../../toolbox/box';
 import BoxHeader from '../../../toolbox/box/header';
@@ -55,7 +56,12 @@ const ForgingDetails = ({
           </nav>
         </div>
         <div className={styles.column}>
-          <h2 className={styles.title}>{t('Total forged')}</h2>
+          <h2 className={styles.title}>
+            <span>{t('Total forged')}</span>
+            <Tooltip className={`${styles.tooltip} showOnBottom`}>
+              <span>{t('This is an estimated value.')}</span>
+            </Tooltip>
+          </h2>
           <div className={styles.list}>
             <span className={styles.totalForged}>
               <LiskAmount token="LSK" val={totalForged} />

--- a/src/components/screens/monitor/delegates/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/forgingDetails.js
@@ -9,6 +9,7 @@ import Box from '../../../toolbox/box';
 import BoxHeader from '../../../toolbox/box/header';
 import styles from './overview.css';
 import LiskAmount from '../../../shared/liskAmount';
+import networks from '../../../../constants/networks';
 
 const Forger = ({ forger }) => (
   <div className={`${styles.forger} forger-item`}>
@@ -24,11 +25,10 @@ const Forger = ({ forger }) => (
 );
 
 const ForgingDetails = ({
-  t, networkStatus,
+  t, networkStatus, network,
 }) => {
-  const initialSupply = 10000000000000000;
   const supply = networkStatus.data.supply;
-  const totalForged = supply - initialSupply;
+  const totalForged = supply - networks[network.name.toLowerCase()].initialSupply;
   const awaitingForgers = useSelector(state => state.blocks.awaitingForgers);
   const latestBlocks = useSelector(state => state.blocks.latestBlocks);
   const lastForger = awaitingForgers

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -88,6 +88,13 @@ const ComposedDelegates = compose(
         defaultData: [],
         transformResponse: transformVotesResponse,
       },
+
+      networkStatus: {
+        apiUtil: liskService.getNetworkStatus,
+        defaultData: {},
+        autoload: true,
+        transformResponse: response => response,
+      },
     },
   ),
   withResizeValues,

--- a/src/components/screens/monitor/delegates/overview.css
+++ b/src/components/screens/monitor/delegates/overview.css
@@ -63,6 +63,12 @@
   color: var(--color-maastricht-blue);
   padding-top: 30px;
   box-sizing: border-box;
+
+  & > span,
+  & .tooltip {
+    vertical-align: middle;
+    line-height: 1em;
+  }
 }
 
 .list {

--- a/src/components/screens/monitor/delegates/overview.css
+++ b/src/components/screens/monitor/delegates/overview.css
@@ -67,7 +67,7 @@
   & > span,
   & .tooltip {
     vertical-align: middle;
-    line-height: 1em;
+    line-height: 1em; /* stylelint-disable-line unit-whitelist */
   }
 }
 

--- a/src/constants/networks.js
+++ b/src/constants/networks.js
@@ -20,12 +20,14 @@ const networks = {
       'https://hub37.lisk.io',
       'https://hub38.lisk.io',
     ],
+    initialSupply: 10000000000000000,
   },
   testnet: { // network name translation t('Testnet');
     name: 'Testnet',
     testnet: true,
     code: 1,
     nodes: ['https://testnet.lisk.io'],
+    initialSupply: 10000000000000000,
   },
   customNode: { // network name translation t('Custom Node');
     name: 'Custom Node',

--- a/src/constants/networks.js
+++ b/src/constants/networks.js
@@ -34,6 +34,7 @@ const networks = {
     custom: true,
     address: 'http://localhost:4000',
     code: 2,
+    initialSupply: 10000000000000000,
   },
 };
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #2884

### How was it solved?
I take the initial supply a constant equal to 100M LSK
and fetch the total supply from the Lisk Service `network/status` endpoint.
the total forged is displayed as `total supply` minus `initial supply`.

