### PR TITLE
Fix fee calculation issues - Closes #3051

### DIFF
--- a/src/components/screens/send/form/form.test.js
+++ b/src/components/screens/send/form/form.test.js
@@ -51,7 +51,7 @@ describe('Form', () => {
       },
       nextStep: jest.fn(),
       initialValue: {
-        recipient: bookmarks.LSK[0].title,
+        recipient: bookmarks.LSK[0].address,
       },
     };
 

--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -81,8 +81,8 @@ const txTypeClassMap = {
 
 // eslint-disable-next-line max-statements
 export const createTransactionInstance = (rawTx, type) => {
-  const DUMMY_FEE = '18446744073709551615';
-  const DUMMY_SIGNATURE = '204514eb1152355799ece36d17037e5feb4871472c60763bdafe67eb6a38bec632a8e2e62f84a32cf764342a4708a65fbad194e37feec03940f0ff84d3df2a05';
+  const FEE_BYTES_PLACEHOLDER = '18446744073709551615';
+  const SIGNATURE_BYTES_PLACEHOLDER = '204514eb1152355799ece36d17037e5feb4871472c60763bdafe67eb6a38bec632a8e2e62f84a32cf764342a4708a65fbad194e37feec03940f0ff84d3df2a05';
   const asset = {
     data: rawTx.data,
   };
@@ -101,8 +101,8 @@ export const createTransactionInstance = (rawTx, type) => {
     senderPublicKey: rawTx.senderPublicKey,
     nonce: rawTx.nonce,
     asset,
-    fee: DUMMY_FEE,
-    signatures: [DUMMY_SIGNATURE],
+    fee: FEE_BYTES_PLACEHOLDER,
+    signatures: [SIGNATURE_BYTES_PLACEHOLDER],
   });
 
   return tx;

--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -150,7 +150,10 @@ export const broadcast = (transaction, network) => new Promise(
 /**
  * Returns a dictionary of base fees for low, medium and high processing speeds
  *
- * @todo get from Lisk Ser
+ * @todo The current implementation mocks the results with realistic values.
+ * We will refactor this function to fetch the base fees from Lisk Service
+ * when the endpoint is ready. Refer to #3081
+ *
  * @returns {Promise<{Low: number, Medium: number, High: number}>} with low,
  * medium and high priority fee options
  */

--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -78,18 +78,20 @@ const txTypeClassMap = {
   vote: Lisk.transactions.VoteTransaction,
 };
 
+
+// eslint-disable-next-line max-statements
 export const createTransactionInstance = (rawTx, type) => {
   const DUMMY_FEE = '18446744073709551615';
   const DUMMY_SIGNATURE = '204514eb1152355799ece36d17037e5feb4871472c60763bdafe67eb6a38bec632a8e2e62f84a32cf764342a4708a65fbad194e37feec03940f0ff84d3df2a05';
-
   const asset = {
     data: rawTx.data,
-    recipientId: rawTx.recipient,
-    amount: rawTx.amount,
   };
 
-  if (type === 'registerDelegate') {
-    asset.username = rawTx.username;
+  if (type === 'transfer') {
+    asset.recipientId = rawTx.recipient;
+    asset.amount = rawTx.amount;
+  } else if (type === 'registerDelegate') {
+    asset.username = rawTx.username || '';
   } else if (type === 'vote') {
     asset.votes = rawTx.votes;
   }


### PR DESCRIPTION
### What was the problem?
This PR resolves #3051

### How was it solved?
- [x] Refactor the fee calculation algorithm so that it calculates the correct fee.
- [x] The fee calculated for different priority types should be the same for the same transaction.
- [x] Use the real min fee for the minimum required for the transaction instead of the lowest transaction priority option.

### How was it tested?
Unit and e2e tests
