### PR TITLE
Fix duplicated timeout toast - #3057

### DIFF
--- a/src/components/screens/wallet/overview/overview.css
+++ b/src/components/screens/wallet/overview/overview.css
@@ -1,6 +1,6 @@
 .wrapper {
   padding-bottom: var(--horizontal-padding-l);
-  padding-top: 20px;
+  padding-top: 30px;
 }
 
 @media (--medium-viewport) {

--- a/src/components/shared/navigationBars/sideBar/autoSignOut/index.js
+++ b/src/components/shared/navigationBars/sideBar/autoSignOut/index.js
@@ -14,6 +14,7 @@ const TimeOutToast = ({ t, history, ...props }) => {
   return (
     renderToast && toast(
       <div className={styles.toastText}>{t('Session timeout')}</div>, {
+        toastId: 'time-out',
         autoClose: false,
         closeButton: <span
           className={styles.closeBtn}


### PR DESCRIPTION
### What was the problem?
When user was auto-logged out and stayed on login screen for longer than 10 minutes 2 time out toast messages where displayed.

### How was it solved?
Add Id to toast to prevent duplicated
*additionally this PR contains a fix of the wrong margin top on wallet screen.

### How was it tested?
Manually.
