### PR TITLE
Fix address overflow - Closes #2954

### DIFF
--- a/src/components/screens/login/login.css
+++ b/src/components/screens/login/login.css
@@ -104,9 +104,11 @@
   max-width: 665px;
   width: 100%;
   border: none;
+  text-align: left;
 
   & > label {
     margin-bottom: 7px;
+    color: var(--color-maastricht-blue);
   }
 }
 

--- a/src/components/screens/login/networkSelector/networkSelector.js
+++ b/src/components/screens/login/networkSelector/networkSelector.js
@@ -284,5 +284,4 @@ class NetworkSelector extends React.Component {
 }
 
 NetworkSelector.displayName = 'NetworkSelector';
-NetworkSelector.whyDidYouRender = true;
 export default withTranslation()(withRouter(NetworkSelector));

--- a/src/components/screens/wallet/overview/accountInfo/accountInfo.css
+++ b/src/components/screens/wallet/overview/accountInfo/accountInfo.css
@@ -24,6 +24,8 @@
   & .info {
     display: flex;
     flex-flow: row nowrap;
+    position: relative;
+    z-index: 1;
 
     & .text {
       position: relative;

--- a/src/components/screens/wallet/overview/accountInfo/accountInfo.css
+++ b/src/components/screens/wallet/overview/accountInfo/accountInfo.css
@@ -3,6 +3,7 @@
 .wrapper {
   & .content {
     height: 200px;
+    position: relative;
 
     &.LSK {
       background-color: var(--color-ultramarine-blue);
@@ -36,6 +37,7 @@
       & .primary {
         @mixin headingNormalIntermediate normal;
 
+        font-size: 22px;
         display: block;
       }
 
@@ -43,20 +45,12 @@
         @mixin contentLargest normal;
 
         opacity: 0.7;
+        display: inline-block;
       }
 
-      & .addressTooltip {
-        font-size: 20px;
-        white-space: nowrap;
-      }
-
-      & .addressWrapper {
-        width: auto;
-        max-width: fit-content;
-      }
-
-      & .address {
-        padding: 10px;
+      & .noSelect {
+        cursor: pointer;
+        user-select: none;
       }
     }
   }
@@ -64,8 +58,12 @@
   & footer {
     display: flex;
     flex-flow: row nowrap;
-    padding: 30px 0 0;
+    padding: 0 0 var(--horizontal-padding-l) 0;
     justify-content: center;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
 
     & .helperIcon {
       width: 40px;

--- a/src/components/screens/wallet/overview/accountInfo/identity.js
+++ b/src/components/screens/wallet/overview/accountInfo/identity.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import styles from './accountInfo.css';
+
+/**
+ *
+ * Displays address and username
+ * The address is initially truncated but
+ * but toggles expanded on user click
+ *
+ */
+const Identity = ({ address, delegate, bookmark }) => {
+  if (!address) return null;
+  const username = (delegate && delegate.username) || '';
+  const truncatedAddress = address.length > 12
+    ? `${address.slice(0, 10)}...${address.slice(-3)}` : address;
+
+  const [modAddress, setModAddress] = useState(truncatedAddress);
+  const onClick = () => setModAddress(modAddress === address ? truncatedAddress : address);
+
+  return (
+    <div className={styles.text}>
+      {
+        username || !!bookmark
+          ? (
+            <>
+              <span className={`${styles.primary} account-primary`}>
+                {username || bookmark.title}
+              </span>
+              <span
+                className={`${styles.secondary} ${styles.noSelect} delegate-secondary`}
+                onClick={onClick}
+              >
+                {modAddress}
+              </span>
+            </>
+          )
+          : (
+            <span
+              className={`${styles.primary} ${styles.noSelect} account-primary`}
+              onClick={onClick}
+            >
+              {modAddress}
+            </span>
+          )
+      }
+    </div>
+  );
+};
+
+/* istanbul ignore next */
+const areEqual = (prevProps, nextProps) => (prevProps.address === nextProps.address);
+
+export default React.memo(Identity, areEqual);

--- a/src/components/screens/wallet/overview/accountInfo/index.js
+++ b/src/components/screens/wallet/overview/accountInfo/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import QRCode from 'qrcode.react';
 import AccountVisual from '../../../../toolbox/accountVisual';
 import Box from '../../../../toolbox/box';
@@ -9,120 +9,86 @@ import { getAddress } from '../../../../../utils/hwManager';
 import styles from './accountInfo.css';
 import Tooltip from '../../../../toolbox/tooltip/tooltip';
 import DialogLink from '../../../../toolbox/dialog/link';
+import Identity from './identity';
 
-const BookmarkIcon = ({ isBookmark }) => (
+const BookmarkIcon = ({ bookmark }) => (
   <Icon
-    name={isBookmark ? 'bookmarkActive' : 'bookmark'}
+    name={bookmark === undefined ? 'bookmark' : 'bookmarkActive'}
     className={styles.bookmark}
   />
 );
 
 /* eslint-disable complexity */
 const AccountInfo = ({
-  address, t, activeToken, hwInfo, delegate, isBookmark,
-}) => {
-  const truncatedAddress = useMemo(
-    () =>
-      `${address.slice(0, 10)}...${address.slice(-3)}`,
-    [address],
-  );
-  const primaryValue = delegate && delegate.username ? delegate.username : truncatedAddress;
-  const secondaryValue = delegate && delegate.username ? truncatedAddress : '';
-  const primaryValueTypeShown = delegate && delegate.username ? 'username' : 'address';
-
-  return (
-    <Box className={styles.wrapper}>
-      <BoxContent className={`${styles.content} ${styles[activeToken]}`}>
-        <h2 className={styles.title}>{t('Wallet address')}</h2>
-        <div className={styles.info}>
-          <AccountVisual
-            address={address}
-            size={40}
-          />
-          <div className={styles.text}>
-            <Tooltip
-              tooltipClassName={styles.addressWrapper}
-              className={`${styles.address} showOnRight`}
-              content={<span className={`${styles.primary} account-primary`}>{primaryValue}</span>}
-            >
-              <span className={`${styles.primary} ${styles.addressTooltip}`}>{address}</span>
-            </Tooltip>
-
-            {
-              secondaryValue
-                && (
-                <>
-                  {
-                    primaryValueTypeShown === 'address' ? (
-                      <Tooltip
-                        tooltipClassName={styles.addressWrapper}
-                        className={`${styles.address} showOnRight`}
-                        content={<span className={`${styles.secondary} delegate-secondary`}>{secondaryValue}</span>}
-                      >
-                        <span className={`${styles.primary} ${styles.addressTooltip}`}>{address}</span>
-                      </Tooltip>
-                    )
-                      : <span className={`${styles.secondary} delegate-secondary`}>{secondaryValue}</span>
-                  }
-                </>
-                )
-            }
-          </div>
-        </div>
-        <footer>
-          <div className={styles.helperIcon}>
-            <CopyToClipboard
-              value={address}
-              type="icon"
-              copyClassName={styles.copyIcon}
-              className={styles.copyIcon}
-            />
-          </div>
-          <div className={styles.helperIcon}>
-            <Tooltip
-              tooltipClassName={styles.qrCodeWrapper}
-              className={`${styles.qrCode} showOnBottom`}
-              title={t('Scan address')}
-              content={<Icon name="qrCodeActive" className={styles.qrCodeIcon} />}
-            >
-              <QRCode value={address} size={154} />
-            </Tooltip>
-          </div>
-          <div className={styles.helperIcon}>
-            <DialogLink component="bookmarks">
-              <BookmarkIcon isBookmark={isBookmark} />
-            </DialogLink>
-          </div>
-          {
-            hwInfo
-              ? (
-                <div
-                  className={`${styles.helperIcon} verify-address`}
-                  onClick={() => getAddress({
-                    deviceId: hwInfo.deviceId,
-                    index: hwInfo.derivationIndex,
-                    showOnDevice: true,
-                  })}
-                >
-                  <Tooltip
-                    className={`${styles.verify} showOnBottom`}
-                    title={t('Verify address')}
-                    content={<Icon name="verifyWalletAddressActive" className={styles.qrCodeIcon} />}
-                  >
-                    <span>{t('Verify the address in your hardware wallet device.')}</span>
-                  </Tooltip>
-                </div>
-              )
-              : null
-          }
-        </footer>
-        <Icon
-          name={activeToken === 'LSK' ? 'liskLogo' : 'bitcoinLogo'}
-          className={styles.watermarkLogo}
+  address, t, activeToken, hwInfo, delegate, bookmark,
+}) => (
+  <Box className={styles.wrapper}>
+    <BoxContent className={`${styles.content} ${styles[activeToken]}`}>
+      <h2 className={styles.title}>{t('Wallet address')}</h2>
+      <div className={styles.info}>
+        <AccountVisual
+          address={address}
+          size={40}
         />
-      </BoxContent>
-    </Box>
-  );
-};
+        <Identity
+          address={address}
+          delegate={delegate}
+          bookmark={bookmark}
+        />
+      </div>
+      <footer>
+        <div className={styles.helperIcon}>
+          <CopyToClipboard
+            value={address}
+            type="icon"
+            copyClassName={styles.copyIcon}
+            className={styles.copyIcon}
+          />
+        </div>
+        <div className={styles.helperIcon}>
+          <Tooltip
+            tooltipClassName={styles.qrCodeWrapper}
+            className={`${styles.qrCode} showOnBottom`}
+            title={t('Scan address')}
+            content={<Icon name="qrCodeActive" className={styles.qrCodeIcon} />}
+          >
+            <QRCode value={address} size={154} />
+          </Tooltip>
+        </div>
+        <div className={styles.helperIcon}>
+          <DialogLink component="bookmarks">
+            <BookmarkIcon bookmark={bookmark} />
+          </DialogLink>
+        </div>
+        {
+          hwInfo
+            ? (
+              <div
+                className={`${styles.helperIcon} verify-address`}
+                onClick={() => getAddress({
+                  deviceId: hwInfo.deviceId,
+                  index: hwInfo.derivationIndex,
+                  showOnDevice: true,
+                })}
+              >
+                <Tooltip
+                  className={`${styles.verify} showOnBottom`}
+                  title={t('Verify address')}
+                  content={<Icon name="verifyWalletAddressActive" className={styles.qrCodeIcon} />}
+                >
+                  <span>{t('Verify the address in your hardware wallet device.')}</span>
+                </Tooltip>
+              </div>
+            )
+            : null
+        }
+      </footer>
+      <Icon
+        name={activeToken === 'LSK' ? 'liskLogo' : 'bitcoinLogo'}
+        className={styles.watermarkLogo}
+      />
+    </BoxContent>
+  </Box>
+);
 
 export default AccountInfo;

--- a/src/components/screens/wallet/overview/index.js
+++ b/src/components/screens/wallet/overview/index.js
@@ -4,7 +4,6 @@ import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import BalanceChart from './balanceChart';
 import AccountInfo from './accountInfo';
 import BalanceInfo from './balanceInfo';
-import { getIndexOfBookmark } from '../../../../utils/bookmarks';
 import { isEmpty } from '../../../../utils/helpers';
 import styles from './overview.css';
 
@@ -24,10 +23,9 @@ const Overview = ({
   const publicKey = getProp(account, 'publicKey', '');
   const hwInfo = getProp(account, 'hwInfo', false);
   const balance = getProp(account, 'balance', 0);
-  const bookmarks = useSelector(state => state.bookmarks);
-  const isBookmark = getIndexOfBookmark(bookmarks, {
-    address, token: activeToken,
-  }) !== -1;
+  const bookmark = useSelector(
+    state => state.bookmarks[activeToken].find(item => (item.address === address)),
+  );
 
   return (
     <section className={`${grid.row} ${styles.wrapper}`}>
@@ -38,7 +36,7 @@ const Overview = ({
           activeToken={activeToken}
           address={address}
           delegate={delegate}
-          isBookmark={isBookmark}
+          bookmark={bookmark}
           publicKey={publicKey}
         />
       </div>


### PR DESCRIPTION
### What was the problem?
This PR resolves #2954

### How was it solved?
- Created a component to display only the text content of the address, username and bookmark title. 
- The address is initially truncated.
- Users can click to switch to full or truncated address.

Additionally
- Removed `whyDidYouRender` from SignIn.
- Fixed the alignment of signIn titles

### How was it tested?
Visually
