### PR TITLE
Trezor passphrase quick fix

### DIFF
--- a/libs/hwManager/constants.js
+++ b/libs/hwManager/constants.js
@@ -4,6 +4,7 @@ export const REMOVE_DEVICE = 'remove';
 export const RESPONSE = 'result';
 export const REQUEST = 'request';
 export const PIN = 'pin';
+export const PASSPHRASE = 'passphrase';
 export const IPC_MESSAGES = {
   CHECK_LEDGER: 'checkLedger',
   CONNECT: 'connect',

--- a/libs/hwManager/index.js
+++ b/libs/hwManager/index.js
@@ -139,6 +139,16 @@ class HwManager {
     });
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  passphraseCallback(callback) {
+    callback(null, '' /* User passphrase here! */);
+    /** TODO this is a quick workaround.
+     * as pinCallback, this procedure needs to take the passphrase from the user
+     * in order to unlock secret wallets (principle of plausible deniability).
+     * More info: https://wiki.trezor.io/Passphrase
+     */
+  }
+
   /**
    * Start listeners set by setTransport
    */
@@ -148,6 +158,7 @@ class HwManager {
         add: data => this.addDevice(data),
         remove: data => this.removeDevice(data),
         pinCallback: (type, callback) => this.pinCallback(type, callback),
+        passphraseCallback: callback => this.passphraseCallback(callback),
       });
     });
   }

--- a/libs/hwManager/manufacturers/trezor/index.js
+++ b/libs/hwManager/manufacturers/trezor/index.js
@@ -2,6 +2,7 @@
 import {
   IPC_MESSAGES,
   PIN,
+  PASSPHRASE,
 } from '../../constants';
 import { TREZOR } from './constants';
 import {
@@ -40,6 +41,10 @@ const onPinCallback = (device, { pinCallback }) => {
   device.on(PIN, (type, callback) => pinCallback(type, callback));
 };
 
+const onPassphraseCallback = (device, { passphraseCallback }) => {
+  device.on(PASSPHRASE, callback => passphraseCallback(callback));
+};
+
 /**
  * listener - function - Always listen for new messages for connect or disconnect devices.
  * @param {object} transport - Library use for handle the trezor devices.
@@ -51,6 +56,7 @@ const listener = (transport, actions) => {
   transport.on(IPC_MESSAGES.CONNECT, (device) => {
     addDevice(device, actions);
     onPinCallback(device, actions);
+    onPassphraseCallback(device, actions);
   });
   transport.on(IPC_MESSAGES.DISCONNECT, (device) => { removeDevice(device, actions); });
   transport.on(IPC_MESSAGES.ERROR, (error) => { throw new Error(error); });


### PR DESCRIPTION
### What was the problem?
This PR is a quick workaround for #2864 and #2860

### How was it solved?
Listening on `passphrase` event and call the callback with an empty password. This implements Trezor connectivity as it was before and it will unlock users funds. 

In order to correctly implement this, the wallet should collect the passphrase from the user (like you already do with the PIN for Trezor One) in order to unlock secret wallets and allow the principle of plausible deniability.
More info: https://wiki.trezor.io/Passphrase

### How was it tested?
No tests. I will let you have the honor :)
