### PR TITLE
Alter Jenkinsfile to make LISK_CORE_IMAGE_VERSION parameter available as an environment variable on first run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,9 @@ pipeline {
 			}
 		}
 		stage('Run tests') {
+			environment {
+				LISK_CORE_IMAGE_VERSION = "${params.LISK_CORE_IMAGE_VERSION}"
+			}
 			steps {
 				parallel (
 					"jest": {


### PR DESCRIPTION
### What was the problem?
PRs recently don't seem to have the default values in the Jenkinsfile set

### How was it solved?
By explicitly setting the environment variable to equal the desired parameter

### How was it tested?
Pushing this branch to Github to see how it behaves :grin: