### PR TITLE
Hide delegate table filter

### DIFF
--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 import Overview from './overview';
-import { Input } from '../../../toolbox/inputs';
+// import { Input } from '../../../toolbox/inputs';
 import Box from '../../../toolbox/box';
 import BoxHeader from '../../../toolbox/box/header';
 import BoxContent from '../../../toolbox/box/content';
@@ -39,14 +39,14 @@ const DelegatesMonitor = ({
     }
   }, [votes.data]);
 
-  const handleFilter = ({ target: { value } }) => {
+  /* const handleFilter = ({ target: { value } }) => {
     applyFilters({
       ...filters,
       search: value,
       offset: 0,
       limit: 101,
     });
-  };
+  }; */
   const tabs = {
     tabs: [
       {

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -19,7 +19,7 @@ const DelegatesMonitor = ({
   chartRegisteredDelegatesData,
   standByDelegates,
   networkStatus,
-  applyFilters,
+  // applyFilters,
   delegates,
   filters,
   votes,

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -88,7 +88,7 @@ const DelegatesMonitor = ({
             ? <h2>{tabs.tabs[0].name}</h2>
             : <BoxTabs {...tabs} />
           }
-          <span className={activeTab === 'votes' ? 'hidden' : ''}>
+          {/* <span className={activeTab === 'votes' ? 'hidden' : ''}>
             <Input
               onChange={handleFilter}
               value={filters.search}
@@ -96,7 +96,7 @@ const DelegatesMonitor = ({
               size="m"
               placeholder={t('Filter by name...')}
             />
-          </span>
+        </span> */}
         </BoxHeader>
         <BoxContent className={styles.content}>
           {

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -43,7 +43,6 @@ const DelegatesMonitor = ({
     applyFilters({
       ...filters,
       search: value,
-      offset: 0,
     });
   };
   const tabs = {

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -43,6 +43,8 @@ const DelegatesMonitor = ({
     applyFilters({
       ...filters,
       search: value,
+      offset: 0,
+      limit: 101,
     });
   };
   const tabs = {

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -43,6 +43,7 @@ const DelegatesMonitor = ({
     applyFilters({
       ...filters,
       search: value,
+      offset: 0,
     });
   };
   const tabs = {

--- a/src/components/screens/monitor/delegates/delegatesTable/delegateRow.js
+++ b/src/components/screens/monitor/delegates/delegatesTable/delegateRow.js
@@ -44,11 +44,11 @@ const DelegateRow = ({
       <span className={`${grid['col-xs-2']} ${grid['col-md-2']}`}>
         {data.username}
       </span>
-      <span className={data.rank > 101 ? `${grid['col-xs-6']} ${grid['col-md-6']}` : `${grid['col-xs-3']} ${grid['col-md-3']}`}>
+      <span className={data.status !== 'active' ? `${grid['col-xs-6']} ${grid['col-md-6']}` : `${grid['col-xs-3']} ${grid['col-md-3']}`}>
         <AccountVisualWithAddress address={data.address} />
       </span>
       {
-        data.rank <= 101 ? (
+        data.status === 'active' ? (
           <Fragment>
             <span className={`${grid['col-xs-2']} ${grid['col-md-2']} ${styles.noEllipsis}`}>
               {formattedForgingTime}

--- a/src/components/screens/monitor/delegates/delegatesTable/index.js
+++ b/src/components/screens/monitor/delegates/delegatesTable/index.js
@@ -54,7 +54,7 @@ const DelegatesTable = ({
 
   const canLoadMore = activeTab === 'active' || !standByDelegates.meta
     ? false
-    : standByDelegates.data.length < (standByDelegates.meta.total - standByDelegates.meta.offset);
+    : standByDelegates.meta.count + standByDelegates.meta.offset < standByDelegates.meta.total;
 
   delegates = activeTab === 'active'
     ? filterDelegates(delegates, filters)

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -16,7 +16,6 @@ import { tokenMap } from '../../../../constants/tokens';
 const defaultUrlSearchParams = { search: '' };
 const delegatesKey = 'delegates';
 const standByDelegatesKey = 'standByDelegates';
-const numberOfActiveDelegates = 103;
 
 const transformDelegatesResponse = (response, oldData = []) => (
   [...oldData, ...response.data.filter(
@@ -70,7 +69,7 @@ const ComposedDelegates = compose(
           params: {
             ...params,
             limit: params.limit || 30,
-            offset: params.offset || numberOfActiveDelegates,
+            offset: params.offset || 101,
           },
         }),
         defaultData: [],

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -13,7 +13,7 @@ import transactionTypes from '../../../../constants/transactionTypes';
 import { MAX_BLOCKS_FORGED } from '../../../../constants/delegates';
 import { tokenMap } from '../../../../constants/tokens';
 
-const defaultUrlSearchParams = { search: '', offset: 0, limit: 101 };
+const defaultUrlSearchParams = { search: '' };
 const delegatesKey = 'delegates';
 const standByDelegatesKey = 'standByDelegates';
 
@@ -68,7 +68,7 @@ const ComposedDelegates = compose(
           network,
           params: {
             ...params,
-            limit: params.limit || 30,
+            limit: params.limit || 10,
             offset: typeof params.offset !== 'undefined' ? params.offset : 101,
           },
         }),

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -68,7 +68,7 @@ const ComposedDelegates = compose(
           network,
           params: {
             ...params,
-            limit: params.limit || 10,
+            limit: params.limit || 30,
             offset: typeof params.offset !== 'undefined' ? params.offset : 101,
           },
         }),

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -13,7 +13,7 @@ import transactionTypes from '../../../../constants/transactionTypes';
 import { MAX_BLOCKS_FORGED } from '../../../../constants/delegates';
 import { tokenMap } from '../../../../constants/tokens';
 
-const defaultUrlSearchParams = { search: '' };
+const defaultUrlSearchParams = { search: '', offset: 0, limit: 101 };
 const delegatesKey = 'delegates';
 const standByDelegatesKey = 'standByDelegates';
 

--- a/src/components/screens/monitor/delegates/index.js
+++ b/src/components/screens/monitor/delegates/index.js
@@ -69,7 +69,7 @@ const ComposedDelegates = compose(
           params: {
             ...params,
             limit: params.limit || 30,
-            offset: params.offset || 101,
+            offset: typeof params.offset !== 'undefined' ? params.offset : 101,
           },
         }),
         defaultData: [],

--- a/src/utils/withFilters.js
+++ b/src/utils/withFilters.js
@@ -24,7 +24,7 @@ function withFilters(apiName, initialFilters, initialSort) {
         this.setState({ filters: f });
         this.props[apiName].loadData(Object.keys(filters).reduce((acc, key) => ({
           ...acc,
-          ...(filters[key] && { [key]: key === 'type' ? transactionTypes.getByCode(Number(filters[key])).outgoingCode : filters[key] }),
+          ...(typeof filters[key] !== 'undefined' && { [key]: key === 'type' ? transactionTypes.getByCode(Number(filters[key])).outgoingCode : filters[key] }),
         }), {}));
       }
 

--- a/src/utils/withFilters.js
+++ b/src/utils/withFilters.js
@@ -24,7 +24,7 @@ function withFilters(apiName, initialFilters, initialSort) {
         this.setState({ filters: f });
         this.props[apiName].loadData(Object.keys(filters).reduce((acc, key) => ({
           ...acc,
-          ...(typeof filters[key] !== 'undefined' && { [key]: key === 'type' ? transactionTypes.getByCode(Number(filters[key])).outgoingCode : filters[key] }),
+          ...(filters[key] && { [key]: key === 'type' ? transactionTypes.getByCode(Number(filters[key])).outgoingCode : filters[key] }),
         }), {}));
       }
 


### PR DESCRIPTION
### What was the problem?
Delegate table filter was not working as expected. We decided to hide the functionality but to fix what we can regarding it until 'delegate status' parameter is available on API

### How was it solved?
- Remove offset from search api call
- Fix canLoadMore status
- Hide filter

### How was it tested?
Manually
