### PR TITLE
Use height for sorting - Closes #3059

### DIFF
--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -2,7 +2,7 @@ import actionTypes from '../../constants/actions';
 import txFilters from '../../constants/transactionFilters';
 
 // TODO the sort should be removed when BTC api returns transactions sorted by timestamp
-const sortByNonce = (a, b) => (b.nonce - a.nonce);
+const sortByHeight = (a, b) => (b.height - a.height);
 
 const addNewTransactions = (array1, array2) => array1.filter(array1Value =>
   array2.filter(array2Value => array2Value.id === array1Value.id).length === 0);
@@ -53,7 +53,7 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
       return {
         ...state,
         // TODO the sort should be removed when BTC api returns transactions sorted by timestamp
-        confirmed: action.data.confirmed.sort(sortByNonce),
+        confirmed: action.data.confirmed.sort(sortByHeight),
         count: action.data.count,
         filters: action.data.filters !== undefined
           ? action.data.filters : state.filters,
@@ -67,7 +67,7 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
           ...action.data.confirmed,
           ...addNewTransactions(state.confirmed, action.data.confirmed),
         // TODO the sort should be removed when BTC api returns transactions sorted by timestamp
-        ].sort(sortByNonce),
+        ].sort(sortByHeight),
         count: action.data.count,
         filters: action.data.filters !== undefined
           ? action.data.filters : state.filters,


### PR DESCRIPTION
### What was the problem?
This PR resolves #3059

### How was it solved?
Used `height` for sorting account txs. for more info read the ticket.

**Note**
1. Since this fixes the failing e2e test, it needs to be merged into development before any other tickets. 
2. This PR fails due to a Lisk core issue. Once it's resolved, e2e tests should run successfully here.

### How was it tested?
unit and e2e
