### PR TITLE
Fix App restart after update has been installed - Closes #2991

### DIFF
--- a/app/src/modules/autoUpdater.js
+++ b/app/src/modules/autoUpdater.js
@@ -73,7 +73,8 @@ export default ({ // eslint-disable-line max-statements
       title: i18n.t('Update download finished'),
       buttons: [i18n.t('Restart now'), i18n.t('Later')],
       message: i18n.t('Updates downloaded, application has to be restarted to apply the updates.'),
-    }, (buttonIndex) => {
+    }).then((result) => {
+      const buttonIndex = result.response;
       if (buttonIndex === 0) {
         autoUpdater.quitAndInstall();
       }

--- a/app/src/modules/autoUpdater.test.js
+++ b/app/src/modules/autoUpdater.test.js
@@ -48,20 +48,25 @@ describe('autoUpdater', () => {
   };
 
   beforeEach(() => {
-    callbacks = {};
+    const quitAndInstall = spy();
+    callbacks = {
+      clickDialogButton: (buttonIndex) => {
+        if (buttonIndex === 0) {
+          quitAndInstall();
+        }
+      },
+    };
     params = {
       autoUpdater: {
         checkForUpdates: spy(),
         on: (name, callback) => {
           callbacks[name] = callback;
         },
-        quitAndInstall: spy(),
+        quitAndInstall,
         downloadUpdate: spy(),
       },
       dialog: {
-        showMessageBox: (options, callback) => {
-          callbacks.dialog = callback;
-        },
+        showMessageBox: () => new Promise(resolve => resolve()),
         showErrorBox: spy(),
       },
       win: {
@@ -140,7 +145,7 @@ describe('autoUpdater', () => {
   it('should install update once downloaded and "Restart now" button pressed', () => {
     autoUpdater(params);
     callbacks['update-downloaded']({ version });
-    callbacks.dialog(0);
+    callbacks.clickDialogButton(0);
 
     expect(params.autoUpdater.quitAndInstall).to.have.been.calledWithExactly();
   });
@@ -148,7 +153,7 @@ describe('autoUpdater', () => {
   it('should not install update when "Later" was pressed', () => {
     autoUpdater(params);
     callbacks['update-downloaded']({ releaseNotes, version });
-    callbacks.dialog(1);
+    callbacks.clickDialogButton(1);
 
     expect(params.autoUpdater.quitAndInstall).to.not.have.been.calledWith();
   });


### PR DESCRIPTION
### What was the problem?
This PR resolves #2991 

### How was it solved?
By using the correct function call for the `updates-downloaded` listener in autoUpdater module. 

### How was it tested?
Manually
