### PR TITLE
Fix settings save issue - Closes #2949

### DIFF
--- a/src/utils/bookmarks.js
+++ b/src/utils/bookmarks.js
@@ -2,15 +2,21 @@ import { tokenKeys, tokenMap } from '../constants/tokens';
 
 export const emptyBookmarks = tokenKeys.reduce((acc, token) => ({ ...acc, [token]: [] }), {});
 
+/**
+ * The bookmarks must be saved as an object whose each member
+ * represents an array of accounts saved for a specific token.
+ *
+ * @param {any} data The bookmarks dictionary
+ * @returns {Object} The valid or empty bookmarks dictionary
+ */
 export const validateBookmarks = (data) => {
-  if (!!data && typeof data !== 'object') return emptyBookmarks;
+  if (!data
+    || typeof data !== 'object'
+    || !tokenKeys.reduce((flag, token) => flag && Array.isArray(data[token]), true)) {
+    return emptyBookmarks;
+  }
 
-  const isValid = tokenKeys.reduce((flag, token) => {
-    flag = flag && Array.isArray(data[token]);
-    return flag;
-  }, true);
-
-  return isValid ? data : emptyBookmarks;
+  return data;
 };
 
 export const getIndexOfBookmark = (bookmarks, { address, token = tokenMap.LSK.key }) =>


### PR DESCRIPTION
### What was the problem?
This PR resolves #2949

### How was it solved?
There was a validation issue with the bookmarks which caused the reducer to discard all the settings when the bookmarks were saved as an array instead of an object.
Before we introduced BTC, bookmarks were stored as array of accounts:
```
[account1, account2, ...]
```
We changed it to
```
{
   [token]: [account1, account2, ...]
}
```
to differentiate accounts saved for each token. but the validation did not account for the migration. practically causing the application to discard user settings when faced old bookmarks.

### How was it tested?
Visually + unit test
