### PR TITLE
Display other accounts balance chart when discreet mode is on - Closes #2987

### DIFF
--- a/src/components/screens/wallet/overview/index.js
+++ b/src/components/screens/wallet/overview/index.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { withRouter } from 'react-router';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import BalanceChart from './balanceChart';
 import AccountInfo from './accountInfo';
 import BalanceInfo from './balanceInfo';
 import { isEmpty } from '../../../../utils/helpers';
 import styles from './overview.css';
-import routes from '../../../../constants/routes';
 
 const getProp = (dic, prop, defaultValue) => {
   if (!dic || isEmpty(dic)) {
@@ -19,7 +17,6 @@ const getProp = (dic, prop, defaultValue) => {
 const Overview = ({
   t, activeToken, transactions, hwInfo,
   discreetMode, isWalletRoute, account,
-  history,
 }) => {
   const address = getProp(account, 'address', '');
   const delegate = getProp(account, 'delegate', {});
@@ -34,7 +31,9 @@ const Overview = ({
       && state.account.info[activeToken]
       && state.account.info[activeToken].address) || '',
   );
-  
+
+  console.log(host, address, host === address);
+
   return (
     <section className={`${grid.row} ${styles.wrapper}`}>
       <div className={`${grid['col-xs-6']} ${grid['col-md-4']} ${grid['col-lg-3']}`}>
@@ -64,7 +63,7 @@ const Overview = ({
           t={t}
           transactions={transactions}
           token={activeToken}
-          isDiscreetMode={discreetMode && history.location.pathname === routes.wallet.path}
+          isDiscreetMode={discreetMode && host === address}
           balance={balance}
           address={address}
         />
@@ -73,4 +72,4 @@ const Overview = ({
   );
 };
 
-export default withRouter(Overview);
+export default Overview;

--- a/src/components/screens/wallet/overview/index.js
+++ b/src/components/screens/wallet/overview/index.js
@@ -32,8 +32,6 @@ const Overview = ({
       && state.account.info[activeToken].address) || '',
   );
 
-  console.log(host, address, host === address);
-
   return (
     <section className={`${grid.row} ${styles.wrapper}`}>
       <div className={`${grid['col-xs-6']} ${grid['col-md-4']} ${grid['col-lg-3']}`}>

--- a/src/components/screens/wallet/overview/index.js
+++ b/src/components/screens/wallet/overview/index.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { withRouter } from 'react-router';
 import grid from 'flexboxgrid/dist/flexboxgrid.css';
 import BalanceChart from './balanceChart';
 import AccountInfo from './accountInfo';
 import BalanceInfo from './balanceInfo';
 import { isEmpty } from '../../../../utils/helpers';
 import styles from './overview.css';
+import routes from '../../../../constants/routes';
 
 const getProp = (dic, prop, defaultValue) => {
   if (!dic || isEmpty(dic)) {
@@ -17,6 +19,7 @@ const getProp = (dic, prop, defaultValue) => {
 const Overview = ({
   t, activeToken, transactions, hwInfo,
   discreetMode, isWalletRoute, account,
+  history,
 }) => {
   const address = getProp(account, 'address', '');
   const delegate = getProp(account, 'delegate', {});
@@ -31,7 +34,7 @@ const Overview = ({
       && state.account.info[activeToken]
       && state.account.info[activeToken].address) || '',
   );
-
+  
   return (
     <section className={`${grid.row} ${styles.wrapper}`}>
       <div className={`${grid['col-xs-6']} ${grid['col-md-4']} ${grid['col-lg-3']}`}>
@@ -61,7 +64,7 @@ const Overview = ({
           t={t}
           transactions={transactions}
           token={activeToken}
-          isDiscreetMode={discreetMode}
+          isDiscreetMode={discreetMode && history.location.pathname === routes.wallet.path}
           balance={balance}
           address={address}
         />
@@ -70,4 +73,4 @@ const Overview = ({
   );
 };
 
-export default Overview;
+export default withRouter(Overview);

--- a/src/components/shared/discreetMode/discreetMode.js
+++ b/src/components/shared/discreetMode/discreetMode.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import routes from '../../../constants/routes';
 import styles from './discreetMode.css';
 import { getTokenFromAddress } from '../../../utils/api/transactions';
+import { selectSearchParamValue } from '../../../utils/searchParams';
 
 class DiscreetMode extends Component {
   handleBlurOnOtherWalletPage() {
-    const { account, location } = this.props;
-    const address = location.pathname.split('/').pop();
+    const { account, location: { search } } = this.props;
+    const address = selectSearchParamValue(search, routes.account.searchParam);
     const token = getTokenFromAddress(address);
     return account.info && address === account.info[token].address;
   }

--- a/src/components/shared/discreetMode/discreetMode.test.js
+++ b/src/components/shared/discreetMode/discreetMode.test.js
@@ -47,7 +47,8 @@ describe('DiscreetMode Component', () => {
     const newProps = {
       ...props,
       location: {
-        pathname: '/explorer/accounts/34234234L',
+        pathname: '/account',
+        search: '?address=34234234L',
       },
       shouldEvaluateForOtherAccounts: true,
     };


### PR DESCRIPTION
### What was the problem?
This PR resolves #2987

### How was it solved?
Wallet overview was passing discreet mode to balance chart indistinctly of which account it was displaying.
I added a condition that just makes that prop true when the host address and the request address are the same.

### How was it tested?
Manual test
