### PR TITLE
Send correct unix timestamp to API - Closes #3350

### DIFF
--- a/src/utils/api/block/index.js
+++ b/src/utils/api/block/index.js
@@ -63,6 +63,8 @@ const blocksFilters = {
   },
 };
 
+const transformDateToUnixTimestamp = date => new Date(date).valueOf() / 1000;
+
 /**
  * Retrieves blocks list.
  *
@@ -84,6 +86,15 @@ export const getBlocks = ({
 }) => {
   // Use HTTP to retrieve accounts with given sorting and pagination parameters
   const normParams = {};
+
+  if (typeof params.dateFrom === 'string') {
+    params.dateFrom = transformDateToUnixTimestamp(params.dateFrom);
+  }
+
+  if (typeof params.dateTo === 'string') {
+    params.dateTo = transformDateToUnixTimestamp(params.dateTo);
+  }
+
   Object.keys(params).forEach((key) => {
     if (blocksFilters[key].test(params[key])) {
       normParams[blocksFilters[key].key] = params[key];

--- a/src/utils/api/block/index.js
+++ b/src/utils/api/block/index.js
@@ -2,6 +2,7 @@ import { subscribe, unsubscribe } from '../ws';
 import http from '../http';
 import { tokenMap } from '../../../constants/tokens';
 import { validateAddress } from '../../validators';
+import { transformStringDateToUnixTimestamp } from '../../datetime';
 
 const httpPrefix = '/api/v1';
 
@@ -63,8 +64,6 @@ const blocksFilters = {
   },
 };
 
-const transformDateToUnixTimestamp = date => new Date(date).valueOf() / 1000;
-
 /**
  * Retrieves blocks list.
  *
@@ -88,11 +87,11 @@ export const getBlocks = ({
   const normParams = {};
 
   if (typeof params.dateFrom === 'string') {
-    params.dateFrom = transformDateToUnixTimestamp(params.dateFrom);
+    params.dateFrom = transformStringDateToUnixTimestamp(params.dateFrom);
   }
 
   if (typeof params.dateTo === 'string') {
-    params.dateTo = transformDateToUnixTimestamp(params.dateTo);
+    params.dateTo = transformStringDateToUnixTimestamp(params.dateTo);
   }
 
   Object.keys(params).forEach((key) => {

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -49,9 +49,12 @@ export const convertUnixSecondsToLiskEpochSeconds = timestamp => (
   moment(timestamp * 1000).unix() - moment(firstBlockTime).unix()
 );
 
+export const transformStringDateToUnixTimestamp = date => new Date(moment(date, 'DD-MM-YYYY').format('MM/DD/YYYY')).valueOf() / 1000;
+
 export default {
   convertUnixSecondsToLiskEpochSeconds,
   getDateTimestampFromFirstBlock,
   formatInputToDate,
   firstBlockTime,
+  transformStringDateToUnixTimestamp,
 };

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -49,6 +49,11 @@ export const convertUnixSecondsToLiskEpochSeconds = timestamp => (
   moment(timestamp * 1000).unix() - moment(firstBlockTime).unix()
 );
 
+/**
+ * Converts a date in DD-MM-YYYY format to timestamp
+ * @param {String} date - Date in DD-MM-YYYY format
+ * @returns {Number} - Unix timestamp
+ */
 export const transformStringDateToUnixTimestamp = date => new Date(moment(date, 'DD-MM-YYYY').format('MM/DD/YYYY')).valueOf() / 1000;
 
 export default {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3350 
API expects date parameters in unix timestamp but desktop was sending strings in "DD.MM.YYYY" format

### How was it solved?
- Convert date string to timestamp accepted by API

### How was it tested?
Manually
