### PR TITLE
Fix vote status report - Closes #3192

### DIFF
--- a/src/components/screens/votingQueue/summary/summary.js
+++ b/src/components/screens/votingQueue/summary/summary.js
@@ -44,14 +44,14 @@ const getResultProps = ({ added, removed, edited }) => {
   }, 0);
 
   const editedWeight = Object.values(edited).reduce((sum, { confirmed, unconfirmed }) => {
-    sum += confirmed - unconfirmed;
+    sum += unconfirmed - confirmed;
     return sum;
   }, 0);
 
   if (editedWeight > 0) {
     locked += editedWeight;
   } else {
-    unlockable += editedWeight;
+    unlockable += Math.abs(editedWeight);
   }
 
   return { locked, unlockable };


### PR DESCRIPTION
### What was the problem?
This PR resolves #3192

### How was it solved?
- The negative value was the root cause. I used `Math.abs` to fix the issue.

