### PR TITLE
Redesign the active delegates table

### DIFF
--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -40,7 +40,7 @@ const DelegatesMonitor = ({
     tabs: [
       {
         value: 'active',
-        name: ('Active delegates'),
+        name: ('Inside round'),
         className: 'active',
       },
       {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3123 

- [x] Active delegate tab should be renamed as Inside round
- [ ] maximum of 103 delegates should be listed in this tab
- [ ] This tab should list out delegates name, delegates productivity, delegates rank, delegate weight, forging time and round status
- [ ] Enable user to sort out delegates based on rank or Forging time. The default sorting should be ----
- [ ] Should have tooltip which explains what is productivity and delegate weight
- [ ] User should have option to see the round status and delegates status
- [ ] load more option is not required for this page

### How was it solved?
WIP

### How was it tested?
WIP
