### PR TITLE
Prevent broadcastTransactionsError from stacking the same transaction - Closes #3389

### DIFF
--- a/src/components/screens/register/chooseAvatar.css
+++ b/src/components/screens/register/chooseAvatar.css
@@ -42,6 +42,7 @@
   display: flex;
   margin: 70px 0;
   justify-content: space-between;
+  max-height: fit-content;
   width: 100%;
 
   & div {

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -104,12 +104,14 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
         ...state,
         transactionsCreated: state.transactionsCreated.filter(tx => tx.id !== action.data.id),
         broadcastedTransactionsError: state.broadcastedTransactionsError
-          .map((tx) => {
+          .some(tx => tx.transaction.id === action.data.transaction.id)
+          ? state.broadcastedTransactionsError.map((tx) => {
             if (tx.transaction.id === action.data.transaction.id) {
               return action.data;
             }
             return tx;
-          }),
+          })
+          : [...state.broadcastedTransactionsError, action.data],
       };
     // TODO can be remove after use HOC for send tx
     case actionTypes.resetTransactionResult:

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -104,7 +104,7 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
         ...state,
         transactionsCreated: state.transactionsCreated.filter(tx => tx.id !== action.data.id),
         broadcastedTransactionsError: state.broadcastedTransactionsError
-          .some(tx => tx.transaction.id === action.data.id)
+          .some(tx => tx.transaction.id === action.data.transaction.id)
           ? state.broadcastedTransactionsError
           : [...state.broadcastedTransactionsError, action.data],
       };

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -104,9 +104,12 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
         ...state,
         transactionsCreated: state.transactionsCreated.filter(tx => tx.id !== action.data.id),
         broadcastedTransactionsError: state.broadcastedTransactionsError
-          .some(tx => tx.transaction.id === action.data.transaction.id)
-          ? state.broadcastedTransactionsError
-          : [...state.broadcastedTransactionsError, action.data],
+          .map((tx) => {
+            if (tx.transaction.id === action.data.transaction.id) {
+              return action.data;
+            }
+            return tx;
+          }),
       };
     // TODO can be remove after use HOC for send tx
     case actionTypes.resetTransactionResult:

--- a/src/store/reducers/transactions.test.js
+++ b/src/store/reducers/transactions.test.js
@@ -229,30 +229,29 @@ describe('Reducer: transactions(state, action)', () => {
 
   it('should add broadcastedTransactionsError', () => {
     const networkError = { message: 'network error' };
-    const transaction1 = { id: 111 };
-    const transaction2 = { id: 222 };
     const state = {
       transactionsCreated: [],
       broadcastedTransactionsError: [],
     };
-    const action = {
+    let changedState = transactions(state, {
       type: actionTypes.broadcastedTransactionError,
-      data: { transaction1, networkError },
-    };
-    const action2 = {
-      type: actionTypes.broadcastedTransactionError,
-      data: { transaction2, networkError },
-    };
-    let changedState = transactions(state, action);
-    expect(changedState).toEqual({
-      ...state,
-      broadcastedTransactionsError: [{ networkError, transaction1 }],
+      data: { transaction: mockTransactions[0], error: networkError },
     });
-    changedState = transactions(state, action2);
     expect(changedState).toEqual({
       ...state,
       broadcastedTransactionsError: [
-        { networkError, transaction1 }, { networkError, transaction2 },
+        { error: networkError, transaction: mockTransactions[0] },
+      ],
+    });
+    changedState = transactions(changedState, {
+      type: actionTypes.broadcastedTransactionError,
+      data: { transaction: mockTransactions[1], error: networkError },
+    });
+    expect(changedState).toEqual({
+      ...state,
+      broadcastedTransactionsError: [
+        { error: networkError, transaction: mockTransactions[0] },
+        { error: networkError, transaction: mockTransactions[1] },
       ],
     });
   });
@@ -260,19 +259,18 @@ describe('Reducer: transactions(state, action)', () => {
   it('should not stack the same transaction in broadcastedTransactionsError and should replace it with the latest error', () => {
     const networkError = { message: 'network error' };
     const apiError = { message: 'API error' };
-    const transaction = { id: 111 };
     const state = {
       transactionsCreated: [],
-      broadcastedTransactionsError: [{ networkError, transaction }],
+      broadcastedTransactionsError: [{ error: networkError, transaction: mockTransactions[0] }],
     };
     const action = {
       type: actionTypes.broadcastedTransactionError,
-      data: { transaction, apiError },
+      data: { transaction: mockTransactions[0], error: apiError },
     };
     const changedState = transactions(state, action);
     expect(changedState).toEqual({
       ...state,
-      broadcastedTransactionsError: [{ apiError, transaction }],
+      broadcastedTransactionsError: [{ error: apiError, transaction: mockTransactions[0] }],
     });
   });
 

--- a/src/store/reducers/transactions.test.js
+++ b/src/store/reducers/transactions.test.js
@@ -227,7 +227,35 @@ describe('Reducer: transactions(state, action)', () => {
     expect(changedState.transactionsCreatedFailed).toEqual([]);
   });
 
-  it.only('should not stack the same transaction in broadcastedTransactionsError', () => {
+  it('should add broadcastedTransactionsError', () => {
+    const networkError = { message: 'network error' };
+    const transaction1 = { id: 111 };
+    const transaction2 = { id: 222 };
+    const state = {
+      transactionsCreated: [],
+      broadcastedTransactionsError: [],
+    };
+    const action = {
+      type: actionTypes.broadcastedTransactionError,
+      data: { transaction1, networkError },
+    };
+    const action2 = {
+      type: actionTypes.broadcastedTransactionError,
+      data: { transaction2, networkError },
+    };
+    let changedState = transactions(state, action);
+    expect(changedState).toEqual({
+      ...state,
+      broadcastedTransactionsError: [{ networkError, transaction1 }],
+    });
+    changedState = transactions(state, action2);
+    expect(changedState).toEqual({
+      ...state,
+      broadcastedTransactionsError: [{ networkError, transaction1 }, { networkError, transaction2 }],
+    });
+  });
+
+  it('should not stack the same transaction in broadcastedTransactionsError', () => {
     const networkError = { message: 'network error' };
     const apiError = { message: 'API error' };
     const transaction = { id: 111 };

--- a/src/store/reducers/transactions.test.js
+++ b/src/store/reducers/transactions.test.js
@@ -251,11 +251,13 @@ describe('Reducer: transactions(state, action)', () => {
     changedState = transactions(state, action2);
     expect(changedState).toEqual({
       ...state,
-      broadcastedTransactionsError: [{ networkError, transaction1 }, { networkError, transaction2 }],
+      broadcastedTransactionsError: [
+        { networkError, transaction1 }, { networkError, transaction2 },
+      ],
     });
   });
 
-  it('should not stack the same transaction in broadcastedTransactionsError', () => {
+  it('should not stack the same transaction in broadcastedTransactionsError and should replace it with the latest error', () => {
     const networkError = { message: 'network error' };
     const apiError = { message: 'API error' };
     const transaction = { id: 111 };

--- a/src/store/reducers/transactions.test.js
+++ b/src/store/reducers/transactions.test.js
@@ -227,6 +227,21 @@ describe('Reducer: transactions(state, action)', () => {
     expect(changedState.transactionsCreatedFailed).toEqual([]);
   });
 
+  it.only('should not stack the same transaction in broadcastedTransactionsError', () => {
+    const error = { message: 'test' };
+    const transaction = { id: 111 };
+    const state = {
+      transactionsCreated: [],
+      broadcastedTransactionsError: [{ error, transaction }],
+    };
+    const action = {
+      type: actionTypes.broadcastedTransactionError,
+      data: { transaction, error },
+    };
+    const changedState = transactions(state, action);
+    expect(changedState).toEqual(state);
+  });
+
   // it('Should update transactions reducer for TransactionCreatedSuccess on RETRY', () => {
   //   const tx = {
   //     id: '12312334',

--- a/src/store/reducers/transactions.test.js
+++ b/src/store/reducers/transactions.test.js
@@ -228,18 +228,22 @@ describe('Reducer: transactions(state, action)', () => {
   });
 
   it.only('should not stack the same transaction in broadcastedTransactionsError', () => {
-    const error = { message: 'test' };
+    const networkError = { message: 'network error' };
+    const apiError = { message: 'API error' };
     const transaction = { id: 111 };
     const state = {
       transactionsCreated: [],
-      broadcastedTransactionsError: [{ error, transaction }],
+      broadcastedTransactionsError: [{ networkError, transaction }],
     };
     const action = {
       type: actionTypes.broadcastedTransactionError,
-      data: { transaction, error },
+      data: { transaction, apiError },
     };
     const changedState = transactions(state, action);
-    expect(changedState).toEqual(state);
+    expect(changedState).toEqual({
+      ...state,
+      broadcastedTransactionsError: [{ apiError, transaction }],
+    });
   });
 
   // it('Should update transactions reducer for TransactionCreatedSuccess on RETRY', () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3389 

### How was it solved?
`tx => tx.transaction.id === action.data.id` condition was always false as the structure of data is `data: { error: {...}, transaction: {...}` that was causing the same transaction to be stacked at broadcastTransactionsError, which was the reason of the bug behaviour of the transaction status modal.

### How was it tested?
Add unit test
