### PR TITLE
Add voting e2e delay

### DIFF
--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -78,3 +78,10 @@ export const calculateAvailableBalance = ({ unlocking = [], address }, currentBl
       (isBlockHeightReached(vote, currentBlock, address) ? acc + parseInt(vote.amount, 10) : acc),
     0,
   );
+
+export const calculateUnlockingBalance = ({ unlocking = [], address }, currentBlock) =>
+  unlocking.reduce(
+    (acc, vote) =>
+      (!isBlockHeightReached(vote, currentBlock, address) ? acc + parseInt(vote.amount, 10) : acc),
+    0,
+  );

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -213,7 +213,3 @@ And(/^I search for account ([^s]+)$/, function (string) {
   cy.wait('@requestAccount');
   cy.wait('@requestDelegate');
 });
-
-Then(/^I wait (.*?) ms$/, function (ms) {
-  cy.wait(ms);
-});

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -213,3 +213,7 @@ And(/^I search for account ([^s]+)$/, function (string) {
   cy.wait('@requestAccount');
   cy.wait('@requestDelegate');
 });
+
+Then(/^I wait (.*?) ms$/, function (ms) {
+  cy.wait(ms);
+});

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -34,7 +34,7 @@ Feature: Vote delegate
 
   Scenario: Unlock balance
     Given I am on wallet page
-    And I wait 1000 ms
+    Then I should that 40 LSK are locked
     Then I click on openUnlockBalanceDialog
     Then I should see unlocking balance 40
     When I click on customFeeOption

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -34,6 +34,7 @@ Feature: Vote delegate
 
   Scenario: Unlock balance
     Given I am on wallet page
+    And I wait 1000 ms
     Then I click on openUnlockBalanceDialog
     Then I should see unlocking balance 40
     When I click on customFeeOption

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -34,7 +34,7 @@ Feature: Vote delegate
 
   Scenario: Unlock balance
     Given I am on wallet page
-    Then I should that 100 LSK are locked
+    Then I see should that 100 LSK are locked
     Then I click on openUnlockBalanceDialog
     Then I should see unlocking balance 40
     When I click on customFeeOption

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -34,7 +34,7 @@ Feature: Vote delegate
 
   Scenario: Unlock balance
     Given I am on wallet page
-    Then I see should that 100 LSK are locked
+    Then I should see that 100 LSK are locked
     Then I click on openUnlockBalanceDialog
     Then I should see unlocking balance 40
     When I click on customFeeOption

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -34,7 +34,7 @@ Feature: Vote delegate
 
   Scenario: Unlock balance
     Given I am on wallet page
-    Then I should that 40 LSK are locked
+    Then I should that 100 LSK are locked
     Then I click on openUnlockBalanceDialog
     Then I should see unlocking balance 40
     When I click on customFeeOption

--- a/test/cypress/features/voting/voting.js
+++ b/test/cypress/features/voting/voting.js
@@ -2,7 +2,7 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
 import ss from '../../../constants/selectors';
 
-Then(/^I should that (.*?) LSK are locked$/, function (amount) {
+Then(/^I should see that (.*?) LSK are locked$/, function (amount) {
   cy.wait(10000);
   cy.get(`${ss.openUnlockBalanceDialog}`).eq(0).contains(amount);
 });

--- a/test/cypress/features/voting/voting.js
+++ b/test/cypress/features/voting/voting.js
@@ -2,6 +2,11 @@
 import { Then } from 'cypress-cucumber-preprocessor/steps';
 import ss from '../../../constants/selectors';
 
+Then(/^I should that (.*?) LSK are locked$/, function (amount) {
+  cy.wait(10000);
+  cy.get(`${ss.openUnlockBalanceDialog}`).eq(0).contains(amount);
+});
+
 Then(/^I should see unlocking balance (.*?)$/, function (amount) {
   cy.get(`${ss.unlockingBalance}`).eq(0).contains(amount);
 });


### PR DESCRIPTION
### What was the problem?
Voting e2e are unpredictably failing at the step of opening unlock LSK modal

### How was it solved?
- Wait and check if locked LSK is displayed

### How was it tested?
Add e2e step
