### PR TITLE
Fix invalid transaction fee amount - Closes #3215

### DIFF
--- a/src/utils/api/lsk/transactions.js
+++ b/src/utils/api/lsk/transactions.js
@@ -172,9 +172,9 @@ export const getTransactionBaseFees = network => liskService.getTransactionBaseF
   .then((response) => {
     const { feeEstimatePerByte } = response.data;
     return {
-      Low: feeEstimatePerByte.low,
-      Medium: feeEstimatePerByte.medium,
-      High: feeEstimatePerByte.high,
+      Low: feeEstimatePerByte.low || 0,
+      Medium: feeEstimatePerByte.medium || 0,
+      High: feeEstimatePerByte.high || 0,
     };
   });
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #3215

### How was it solved?
Lisk Service returns `{ feeEstimatePerByte: {} }` which was not expected. We anticipated this endpoint to either fail or succeed with values for Low, Medium, and High processing speeds.
I added default values equal to zero for each processing speed. This is a quick work around for when this endpoint fails to return correct values.
