### PR TITLE
Update account info after sending tokens - Closes #3322

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -5,30 +5,6 @@ import { getConnectionErrorMessage } from '../utils/getNetwork';
 import loginTypes from '../constants/loginTypes';
 import { networkStatusUpdated } from './network';
 import actionTypes from '../constants/actions';
-import { tokenMap } from '../constants/tokens';
-
-/**
- * Trigger this action to remove passphrase from account object
- *
- * @param {Object} data - account data
- * @returns {Object} - Action object
- */
-export const removePassphrase = data => ({
-  data,
-  type: actionTypes.removePassphrase,
-});
-
-/**
- * Trigger this action to update the account object
- * while already logged in
- *
- * @param {Object} data - account data
- * @returns {Object} - Action object
- */
-export const accountUpdated = data => ({
-  data,
-  type: actionTypes.accountUpdated,
-});
 
 /**
  * Trigger this action to log out of the account
@@ -47,18 +23,6 @@ export const accountLoggedOut = () => ({
 export const timerReset = date => ({
   type: actionTypes.timerReset,
   data: date,
-});
-
-/**
- * Trigger this action to login to an account
- * The login middleware triggers this action
- *
- * @param {Object} data - account data
- * @returns {Object} - Action object
- */
-export const accountLoggedIn = data => ({
-  type: actionTypes.accountLoggedIn,
-  data,
 });
 
 export const accountLoading = () => ({

--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -40,38 +40,11 @@ export const passphraseUsed = data => ({
   data,
 });
 
-/**
- * This action is used to update account balance when new block was forged and
- * account middleware detected that it contains a transaction that affects balance
- * of the active account
- *
- * @param {Object} data
- * @param {Object} data.account - current account with address and publicKey
- */
-export const accountDataUpdated = ({ account }) =>
-  async (dispatch, getState) => {
-    const network = getState().network;
-    const activeToken = getState().settings.token.active;
-    const [error, result] = await to(getAccount({
-      network,
-      address: account.address,
-      publicKey: account.publicKey,
-    }, activeToken));
-    if (result) {
-      dispatch(accountUpdated(result));
-      dispatch(networkStatusUpdated({ online: true }));
-    } else {
-      dispatch(networkStatusUpdated({ online: false, code: error.error.code }));
-    }
-  };
-
-
-async function getAccounts(tokens, options) {
-  return tokens.reduce(async (accountsPromise, token) => {
+async function getAccounts({ network, params }) {
+  return Object.keys(params).reduce(async (accountsPromise, token) => {
     const accounts = await accountsPromise;
-    const { network, ...params } = options;
     const baseUrl = network.networks[token].serviceUrl;
-    const account = await getAccount({ params, network, baseUrl }, token);
+    const account = await getAccount({ network, baseUrl, params: params[token] }, token);
     return {
       ...accounts,
       [token]: account,
@@ -79,22 +52,39 @@ async function getAccounts(tokens, options) {
   }, Promise.resolve({}));
 }
 
-export const updateEnabledTokenAccount = token => async (dispatch, getState) => {
-  const { network, account } = getState();
-  const activeToken = getState().settings.token.active;
-  if (token !== tokenMap.LSK.key) {
-    const [error, result] = await to(getAccount({
-      token,
-      network,
-      passphrase: account.passphrase,
-    }, activeToken));
-    if (error) {
-      toast.error(getConnectionErrorMessage(error));
+/**
+ * This action is used to update account balance when new block was forged and
+ * account middleware detected that it contains a transaction that affects balance
+ * of the active account
+ *
+ * @param {String} tokensTypes - Options of 'enabled' and 'active'
+ */
+export const accountDataUpdated = tokensTypes =>
+  async (dispatch, getState) => {
+    const state = getState();
+    const { network, settings, account } = state;
+    const activeTokens = tokensTypes === 'enabled'
+      ? Object.keys(settings.token.list)
+        .filter(key => settings.token.list[key])
+      : [settings.token.active];
+
+    const params = activeTokens.reduce((acc, token) => {
+      acc[token] = { address: account.info[token].address };
+      return acc;
+    }, {});
+
+    const [error, info] = await to(getAccounts({ network, params }));
+
+    if (info) {
+      dispatch({
+        type: actionTypes.accountUpdated,
+        data: info,
+      });
+      dispatch(networkStatusUpdated({ online: true }));
     } else {
-      dispatch(accountUpdated(result));
+      dispatch(networkStatusUpdated({ online: false, code: error.error.code }));
     }
-  }
-};
+  };
 
 /**
  * This action is used on login to fetch account info for all enabled token
@@ -109,11 +99,13 @@ export const login = ({ passphrase, publicKey, hwInfo }) => async (dispatch, get
   const { network, settings } = getState();
   dispatch(accountLoading());
 
-  const activeTokens = Object.keys(settings.token.list)
-    .filter(key => settings.token.list[key]);
-  const [error, info] = await to(getAccounts(activeTokens, {
-    network, publicKey, passphrase,
-  }));
+  const params = Object.keys(settings.token.list)
+    .filter(key => settings.token.list[key])
+    .reduce((acc, token) => {
+      acc[token] = { passphrase, publicKey };
+      return acc;
+    }, {});
+  const [error, info] = await to(getAccounts({ network, params }));
 
   if (error) {
     toast.error(getConnectionErrorMessage(error));
@@ -122,12 +114,15 @@ export const login = ({ passphrase, publicKey, hwInfo }) => async (dispatch, get
     const loginType = hwInfo
       ? ['trezor', 'ledger'].find(item => hwInfo.deviceModel.toLowerCase().indexOf(item) > -1)
       : 'passphrase';
-    dispatch(accountLoggedIn({
-      passphrase,
-      loginType: loginTypes[loginType].code,
-      hwInfo: hwInfo || {},
-      date: new Date(),
-      info,
-    }));
+    dispatch({
+      type: actionTypes.accountLoggedIn,
+      data: {
+        passphrase,
+        loginType: loginTypes[loginType].code,
+        hwInfo: hwInfo || {},
+        date: new Date(),
+        info,
+      },
+    });
   }
 };

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -1,15 +1,11 @@
 import { toast } from 'react-toastify';
 import actionTypes from '../constants/actions';
 import {
-  accountUpdated,
   accountLoggedOut,
-  removePassphrase,
   accountDataUpdated,
-  updateEnabledTokenAccount,
   login,
 } from './account';
 import * as accountApi from '../utils/api/account';
-import networks from '../constants/networks';
 import accounts from '../../test/constants/accounts';
 import * as networkActions from './network';
 
@@ -47,20 +43,6 @@ describe('actions: account', () => {
     networkActions.networkStatusUpdated.mockReset();
   });
 
-  describe('accountUpdated', () => {
-    it('should create an action to set values to account', () => {
-      const data = {
-        passphrase: 'robust swift grocery peasant forget share enable convince deputy road keep cheap',
-      };
-
-      const expectedAction = {
-        data,
-        type: actionTypes.accountUpdated,
-      };
-      expect(accountUpdated(data)).toEqual(expectedAction);
-    });
-  });
-
   describe('accountLoggedOut', () => {
     it('should create an action to reset the account', () => {
       const expectedAction = {
@@ -68,23 +50,6 @@ describe('actions: account', () => {
       };
 
       expect(accountLoggedOut()).toEqual(expectedAction);
-    });
-  });
-
-  describe('removePassphrase', () => {
-    it('should create an action to remove passphrase', () => {
-      const data = {
-        publicKey: accounts.genesis.publicKey,
-        network: networks.testnet,
-        address: accounts.genesis.address,
-      };
-
-      const expectedAction = {
-        data,
-        type: actionTypes.removePassphrase,
-      };
-
-      expect(removePassphrase(data)).toEqual(expectedAction);
     });
   });
 
@@ -203,50 +168,6 @@ describe('actions: account', () => {
       accountApi.getAccount.mockRejectedValue({ message: 'custom error' });
       await login({ passphrase })(dispatch, getState);
       expect(toast.error).toHaveBeenNthCalledWith(1, 'Unable to connect to the node, no response from the server.');
-    });
-  });
-
-  describe('updateEnabledTokenAccount', () => {
-    let state;
-    const getState = () => (state);
-    const {
-      address,
-      balance,
-      passphrase,
-    } = accounts.genesis;
-
-    beforeEach(() => {
-      state = {
-        account: {
-          passphrase,
-        },
-        network,
-        settings: {
-          autoLog: true,
-          token: {
-            list: {
-              LSK: true,
-              BTC: true,
-            },
-          },
-        },
-      };
-    });
-
-    it('should call account api and dispatch accountUpdated ', async () => {
-      accountApi.getAccount.mockResolvedValue({ balance, address });
-      await updateEnabledTokenAccount('BTC')(dispatch, getState);
-      expect(dispatch).toHaveBeenCalledWith({
-        type: actionTypes.accountUpdated,
-        data: expect.objectContaining({ address, balance }),
-      });
-    });
-
-    it('should fire an error toast if getAccount fails ', async () => {
-      jest.spyOn(toast, 'error');
-      accountApi.getAccount.mockRejectedValue({ message: 'custom error' });
-      await updateEnabledTokenAccount('BTC')(dispatch, getState);
-      expect(toast.error).toHaveBeenCalled();
     });
   });
 });

--- a/src/actions/account.test.js
+++ b/src/actions/account.test.js
@@ -72,45 +72,37 @@ describe('actions: account', () => {
           token: {
             active: 'LSK',
           },
+          list: [
+            { LSK: true },
+            { BTC: false },
+          ],
+        },
+        account: {
+          passphrase: accounts.genesis.passphrase,
+          info: {
+            LSK: {
+              address: accounts.genesis.address,
+              publicKey: accounts.genesis.publicKey,
+              balance: 0,
+            },
+          },
         },
       });
     });
 
-    it(`should call account API methods on ${actionTypes.newBlockCreated} action when online`, async () => {
+    it('should call account API methods on newBlockCreated action when online', async () => {
       accountApi.getAccount.mockResolvedValue({ balance: 10e8 });
 
-      const data = {
-        windowIsFocused: false,
-        transactions: {
-          pending: [{
-            id: 12498250891724098,
-          }],
-          confirmed: [],
-          account: { address: accounts.second_passphrase_account.address, balance: 0 },
-        },
-        account: { address: accounts.genesis.address, balance: 0 },
-      };
-
-      await accountDataUpdated(data)(dispatch, getState);
+      await accountDataUpdated('active')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledTimes(2);
       expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({ online: true });
     });
 
-    it(`should call account API methods on ${actionTypes.newBlockCreated} action when offline`, async () => {
+    it('should call account API methods on newBlockCreated action when offline', async () => {
       const code = 'EUNAVAILABLE';
       accountApi.getAccount.mockRejectedValue({ error: { code } });
 
-      const data = {
-        windowIsFocused: true,
-        transactions: {
-          pending: [{ id: 12498250891724098 }],
-          confirmed: [],
-          account: { address: accounts.second_passphrase_account.address, balance: 0 },
-        },
-        account: { address: accounts.genesis.address },
-      };
-
-      await accountDataUpdated(data)(dispatch, getState);
+      await accountDataUpdated('active')(dispatch, getState);
       expect(networkActions.networkStatusUpdated).toHaveBeenCalledWith({
         online: false, code,
       });

--- a/src/actions/transactions.js
+++ b/src/actions/transactions.js
@@ -175,7 +175,6 @@ export const transactionBroadcasted = (transaction, callback = () => {}) =>
       data: transaction,
     });
 
-    console.log(transaction);
     if (activeToken !== tokenMap.BTC.key) {
       dispatch(addNewPendingTransaction({
         ...transaction,

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -61,7 +61,7 @@ const App = ({ history }) => {
         <main className={`${styles.bodyWrapper} ${loaded ? styles.loaded : ''}`}>
           <section className="scrollContainer">
             <FlashMessageHolder />
-            <InitializationMessage history={history} />
+            {/* <InitializationMessage history={history} /> */}
             <div className={`${styles.mainContent} ${styles.mainBox}`}>
               <Switch>
                 {

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -13,7 +13,7 @@ import './variables.css';
 import OfflineWrapper from '../components/shared/offlineWrapper';
 import CustomRoute from '../components/shared/customRoute';
 import NotFound from '../components/shared/notFound';
-import InitializationMessage from '../components/shared/initializationMessage';
+// import InitializationMessage from '../components/shared/initializationMessage';
 import routes from '../constants/routes';
 import NavigationBars from '../components/shared/navigationBars';
 import FlashMessageHolder from '../components/toolbox/flashMessage/holder';

--- a/src/components/shared/navigationBars/topBar/index.js
+++ b/src/components/shared/navigationBars/topBar/index.js
@@ -2,8 +2,7 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { withTranslation } from 'react-i18next';
-import { accountLoggedOut, accountUpdated } from '../../../../actions/account';
-import accountConfig from '../../../../constants/account';
+import { accountLoggedOut, passphraseUsed } from '../../../../actions/account';
 import TopBar from './topBar';
 
 const mapStateToProps = state => ({
@@ -18,7 +17,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   logOut: accountLoggedOut,
-  resetTimer: () => accountUpdated({ expireTime: Date.now() + accountConfig.lockDuration }),
+  resetTimer: () => passphraseUsed(new Date()),
 };
 
 export default withRouter(

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -30,7 +30,7 @@ import { getTransactions } from '../../utils/api/transaction';
  */
 const delay = () => new Promise((resolve) => {
   setTimeout(() => {
-    resolve(true);
+    resolve();
   }, 100);
 });
 

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -1,6 +1,5 @@
 import {
   accountDataUpdated,
-  updateEnabledTokenAccount,
 } from '../../actions/account';
 import {
   emptyTransactionsData,
@@ -21,11 +20,19 @@ import transactionTypes from '../../constants/transactionTypes';
 import { tokenMap } from '../../constants/tokens';
 import { getTransactions } from '../../utils/api/transaction';
 
-const updateAccountData = (store) => {
-  const account = getActiveTokenAccount(store.getState());
-
-  store.dispatch(accountDataUpdated({ account }));
-};
+/**
+ * After a new block is created and broadcasted
+ * it takes a few ms for Lisk Service
+ * to update transactions index, so we need to wait
+ * before retrieving the the transaction by blockId
+ *
+ * @returns {Promise} resolves with True after 100ms
+ */
+const delay = () => new Promise((resolve) => {
+  setTimeout(() => {
+    resolve(true);
+  }, 100);
+});
 
 const getRecentTransactionOfType = (transactionsList, type) => (
   transactionsList.filter(transaction => (
@@ -73,6 +80,7 @@ const checkTransactionsAndUpdateAccount = async (store, action) => {
   const { numberOfTransactions, id } = action.data.block;
 
   if (numberOfTransactions) {
+    await delay();
     const { data: txs } = await getTransactions({ network, params: { blockId: id } }, token.active);
     const blockContainsRelevantTransaction = txs.filter((transaction) => {
       if (!transaction) return false;
@@ -87,17 +95,11 @@ const checkTransactionsAndUpdateAccount = async (store, action) => {
       && transactions.confirmed.filter(t => t.confirmations === 1).length > 0;
 
     if (blockContainsRelevantTransaction || recentBtcTransaction) {
-      // it was not getting the account with secondPublicKey right
-      // after a new block with second passphrase registration transaction was received
-      // Adding timeout explained in
-      // https://github.com/LiskHQ/lisk-desktop/pull/1609
-      setTimeout(() => {
-        updateAccountData(store);
-        store.dispatch(transactionsRetrieved({
-          address: account.address,
-          filters: transactions.filters,
-        }));
-      }, 500);
+      store.dispatch(accountDataUpdated());
+      store.dispatch(transactionsRetrieved({
+        address: account.address,
+        filters: transactions.filters,
+      }));
     }
   }
 };

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -142,15 +142,9 @@ const accountMiddleware = store => next => async (action) => {
       store.dispatch(settingsUpdated({ token: { active: tokenMap.LSK.key } }));
       store.dispatch(emptyTransactionsData());
       break;
-    case actionTypes.settingsUpdated: {
-      const tokensList = action.data.token && action.data.token.list;
-      const token = tokensList && Object.keys(tokensList)
-        .find(t => tokensList[t]);
-      if (tokensList && tokensList[token]) {
-        store.dispatch(updateEnabledTokenAccount(token));
-      }
+    case actionTypes.settingsUpdated:
+      store.dispatch(accountDataUpdated('enabled'));
       break;
-    }
     /* istanbul ignore next */
     default: break;
   }

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -100,7 +100,6 @@ describe('Account middleware', () => {
 
   jest.useFakeTimers();
   jest.spyOn(transactionsActions, 'transactionsRetrieved');
-  jest.spyOn(accountActions, 'updateEnabledTokenAccount');
   const accountDataUpdatedSpy = jest.spyOn(accountActions, 'accountDataUpdated');
   window.Notification = () => { };
   const windowNotificationSpy = jest.spyOn(window, 'Notification');
@@ -247,7 +246,7 @@ describe('Account middleware', () => {
         data: { token: { list: { BTC: true } } },
       };
       middleware(store)(next)(settingsUpdatedAction);
-      expect(accountActions.updateEnabledTokenAccount).toHaveBeenCalledWith('BTC');
+      expect(accountActions.accountDataUpdated).toHaveBeenCalledWith('enabled');
       expect(store.dispatch).toHaveBeenCalled();
     });
   });

--- a/src/store/reducers/account.js
+++ b/src/store/reducers/account.js
@@ -12,18 +12,12 @@ const account = (state = {}, action) => {
     case actionTypes.removePassphrase:
       return { ...state, passphrase: null, expireTime: 0 };
     case actionTypes.accountUpdated:
-      return action.data.token ? {
+      return {
         ...state,
         info: {
-          ...(state.info || {}),
-          [action.data.token]: {
-            ...((state.info && state.info[action.data.token]) || {}),
-            ...action.data,
-          },
+          ...state.info,
+          ...action.data,
         },
-      } : {
-        ...state,
-        ...action.data,
       };
     case actionTypes.passphraseUsed:
       return { ...state, expireTime: new Date(action.data.getTime() + accountConfig.lockDuration) };

--- a/src/store/reducers/account.test.js
+++ b/src/store/reducers/account.test.js
@@ -24,17 +24,16 @@ describe('Reducer: account(state, action)', () => {
     const action = {
       type: actionTypes.accountUpdated,
       data: {
-        address: state.address,
-        balance: 100000000,
-        token: 'LSK',
+        LSK: {
+          address: state.address,
+          balance: 100000000,
+        },
       },
     };
     const changedAccount = account(state, action);
     expect(changedAccount).toEqual({
       ...state,
-      info: {
-        LSK: action.data,
-      },
+      info: action.data,
     });
   });
 

--- a/src/utils/getNetwork.test.js
+++ b/src/utils/getNetwork.test.js
@@ -2,6 +2,7 @@ import { constants } from '@liskhq/lisk-client';
 import {
   getNetworksList,
   getNetworkNameBasedOnNethash,
+  getConnectionErrorMessage,
 } from './getNetwork';
 
 describe('Utils: getNetwork', () => {
@@ -53,6 +54,14 @@ describe('Utils: getNetwork', () => {
         },
       };
       expect(getNetworkNameBasedOnNethash(network, 'LSK')).toEqual('customNode');
+    });
+  });
+
+  describe('getConnectionErrorMessage', () => {
+    it('should display the error message if presented', () => {
+      expect(getConnectionErrorMessage({
+        message: 'sample error message',
+      })).toEqual('Unable to connect to the node, Error: sample error message');
     });
   });
 });


### PR DESCRIPTION
### What was the problem?
This PR resolves #3322

### How was it solved?
The API call to retrieve the account and transactions were called/fired too soon. It takes a few ms for Lisk Core to update the tx indexes and I added a delay of 100ms before fetching the information (after receiving new block info).

I had to refactor a few actions to make it work, therefore I had to adapt the account middleware and reducer. 

I also disabled the account initialization banner, since the new address system doesn't have this issue.

### How was it tested?
Unit tests
