### PR TITLE
Refactor transactions module to use Lisk Service endpoints to retrieve data - Closes #3163

### DIFF
--- a/src/actions/network/btc.js
+++ b/src/actions/network/btc.js
@@ -1,14 +1,17 @@
 import actionTypes from '../../constants/actions';
 import { getNetworkConfig } from '../../utils/api/network';
+import { tokenMap } from '../../constants/tokens';
 
 // eslint-disable-next-line import/prefer-default-export
 export const btcNetworkSet = data => (dispatch) => {
-  dispatch({
-    type: actionTypes.nodeDefined,
-    data: {
-      token: 'BTC',
-      ...data,
-      ...getNetworkConfig(data),
-    },
-  });
+  getNetworkConfig(data, tokenMap.BTC.key)
+    .then((config) => {
+      dispatch({
+        type: actionTypes.networkSet,
+        data: {
+          token: tokenMap.BTC.key,
+          config,
+        },
+      });
+    });
 };

--- a/src/actions/network/btc.js
+++ b/src/actions/network/btc.js
@@ -1,0 +1,14 @@
+import actionTypes from '../../constants/actions';
+import { getNetworkConfig } from '../../utils/api/network';
+
+// eslint-disable-next-line import/prefer-default-export
+export const btcNetworkSet = data => (dispatch) => {
+  dispatch({
+    type: actionTypes.nodeDefined,
+    data: {
+      token: 'BTC',
+      ...data,
+      ...getNetworkConfig(data),
+    },
+  });
+};

--- a/src/actions/network/index.js
+++ b/src/actions/network/index.js
@@ -1,8 +1,13 @@
 import { lskNetworkSet } from './lsk';
+import { btcNetworkSet } from './btc';
 import actionTypes from '../../constants/actions';
 
-export const networkSet = data => dispatch =>
+export const networkSet = data => (dispatch) => {
   dispatch(lskNetworkSet(data));
+  if (data.name) {
+    dispatch(btcNetworkSet(data));
+  }
+}
 
 /**
  * Returns required action object to update offline/online status of network

--- a/src/actions/network/index.js
+++ b/src/actions/network/index.js
@@ -7,7 +7,7 @@ export const networkSet = data => (dispatch) => {
   if (data.name) {
     dispatch(btcNetworkSet(data));
   }
-}
+};
 
 /**
  * Returns required action object to update offline/online status of network

--- a/src/actions/network/lsk.js
+++ b/src/actions/network/lsk.js
@@ -1,17 +1,20 @@
-import networks from '../../constants/networks';
+import { getNetworkConfig, getServerUrl } from '../../utils/api/network';
 import actionTypes from '../../constants/actions';
+import { tokenMap } from '../../constants/tokens';
 
 // eslint-disable-next-line import/prefer-default-export
 export const lskNetworkSet = data => (dispatch) => {
-  const nodeUrl = data.name === networks.customNode.name
-    ? data.network.address
-    : networks[data.name.toLowerCase()].nodes[0];
-  dispatch({
-    type: actionTypes.nodeDefined,
-    data: {
-      token: 'LSK',
-      ...data,
-      nodeUrl,
-    },
-  });
+  getNetworkConfig(data, tokenMap.LSK.key)
+    .then((config) => {
+      dispatch({
+        type: actionTypes.networkSet,
+        data: {
+          token: tokenMap.LSK.key,
+          config: {
+            ...config,
+          },
+          serviceUrl: getServerUrl(config.nodeUrl, config.nethash),
+        },
+      });
+    });
 };

--- a/src/actions/network/lsk.js
+++ b/src/actions/network/lsk.js
@@ -9,6 +9,7 @@ export const lskNetworkSet = data => (dispatch) => {
   dispatch({
     type: actionTypes.nodeDefined,
     data: {
+      token: 'LSK',
       ...data,
       nodeUrl,
     },

--- a/src/store/middlewares/network.js
+++ b/src/store/middlewares/network.js
@@ -1,25 +1,7 @@
-import Lisk from '@liskhq/lisk-client';
 import { toast } from 'react-toastify';
 
 import actionTypes from '../../constants/actions';
 import { tokenMap } from '../../constants/tokens';
-import { getConnectionErrorMessage } from '../../utils/getNetwork';
-
-const getServerUrl = (nodeUrl, nethash) => {
-  if (nethash === Lisk.constants.MAINNET_NETHASH) {
-    return 'https://mainnet-service.lisk.io';
-  }
-  if (nethash === Lisk.constants.TESTNET_NETHASH) {
-    return 'https://testnet-service.lisk.io';
-  }
-  if (/liskdev.net:\d{2,4}$/.test(nodeUrl)) {
-    return nodeUrl.replace(/:\d{2,4}/, ':9901');
-  }
-  if (/\.(liskdev.net|lisk.io)$/.test(nodeUrl)) {
-    return nodeUrl.replace(/\.(liskdev.net|lisk.io)$/, $1 => `-service${$1}`);
-  }
-  return 'http://localhost:9091';
-};
 
 const generateAction = (data, config) => ({
   data: {
@@ -30,42 +12,12 @@ const generateAction = (data, config) => ({
   type: actionTypes.networkSet,
 });
 
-const getNetworkInfo = async nodeUrl => (
-  new Promise(async (resolve, reject) => {
-    new Lisk.APIClient([nodeUrl], {}).node.getConstants().then((response) => {
-      resolve(response.data);
-    }).catch((error) => {
-      reject(getConnectionErrorMessage(error));
-    });
-  })
-);
 
+// eslint-disable-next-line no-unused-vars
 const network = store => next => (action) => {
-  const { dispatch } = store;
   switch (action.type) {
     case actionTypes.nodeDefined:
       next(action);
-      getNetworkInfo(action.data.nodeUrl).then(({ nethash, networkId }) => {
-        const networkConfig = {
-          nodeUrl: action.data.nodeUrl,
-          custom: action.data.network.custom,
-          code: action.data.network.code,
-          nethash,
-          networkIdentifier: networkId,
-        };
-        dispatch(generateAction(action.data, networkConfig));
-        dispatch({
-          data: getServerUrl(action.data.nodeUrl, nethash),
-          type: actionTypes.serviceUrlSet,
-        });
-      }).catch((error) => {
-        dispatch(generateAction(action.data, {
-          nodeUrl: action.data.network.address,
-          custom: action.data.network.custom,
-          code: action.data.network.code,
-        }));
-        toast.error(error);
-      });
 
       break;
     default:

--- a/src/utils/api/http.js
+++ b/src/utils/api/http.js
@@ -22,6 +22,7 @@ const http = ({
     method,
     mode: 'no-cors',
     headers: {
+      Accept: 'application/json',
       'Content-Type': 'application/json',
     },
     ...restOptions,

--- a/src/utils/api/network/btc.js
+++ b/src/utils/api/network/btc.js
@@ -1,21 +1,38 @@
 import * as bitcoin from 'bitcoinjs-lib';
 import networks from '../../../constants/networks';
 
+/**
+ * Returns network code for a given network name
+ *
+ * @param {Object} network
+ * @param {String} network.name - Mainnet, or Testnet
+ * @returns {Number} network code
+ */
 export const getNetworkCode = network => (
   network.name === networks.mainnet.name
     ? networks.mainnet.code
     : networks.testnet.code
 );
 
+/**
+ * Returns network config to use for future API calls.
+ *
+ * @param {Object} network
+ * @param {String} network.name - Mainnet, or Testnet
+ * @returns {Promise} A promise that resolves network config object
+ * This method doesn't perform an async action, but it's a promise to
+ * match the LSK getNetworkConfig function signature.
+ */
 export const getNetworkConfig = (network) => {
   const netCode = getNetworkCode(network);
 
-  return ({
-    isTestnet: netCode !== 0,
-    url: netCode !== 0 ? 'https://btc-test.lisk.io' : 'https://btc.lisk.io',
-    minerFeesURL: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
-    network: netCode !== 0 ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
-    derivationPath: netCode !== 0 ? "m/44'/1'/0'/0/0" : "m/44'/0'/0'/0/0",
-    transactionExplorerURL: `https://www.blockchain.com/${netCode !== 0 ? 'btctest' : 'btc'}/tx`,
-  });
+  return new Promise(resolve =>
+    resolve({
+      isTestnet: netCode !== 0,
+      url: netCode !== 0 ? 'https://btc-test.lisk.io' : 'https://btc.lisk.io',
+      minerFeesURL: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
+      network: netCode !== 0 ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
+      derivationPath: netCode !== 0 ? "m/44'/1'/0'/0/0" : "m/44'/0'/0'/0/0",
+      transactionExplorerURL: `https://www.blockchain.com/${netCode !== 0 ? 'btctest' : 'btc'}/tx`,
+    }));
 };

--- a/src/utils/api/network/btc.js
+++ b/src/utils/api/network/btc.js
@@ -1,0 +1,21 @@
+import * as bitcoin from 'bitcoinjs-lib';
+import networks from '../../../constants/networks';
+
+export const getNetworkCode = network => (
+  network.name === networks.mainnet.name
+    ? networks.mainnet.code
+    : networks.testnet.code
+);
+
+export const getNetworkConfig = (network) => {
+  const netCode = getNetworkCode(network);
+
+  return ({
+    isTestnet: netCode !== 0,
+    url: netCode !== 0 ? 'https://btc-test.lisk.io' : 'https://btc.lisk.io',
+    minerFeesURL: 'https://bitcoinfees.earn.com/api/v1/fees/recommended',
+    network: netCode !== 0 ? bitcoin.networks.testnet : bitcoin.networks.bitcoin,
+    derivationPath: netCode !== 0 ? "m/44'/1'/0'/0/0" : "m/44'/0'/0'/0/0",
+    transactionExplorerURL: `https://www.blockchain.com/${netCode !== 0 ? 'btctest' : 'btc'}/tx`,
+  });
+};

--- a/src/utils/api/network/index.js
+++ b/src/utils/api/network/index.js
@@ -1,8 +1,5 @@
-export const getConnectedPeers = data => new Promise(resolve =>
-  resolve({ endpoint: 'getConnectedPeers', token: 'LSK', data }));
+import * as lsk from './lsk';
+import * as btc from './btc';
+import functionMapper from '../functionMapper';
 
-export const getNetworkStatus = data => new Promise(resolve =>
-  resolve({ endpoint: 'getNetworkStatus', token: 'LSK', data }));
-
-export const getNetworkStatistics = data => new Promise(resolve =>
-  resolve({ endpoint: 'getNetworkStatistics', token: 'LSK', data }));
+export default functionMapper(lsk, btc);

--- a/src/utils/api/network/lsk.js
+++ b/src/utils/api/network/lsk.js
@@ -1,0 +1,8 @@
+export const getConnectedPeers = data => new Promise(resolve =>
+  resolve({ endpoint: 'getConnectedPeers', token: 'LSK', data }));
+
+export const getNetworkStatus = data => new Promise(resolve =>
+  resolve({ endpoint: 'getNetworkStatus', token: 'LSK', data }));
+
+export const getNetworkStatistics = data => new Promise(resolve =>
+  resolve({ endpoint: 'getNetworkStatistics', token: 'LSK', data }));

--- a/src/utils/api/network/lsk.js
+++ b/src/utils/api/network/lsk.js
@@ -1,3 +1,49 @@
+import Lisk from '@liskhq/lisk-client';
+
+import networks from '../../../constants/networks';
+
+export const getServerUrl = (nodeUrl, nethash) => {
+  if (nethash === Lisk.constants.MAINNET_NETHASH) {
+    return 'https://mainnet-service.lisk.io';
+  }
+  if (nethash === Lisk.constants.TESTNET_NETHASH) {
+    return 'https://testnet-service.lisk.io';
+  }
+  if (/localhost|liskdev.net:\d{2,4}$/.test(nodeUrl)) {
+    return nodeUrl.replace(/:\d{2,4}/, ':9901');
+  }
+  if (/\.(liskdev.net|lisk.io)$/.test(nodeUrl)) {
+    return nodeUrl.replace(/\.(liskdev.net|lisk.io)$/, $1 => `-service${$1}`);
+  }
+  return 'unavailable';
+};
+
+/**
+ * Returns network config to use for future API calls.
+ *
+ * @param {Object} network
+ * @param {String} network.name - Mainnet, or Testnet, Custom node
+ * @param {String} network.nodeUrl - a valid URL pointing to a running node
+ * @returns {Promise}
+ */
+export const getNetworkConfig = (network) => {
+  const networkConfig = networks[network.name.toLowerCase()].nodes[0];
+  if (networkConfig.name === networks.customNode.name) {
+    networkConfig.nodes = [network.address];
+  }
+
+  // get mainnet testnet node url here
+  new Lisk.APIClient([networkConfig.nodes[0]], {}).node.getConstants()
+    .then(({ nethash, networkId }) => ({
+      ...networkConfig,
+      nodeUrl: networkConfig.nodes[0],
+      custom: networkConfig.name === networks.customNode.name,
+      code: networkConfig.code,
+      nethash,
+      networkIdentifier: networkId,
+    }));
+};
+
 export const getConnectedPeers = data => new Promise(resolve =>
   resolve({ endpoint: 'getConnectedPeers', token: 'LSK', data }));
 

--- a/src/utils/api/transaction/btc.js
+++ b/src/utils/api/transaction/btc.js
@@ -1,5 +1,85 @@
-export const getTransaction = data => new Promise(resolve =>
-  resolve({ endpoint: 'getTransaction', token: 'BTC', data }));
+// import bitcoin from 'bitcoinjs-lib';
+import { getNetworkCode, getNetworkConfig } from '../network';
+import { validateAddress } from '../../validators';
+import { tokenMap } from '../../../constants/tokens';
+import http from '../http';
 
-export const getTransactions = data => new Promise(resolve =>
-  resolve({ endpoint: 'getTransactions', token: 'BTC', data }));
+/**
+ * Normalizes transaction data retrieved from Blockchain.info API
+ * @param {Object} data
+ * @param {String} data.address Base address to use for formatting transactions
+ * @param {Array} data.list Transaction list retrieved from API
+ * @param {Number} data.blockHeight Latest block height for calculating confirmation count
+ */
+const normalizeTransactionsResponse = ({
+  network,
+  list,
+  // eslint-disable-next-line max-statements
+}) => list.map(({
+  tx, feeSatoshi, confirmations, timestamp,
+}) => {
+  const data = {
+    id: tx.txid,
+    timestamp: timestamp ? Number(timestamp) * 1000 : null,
+    confirmations: confirmations || 0,
+    type: 0,
+    data: '',
+    fee: feeSatoshi,
+    explorerLink: `${getNetworkConfig(network).transactionExplorerURL}/${tx.txid}`,
+  };
+
+  const networkCode = getNetworkCode(network);
+  data.senderId = tx.inputs[0].txDetail.scriptPubKey.addresses[0];
+  const extractedAddress = tx.outputs[0].scriptPubKey.addresses[0];
+  data.recipientId = validateAddress(tokenMap.BTC.key, extractedAddress, networkCode) === 0
+    ? extractedAddress : 'Unparsed Address';
+  data.amount = tx.outputs[0].satoshi.toString();
+
+  return data;
+});
+
+/**
+ * Retrieves the details of a single BTC transaction for a given id
+ * Converts the response to match Lisk data structure
+ *
+ * @param {Object} data
+ * @param {String} data.params - Id of the transaction
+ * @param {Object} data.network - Network setting from Redux store
+ * @returns {Promise} Transaction details API call
+ */
+export const getTransaction = ({
+  network,
+  id,
+}) => http({
+  network,
+  params: { id },
+}).then(response => normalizeTransactionsResponse({
+  network,
+  list: [response.body.data],
+}));
+
+/**
+ * Retrieves the list of BTC transactions for a given parameters set
+ * Converts the response to match Lisk data structure
+ *
+ * @param {Object} data
+ * @param {Object} data.network - Network setting from Redux store
+ * @param {Object} data.params
+ * @param {Number} data.params.offset Used for pagination
+ * @param {Number} data.params.limit Used for pagination
+ * @param {String} data.params.sort an option of 'amount:asc',
+ * 'amount:desc', 'timestamp:asc', 'timestamp:desc',
+ * @returns {Promise} Transactions list API call
+ *
+ * @todo normalize params id necessary
+ */
+export const getTransactions = ({
+  network,
+  params,
+}) => http({
+  network,
+  params,
+}).then(response => normalizeTransactionsResponse({
+  network,
+  list: [response.body.data],
+}));

--- a/src/utils/api/transaction/btc.js
+++ b/src/utils/api/transaction/btc.js
@@ -1,11 +1,11 @@
 // import bitcoin from 'bitcoinjs-lib';
-import { getNetworkCode, getNetworkConfig } from '../network';
 import { validateAddress } from '../../validators';
 import { tokenMap } from '../../../constants/tokens';
 import http from '../http';
 
 /**
  * Normalizes transaction data retrieved from Blockchain.info API
+ *
  * @param {Object} data
  * @param {String} data.address Base address to use for formatting transactions
  * @param {Array} data.list Transaction list retrieved from API
@@ -25,13 +25,12 @@ const normalizeTransactionsResponse = ({
     type: 0,
     data: '',
     fee: feeSatoshi,
-    explorerLink: `${getNetworkConfig(network).transactionExplorerURL}/${tx.txid}`,
+    explorerLink: `${network.networks.BTC.transactionExplorerURL}/${tx.txid}`,
   };
 
-  const networkCode = getNetworkCode(network);
   data.senderId = tx.inputs[0].txDetail.scriptPubKey.addresses[0];
   const extractedAddress = tx.outputs[0].scriptPubKey.addresses[0];
-  data.recipientId = validateAddress(tokenMap.BTC.key, extractedAddress, networkCode) === 0
+  data.recipientId = validateAddress(tokenMap.BTC.key, extractedAddress, network) === 0
     ? extractedAddress : 'Unparsed Address';
   data.amount = tx.outputs[0].satoshi.toString();
 
@@ -81,5 +80,5 @@ export const getTransactions = ({
   params,
 }).then(response => normalizeTransactionsResponse({
   network,
-  list: [response.body.data],
+  list: response.body.data,
 }));

--- a/src/utils/api/transaction/btc.test.js
+++ b/src/utils/api/transaction/btc.test.js
@@ -1,0 +1,103 @@
+import { getTransaction, getTransactions } from './btc';
+import http from '../http';
+
+jest.mock('../http', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('API: BTC Transactions', () => {
+  const network = {
+    serviceUrl: 'http://sample.com/',
+    networks: {
+      BTC: {
+        name: 'mainnet',
+      },
+    },
+  };
+  const sampleId = 'sample_id';
+  const sampleTx = i => ({
+    txid: `sample_id_${i}`,
+    timestamp: 1607352618,
+    confirmations: i,
+    feeSatoshi: 1000,
+    tx: {
+      inputs: [
+        {
+          txDetail: {
+            scriptPubKey: { addresses: ['3DjJKAX3JztZ5wAqPGNe1qmGPTdK76adZt'] },
+          },
+        },
+      ],
+      outputs: [
+        {
+          scriptPubKey: { addresses: ['3P7J9iUSEbpfpkjXkhbMqNTSepcXzMSTmg'] },
+          satoshi: 1000 * (i + 1),
+        },
+      ],
+    },
+  });
+
+  describe('getTransaction', () => {
+    it('Should call http with given params', async () => {
+      jest.clearAllMocks();
+      http.mockResolvedValue({
+        body: {
+          data: sampleTx(0),
+          meta: { total: 1 },
+        },
+      });
+      await getTransaction({
+        network,
+        id: sampleId,
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        params: { id: sampleId },
+        network,
+      });
+    });
+  });
+
+  describe('getTransactions', () => {
+    it('Should call http with given params', async () => {
+      const total = 10;
+      const params = {
+        offset: total,
+        limit: total,
+        sort: 'amount:asc',
+      };
+      jest.clearAllMocks();
+      http.mockResolvedValue({
+        body: {
+          data: Array.from(Array(total).keys()).map(sampleTx),
+          meta: { total },
+        },
+      });
+      await getTransactions({
+        network,
+        params,
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        params,
+        network,
+      });
+    });
+
+    it('Should not allow call with wrong params', async () => {
+      const params = {
+        sort: 'wrong_sort_value',
+      };
+      jest.clearAllMocks();
+      http.mockRejectedValue(new Error('Error fetching data.'));
+
+      await expect(getTransactions({
+        network,
+        params,
+      }))
+        .rejects
+        .toThrow('Error fetching data.');
+    });
+  });
+});

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -1,5 +1,21 @@
-export const getTransaction = data => new Promise(resolve =>
-  resolve({ endpoint: 'getTransaction', token: 'LSK', data }));
+import http from '../http';
+
+/**
+ * Retrieves the details of a single transaction
+ *
+ * @param {Object} data
+ * @param {String} data.params - Id of the transaction
+ * @param {String?} data.baseUrl - Lisk Service API url to override the
+ * existing ServiceUrl on the network param
+ * @param {Object} data.network - Network setting from Redux store
+ * @returns {Object} Transaction details
+ */
+export const getTransaction = data => http({
+  path: 'transactions',
+  params: { id: data.id },
+  network: data.network,
+  baseUrl: data.baseUrl,
+});
 
 export const getTransactions = data => new Promise(resolve =>
   resolve({ endpoint: 'getTransactions', token: 'LSK', data }));

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -104,7 +104,7 @@ export const getRegisteredDelegates = async ({ network }) => {
   });
 
   if (delegates.error || transactions.error) {
-    throw Error('Error fetching data.');
+    return Error('Error fetching data.');
   }
 
   // get number of registration in each month

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -14,20 +14,22 @@ import { getDelegates } from '../delegate';
  * @param {Object} data.network - Network setting from Redux store
  * @returns {Promise} Transaction details API call
  */
-export const getTransaction = data => http({
+export const getTransaction = ({
+  id, network, baseUrl,
+}) => http({
   path: 'transactions',
-  params: { id: data.id },
-  network: data.network,
-  baseUrl: data.baseUrl,
+  params: { id },
+  network,
+  baseUrl,
 });
 
 const txFilters = {
-  dateFrom: { key: 'from', test: str => typeof str === 'string' },
-  dateTo: { key: 'to', test: str => typeof str === 'string' },
-  amountFrom: { key: 'min', test: str => typeof str === 'string' },
-  amountTo: { key: 'max', test: str => typeof str === 'string' },
-  limit: { key: 'limit', test: num => (typeof num === 'number') },
-  offset: { key: 'offset', test: num => (typeof num === 'number' && num > 0) },
+  dateFrom: { key: 'from', test: timestamp => (new Date(timestamp)).getTime() > 0 },
+  dateTo: { key: 'to', test: timestamp => (new Date(timestamp)).getTime() > 0 },
+  amountFrom: { key: 'min', test: num => typeof num === 'number' && num >= 0 },
+  amountTo: { key: 'max', test: num => typeof num === 'number' && num > 0 },
+  limit: { key: 'limit', test: num => (typeof num === 'number' && num > 0) },
+  offset: { key: 'offset', test: num => (typeof num === 'number' && num >= 0) },
   sort: {
     key: 'sort',
     test: str => ['amount:asc', 'amount:desc', 'timestamp:asc', 'timestamp:desc'].includes(str),
@@ -81,6 +83,9 @@ export const getTransactions = ({
     Object.keys(params).forEach((key) => {
       if (txFilters[key].test(params[key])) {
         normParams[txFilters[key].key] = params[key];
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(`getTransactions: Dropped ${key} parameter, it's invalid.`);
       }
     });
   }

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -6,7 +6,8 @@ import http from '../http';
  * @param {Object} data
  * @param {String} data.params - Id of the transaction
  * @param {String?} data.baseUrl - Lisk Service API url to override the
- * existing ServiceUrl on the network param
+ * existing ServiceUrl on the network param. We may use this to retrieve
+ * the details of an archived transaction.
  * @param {Object} data.network - Network setting from Redux store
  * @returns {Object} Transaction details
  */
@@ -23,5 +24,18 @@ export const getTransactions = data => new Promise(resolve =>
 export const getRegisteredDelegates = data => new Promise(resolve =>
   resolve({ endpoint: 'getRegisteredDelegates', token: 'LSK', data }));
 
-export const getTransactionStats = data => new Promise(resolve =>
-  resolve({ endpoint: 'getTransactionStats', token: 'LSK', data }));
+/**
+ * Retrieves the overall statistics of network transactions.
+ *
+ * @param {Object} data
+ * @param {Object} data.params
+ * @param {String} data.params.period - An option of 'day' or 'month'
+ * @param {Number} data.params.limit - The number of results
+ * @param {Object} data.network - Network setting from Redux store
+ * @returns {Object} Network transactions statistics
+ */
+export const getTransactionStats = data => http({
+  path: `transactions/statistics/${data.params.period}`,
+  params: { limit: data.limit },
+  network: data.network,
+});

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -104,11 +104,11 @@ export const getRegisteredDelegates = async ({ network }) => {
   });
 
   if (delegates.error || transactions.error) {
-    return Error('Error fetching data.');
+    throw Error('Error fetching data.');
   }
 
   // get number of registration in each month
-  const monthStats = transactions
+  const monthStats = transactions.data
     .map((tx) => {
       const date = new Date(tx.timestamp * 1000);
       return `${date.getFullYear()}-${date.getMonth() + 1}`;
@@ -118,12 +118,13 @@ export const getRegisteredDelegates = async ({ network }) => {
       return acc;
     }, {});
 
-  // start with [delegates.total]
+
+  // start with [total delegates number]
   // subtract total of each month to get prev month's stats
-  return monthStats.reduce((acc, item) => {
+  return Object.values(monthStats).reduce((acc, item) => {
     acc.unshift(acc[0] - item);
     return acc;
-  }, [delegates.total]);
+  }, [delegates.meta.total]);
 };
 
 /**

--- a/src/utils/api/transaction/lsk.js
+++ b/src/utils/api/transaction/lsk.js
@@ -36,6 +36,6 @@ export const getRegisteredDelegates = data => new Promise(resolve =>
  */
 export const getTransactionStats = data => http({
   path: `transactions/statistics/${data.params.period}`,
-  params: { limit: data.limit },
+  params: { limit: data.params.limit },
   network: data.network,
 });

--- a/src/utils/api/transaction/lsk.test.js
+++ b/src/utils/api/transaction/lsk.test.js
@@ -2,9 +2,11 @@ import {
   getTransaction,
   getTransactions,
   getTransactionStats,
+  getRegisteredDelegates,
 } from './lsk';
 import http from '../http';
 import ws from '../ws';
+import * as delegates from '../delegate';
 
 jest.mock('../http', () => ({
   __esModule: true,
@@ -16,16 +18,20 @@ jest.mock('../ws', () => ({
   default: jest.fn(),
 }));
 
+jest.mock('../delegate', () => ({
+  getDelegates: jest.fn(),
+}));
+
 describe('API: LSK Transactions', () => {
   const network = { serviceUrl: 'http://sample.com/' };
   const baseUrl = 'http://custom-basse-url.com/';
   const sampleId = 'sample_id';
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   describe('getTransaction', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('Should call http with given params', () => {
       getTransaction({
         network,
@@ -43,6 +49,10 @@ describe('API: LSK Transactions', () => {
   });
 
   describe('getTransactions', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
     it('should call WS with correct list of types', async () => {
       await getTransactions({
         network, params: { type: 'transfer' },
@@ -120,9 +130,37 @@ describe('API: LSK Transactions', () => {
     });
   });
 
+  describe.skip('getRegisteredDelegates', () => {
+    it('should throw if any of the API endpoints throw', () => {
+
+    });
+
+    it('should return correct stats of registered delegates', async () => {
+      const txs = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4]
+        .map((item) => {
+          const t = new Date();
+          t.setMonth(t.getMonth() + item);
+          return { timestamp: t.getTime() };
+        });
+      delegates.getDelegates.mockResolvedValue({
+        data: {},
+        meta: { total: 10 },
+      });
+      getTransactions.mockResolvedValue({
+        data: txs,
+        meta: { total: 10 },
+      });
+
+      const response = await getRegisteredDelegates({ network });
+      expect(response).toEqual([]);
+
+      // delegates.getDelegates.mockReset();
+      // getTransactions.mockReset();
+    });
+  });
+
   describe('getTransactionStats', () => {
     it('Should call http with given params', () => {
-      const network = { serviceUrl: 'http://sample.com/' };
       const params = { period: 'day', limit: 7 };
 
       getTransactionStats({

--- a/src/utils/api/transaction/lsk.test.js
+++ b/src/utils/api/transaction/lsk.test.js
@@ -1,21 +1,32 @@
 import {
   getTransaction,
+  getTransactions,
   getTransactionStats,
 } from './lsk';
 import http from '../http';
+import ws from '../ws';
 
 jest.mock('../http', () => ({
   __esModule: true,
   default: jest.fn(),
 }));
 
+jest.mock('../ws', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
 describe('API: LSK Transactions', () => {
+  const network = { serviceUrl: 'http://sample.com/' };
+  const baseUrl = 'http://custom-basse-url.com/';
+  const sampleId = 'sample_id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('getTransaction', () => {
     it('Should call http with given params', () => {
-      const network = { serviceUrl: 'http://sample.com/' };
-      const baseUrl = 'http://custom-basse-url.com/';
-      const sampleId = 'sample_tx_id';
-
       getTransaction({
         network,
         baseUrl,
@@ -27,6 +38,84 @@ describe('API: LSK Transactions', () => {
         params: { id: sampleId },
         network,
         baseUrl,
+      });
+    });
+  });
+
+  describe('getTransactions', () => {
+    it('should call WS with correct list of types', async () => {
+      await getTransactions({
+        network, params: { type: 'transfer' },
+      });
+
+      expect(ws).toHaveBeenCalledWith({
+        baseUrl: 'http://sample.com/',
+        requests: [
+          { method: 'get.transactions', params: { type: 0 } },
+          { method: 'get.transactions', params: { type: 8 } },
+        ],
+      });
+    });
+
+    it('should call http with block id', async () => {
+      await getTransactions({
+        network, params: { blockId: sampleId },
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        path: 'transactions',
+        params: { block: sampleId },
+        network,
+        baseUrl: undefined,
+      });
+    });
+
+    it('should call http with filters', async () => {
+      await getTransactions({
+        network,
+        params: {
+          dateFrom: 'from_date',
+          dateTo: 'to_date',
+          amountFrom: 'amount_from',
+          amountTo: 'amount_to',
+          sort: 'amount:asc',
+        },
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        network,
+        path: 'transactions',
+        baseUrl: undefined,
+        params: {
+          from: 'from_date',
+          to: 'to_date',
+          min: 'amount_from',
+          max: 'amount_to',
+          sort: 'amount:asc',
+        },
+      });
+    });
+
+    it('should call http and ignore wrong filters', async () => {
+      await getTransactions({
+        network,
+        params: {
+          dateFrom: 12345,
+          dateTo: 'to_date',
+          amountFrom: 123445,
+          amountTo: 'amount_to',
+          sort: 'wrong_sort',
+        },
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        network,
+        path: 'transactions',
+        baseUrl: undefined,
+        params: {
+          to: 'to_date',
+          max: 'amount_to',
+        },
       });
     });
   });

--- a/src/utils/api/transaction/lsk.test.js
+++ b/src/utils/api/transaction/lsk.test.js
@@ -1,0 +1,51 @@
+import {
+  getTransaction,
+  getTransactionStats,
+} from './lsk';
+import http from '../http';
+
+jest.mock('../http', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+describe('API: LSK Transactions', () => {
+  describe('getTransaction', () => {
+    it('Should call http with given params', () => {
+      const network = { serviceUrl: 'http://sample.com/' };
+      const baseUrl = 'http://custom-basse-url.com/';
+      const sampleId = 'sample_tx_id';
+
+      getTransaction({
+        network,
+        baseUrl,
+        id: sampleId,
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        path: 'transactions',
+        params: { id: sampleId },
+        network,
+        baseUrl,
+      });
+    });
+  });
+
+  describe('getTransactionStats', () => {
+    it('Should call http with given params', () => {
+      const network = { serviceUrl: 'http://sample.com/' };
+      const params = { period: 'day', limit: 7 };
+
+      getTransactionStats({
+        network,
+        params,
+      });
+
+      expect(http).toHaveBeenCalledWith({
+        path: `transactions/statistics/${params.period}`,
+        params: { limit: params.limit },
+        network,
+      });
+    });
+  });
+});

--- a/src/utils/api/transaction/lsk.test.js
+++ b/src/utils/api/transaction/lsk.test.js
@@ -130,32 +130,43 @@ describe('API: LSK Transactions', () => {
     });
   });
 
-  describe.skip('getRegisteredDelegates', () => {
-    it('should throw if any of the API endpoints throw', () => {
+  describe('getRegisteredDelegates', () => {
+    beforeEach(() => {
+      ws.mockReset();
+    });
 
+    it('should throw if any of the API endpoints throw', async () => {
+      // Mock promise failure
+      ws.mockRejectedValue(new Error('Error fetching data.'));
+
+      // call and anticipate failure
+      await expect(getRegisteredDelegates({ network }))
+        .rejects
+        .toThrow('Error fetching data.');
     });
 
     it('should return correct stats of registered delegates', async () => {
+      // create sample delegate registration transactions
       const txs = [1, 1, 1, 2, 2, 2, 3, 3, 3, 4]
         .map((item) => {
           const t = new Date();
           t.setMonth(t.getMonth() + item);
           return { timestamp: t.getTime() };
         });
+
+      // mock internals
       delegates.getDelegates.mockResolvedValue({
         data: {},
         meta: { total: 10 },
       });
-      getTransactions.mockResolvedValue({
+      ws.mockResolvedValue({
         data: txs,
         meta: { total: 10 },
       });
 
+      // Call and expect right values
       const response = await getRegisteredDelegates({ network });
-      expect(response).toEqual([]);
-
-      // delegates.getDelegates.mockReset();
-      // getTransactions.mockReset();
+      expect(response).toEqual([0, 1, 4, 7, 10]);
     });
   });
 

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -3,7 +3,6 @@ import numeral from 'numeral';
 import { cryptography } from '@liskhq/lisk-client';
 import { tokenMap } from '../constants/tokens';
 import { minBalance } from '../constants/transactions';
-import getBtcConfig from './api/btc/config';
 import { toRawLsk } from './lsk';
 import i18n from '../i18n';
 import reg from './regex';
@@ -12,11 +11,11 @@ import reg from './regex';
  * Validates the given address with respect to the tokenType
  * @param {String} tokenType
  * @param {String} address
- * @param {Number} [netCode=1]
+ * @param {Object} network The network config from Redux store
  * @returns {Number} -> 0: valid, 1: invalid, -1: empty
  */
 // eslint-disable-next-line import/prefer-default-export
-export const validateAddress = (tokenType, address, netCode = 1) => {
+export const validateAddress = (tokenType, address, network) => {
   if (address === '') {
     return -1;
   }
@@ -25,9 +24,8 @@ export const validateAddress = (tokenType, address, netCode = 1) => {
     // Reference: https://github.com/bitcoinjs/bitcoinjs-lib/issues/890
     case tokenMap.BTC.key:
       try {
-        const config = getBtcConfig(netCode);
         bitcoin.address.fromBase58Check(address); // eliminates segwit addresses
-        bitcoin.address.toOutputScript(address, config.network);
+        bitcoin.address.toOutputScript(address, network.name);
         return 0;
       } catch (e) {
         return 1;


### PR DESCRIPTION
### What was the problem?
This PR resolves #3163

### How was it solved?
I had to implement the following modules:
- getTransaction (BTC)
   - [x] Implementation
   - [x] Test coverage 
- getTransactions (BTC)
   - [x] Implementation
   - [x] Test coverage 
- getTransaction (LSK)
   - [x] Implementation
   - [x] Test coverage 
- getTransactions (LSK)
   - [x] Implementation
   - [x] Test coverage 
- getRegisteredDelegates
   - [x] Implementation
   - [x] Test coverage 
- getTransactionStats
   - [x] Implementation
   - [x] Test coverage 

But before that, I had to update our network config modules, actions, reducer, and middleware to work consistently.

