### PR TITLE
Jenkinsfile: parameterize core image version - Closes #3021

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,11 +119,11 @@ services:
 EOF
 
 										ENV_LISK_VERSION="$LISK_CORE_IMAGE_VERSION" make coldstart
-										export CYPRESS_baseUrl=http://127.0.0.1:300$N/#/
+										export CYPRESS_baseUrl=http://127.0.0.1:565$N/#/
 										export CYPRESS_coreUrl=http://127.0.0.1:$( docker-compose port lisk 4000 |cut -d ":" -f 2 )
 										cd -
 
-										npm run serve -- $WORKSPACE/app/build -p 300$N -a 127.0.0.1 &>server.log &
+										npm run serve -- $WORKSPACE/app/build -p 565$N -a 127.0.0.1 &>server.log &
 										set +e
 										set -o pipefail
 										npm run cypress:run |tee cypress.log

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build-prod": "webpack --config ./config/webpack.config.prod",
     "build-electron": "webpack --config ./config/webpack.config.electron --mode production",
     "cypress:open": "cypress open --project test/cypress",
-    "cypress:run": "cypress run --project test/cypress",
+    "cypress:run": "cypress run --project test/cypress -b chrome",
     "test": "jest --config ./jest.config.js",
     "test-live": "npm test -- --watch",
     "analyze-bundles": "webpack  --config ./config/webpack.config.analyze",


### PR DESCRIPTION
### What was the problem?
The `Jenkinsfile` would always use a set version of lisk-core.

### How was it solved?
Make the lisk-core (image) versions parameters.

### How was it tested?
https://jenkins.lisk.io/job/lisk-desktop/job/jenkinsfile-parameterize-core-image-version/