### PR TITLE
Fix balance graph - Closes #3651

### DIFF
--- a/src/components/screens/wallet/overview/index.js
+++ b/src/components/screens/wallet/overview/index.js
@@ -58,14 +58,16 @@ const Overview = ({
         />
       </div>
       <div className={`${grid['col-xs-12']} ${grid['col-md-6']} ${grid['col-lg-6']} ${styles.balanceChart}`}>
-        <BalanceChart
-          t={t}
-          transactions={transactions}
-          token={activeToken}
-          isDiscreetMode={discreetMode && host === address}
-          balance={balance}
-          address={address}
-        />
+        {address && (
+          <BalanceChart
+            t={t}
+            transactions={transactions}
+            token={activeToken}
+            isDiscreetMode={discreetMode && host === address}
+            balance={balance}
+            address={address}
+          />
+        )}
       </div>
     </section>
   );

--- a/src/utils/datetime.js
+++ b/src/utils/datetime.js
@@ -7,8 +7,7 @@ import { firstBlockTime } from '../constants/datetime';
  * @returns {Number} - timestamp in Unix timestamp format
  */
 export const getUnixTimestampFromValue = value =>
-  ((moment(firstBlockTime).format('x') / 1000) + +moment(value).format('x')) * 1000;
-
+  +moment(value).format('x') * 1000;
 
 /**
  * returns timestamp from first block not considering time

--- a/src/utils/datetime.test.js
+++ b/src/utils/datetime.test.js
@@ -7,7 +7,7 @@ import {
 describe('Datetime', () => {
   describe('getUnixTimestampFromValue', () => {
     it('should return valid unix timestamp', () => {
-      expect(getUnixTimestampFromValue(131302820)).toEqual(1595412020000);
+      expect(getUnixTimestampFromValue(131302820)).toEqual(131302820000);
     });
   });
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #3651

### How was it solved?
- The data calculated had an unnecessary offset. 
- The balance calculation needs the account address and the graph was being rendered too early for the api to have had completed.

### How was it tested?
Visually + unit and e2e tests
