### PR TITLE
Fix vote transaction when one transaction has already been sent - Closes #3187

### DIFF
--- a/src/components/screens/votingQueue/editor/editor.js
+++ b/src/components/screens/votingQueue/editor/editor.js
@@ -49,10 +49,12 @@ const header = t => ([
  * @returns {Array} Array of votes as Lisk Element expects
  */
 const normalizeVotesForTx = votes =>
-  Object.keys(votes).map(delegateAddress => ({
-    delegateAddress,
-    amount: (votes[delegateAddress].unconfirmed - votes[delegateAddress].confirmed).toString(),
-  }));
+  Object.keys(votes)
+    .filter(address => votes[address].confirmed !== votes[address].unconfirmed)
+    .map(delegateAddress => ({
+      delegateAddress,
+      amount: (votes[delegateAddress].unconfirmed - votes[delegateAddress].confirmed).toString(),
+    }));
 
 /**
  * Validates given votes against the following criteria:


### PR DESCRIPTION
### What was the problem?
This PR resolves #3187

### How was it solved?
Filter for votes that have changed and only submit a transaction with those. 

### How was it tested?
Manually.