### PR TITLE
Search feature doesn't work - Closes #3332

### DIFF
--- a/src/utils/api/search/lsk.js
+++ b/src/utils/api/search/lsk.js
@@ -79,7 +79,7 @@ export const search = ({ network, params, baseUrl }) => {
   }
   return getDelegates({
     network,
-    params: { address: params.query },
+    params: { search: params.query, limit: 4 },
     baseUrl,
   }).then(res => ({ data: { delegates: res.data }, meta: res.meta }));
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #3332

### How was it solved?
[This change](https://github.com/LiskHQ/lisk-desktop/commit/0a7c9898c0a45d41ef9182e6570cb028385e3961#diff-7805b1bdf2e0792a6175e0d81c92cdca52a9aa37682b0887075c47de5c0b5b18) was wrong. The address is already handled [here](https://github.com/LiskHQ/lisk-desktop/blob/development/src/utils/api/search/lsk.js#L71) and if the address is valid, `getDelegates` will never be called.

### How was it tested?
Unit test + e2e test
