### PR TITLE
Fix the search modal crash - Closes #3158

### DIFF
--- a/src/components/screens/wallet/delegateProfile/index.js
+++ b/src/components/screens/wallet/delegateProfile/index.js
@@ -40,7 +40,8 @@ const apis = {
     apiUtil: (liskAPIClient, params) => getAPIClient(liskAPIClient).blocks.get(params),
     defaultData: {},
     getApiParams: state => ({
-      height: state.account.info && state.account.info.LSK.delegate.lastForgedHeight,
+      height: state.account.info && state.account.info.LSK.delegate
+        ? state.account.info.LSK.delegate.lastForgedHeight : 0,
     }),
     transformResponse: response => (response ? response.data[0] : {}),
   },

--- a/src/components/shared/searchBar/delegates.js
+++ b/src/components/shared/searchBar/delegates.js
@@ -17,10 +17,10 @@ const Delegates = ({
           key={index}
           data-index={index}
           className={`${styles.accountRow} ${rowItemIndex === index ? styles.active : ''} delegates-row`}
-          onClick={() => onSelectedRow(delegate.account.address)}
+          onClick={() => onSelectedRow(delegate.address)}
           onMouseEnter={updateRowItemIndex}
         >
-          <AccountVisual address={delegate.account.address} />
+          <AccountVisual address={delegate.address} />
           <div className={styles.accountInformation}>
             <div>
               <span className={`${styles.delegateName} delegate-name`}>
@@ -32,7 +32,7 @@ const Delegates = ({
                 />
               </span>
             </div>
-            <span className={styles.accountSubtitle}>{delegate.account.address}</span>
+            <span className={styles.accountSubtitle}>{delegate.address}</span>
           </div>
           <span className={styles.accountBalance}>
             <span className={styles.tag}>


### PR DESCRIPTION
### What was the problem?
This PR resolves #3158

### How was it solved?
The data structure has changed, I had to change `delegate.account.address` to `delegate.address`.  Plus I fixed a poor null check.

### How was it tested?
The app doesn't crash anymore and the data is shown properly.
