### PR TITLE
Fix Cypress failure on Jenkins - Closes #3064

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
 	}
 	parameters {
 		booleanParam(name: 'SKIP_PERCY', defaultValue: false, description: 'Skip running percy.')
-		string(name: 'LISK_CORE_VERSION', defaultValue: 'release/3.0.0', description: 'Use lisk-core branch.', )
+		string(name: 'LISK_CORE_VERSION', defaultValue: 'release/3.0.0-beta.1', description: 'Use lisk-core branch.', )
 		string(name: 'LISK_CORE_IMAGE_VERSION', defaultValue: '3.0.0-beta.1-a7842d112d5136d9462501763c4cb2895096e900', description: 'Use lisk-core docker image.', )
 	}
 	stages {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3064

### How was it solved?
There was an issue with Lisk Core. We have to use `release/3.0.0-beta.1` instead.

### How was it tested?
All tests have to pass.
