### PR TITLE
Change account bookmark icon tooltip text - #3057 

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -25,7 +25,6 @@
   "Add address to bookmarks": "Add address to bookmarks",
   "Add bookmark": "Add bookmark",
   "Add new": "Add new",
-  "Add to bookmarks": "Add to bookmarks",
   "Added": "Added",
   "Added votes": "Added votes",
   "Address": "Address",

--- a/src/components/screens/wallet/overview/accountInfo/index.js
+++ b/src/components/screens/wallet/overview/accountInfo/index.js
@@ -106,7 +106,7 @@ const AccountInfo = ({
                   </DialogLink>
                 )}
               >
-                <p>{t('Add to bookmarks')}</p>
+                <p>{t(bookmark === undefined ? 'Add to bookmarks' : 'Edit bookmark')}</p>
               </Tooltip>
             </div>
           ) : null


### PR DESCRIPTION
### What was the problem?
The tooltip on account bookmark icon was always saying 'Add to bookmarks' whether account was bookmarked or not

### How was it solved?
Adding a condition to show 'Edit bookmark' when account is bookmarked

### How was it tested?
Manual test
