### PR TITLE
Fix errors thrown because of missing server URL - Closes #3272

### DIFF
--- a/src/store/middlewares/block.js
+++ b/src/store/middlewares/block.js
@@ -69,8 +69,10 @@ const blockMiddleware = store => (
     next(action);
     switch (action.type) {
       case actionTypes.networkSet:
-        store.dispatch(olderBlocksRetrieved());
-        blockListener(store);
+        if (action.data.token === tokenMap.LSK.key) {
+          blockListener(store);
+          store.dispatch(olderBlocksRetrieved());
+        }
         clearInterval(interval);
         interval = setInterval(() => {
           // if user refreshes the page, we might have a race condition here.

--- a/src/store/middlewares/block.js
+++ b/src/store/middlewares/block.js
@@ -1,11 +1,8 @@
 import actionTypes from '../../constants/actions';
 import { networkStatusUpdated } from '../../actions/network';
-import { olderBlocksRetrieved, forgingTimesRetrieved } from '../../actions/blocks';
+import { olderBlocksRetrieved } from '../../actions/blocks';
 import { blockSubscribe, blockUnsubscribe } from '../../utils/api/block';
 import { tokenMap } from '../../constants/tokens';
-
-const intervalTime = 5000;
-let interval;
 
 // eslint-disable-next-line max-statements
 const blockListener = (store) => {
@@ -73,14 +70,6 @@ const blockMiddleware = store => (
           blockListener(store);
           store.dispatch(olderBlocksRetrieved());
         }
-        clearInterval(interval);
-        interval = setInterval(() => {
-          // if user refreshes the page, we might have a race condition here.
-          // I'll skip the first retrieval since it is useless without the blocks list
-          if (store.getState().blocks.latestBlocks.length) {
-            store.dispatch(forgingTimesRetrieved());
-          }
-        }, intervalTime);
         break;
 
       default: break;

--- a/src/store/reducers/network.js
+++ b/src/store/reducers/network.js
@@ -19,7 +19,7 @@ const network = (state = initialState, action) => {
       return {
         ...state,
         name: action.data.config ? action.data.config.name : '',
-        serviceUrl: action.data.serviceUrl, // TODO
+        serviceUrl: action.data.serviceUrl,
         networks: {
           ...state.networks,
           [action.data.token]: action.data.config || {},
@@ -29,11 +29,6 @@ const network = (state = initialState, action) => {
       return {
         ...state,
         status: action.data,
-      };
-    case actionTypes.serviceUrlSet:
-      return {
-        ...state,
-        serviceUrl: action.data,
       };
     case actionTypes.socketConnectionsUpdated:
       return {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3272

### How was it solved?
Node url was `undefined` because we dispatch `networkSet` once for each token, and `BTC` resolves faster, making `node` address `undefined` at the time of subscription. I moved the subscription into a `LSK` check condition.

