### PR TITLE
Add balance reclaim transaction support - Closes #3471

### DIFF
--- a/src/constants/moduleAssets.js
+++ b/src/constants/moduleAssets.js
@@ -2,6 +2,7 @@ const modules = {
   token: 2,
   dpos: 5,
   multiSignature: 4,
+  legacyAccount: 1000,
 };
 
 const assets = {
@@ -10,6 +11,7 @@ const assets = {
   voteDelegate: 1,
   unlockToken: 2,
   registerMultisignatureGroup: 0,
+  reclaimLSK: 0,
 };
 
 const moduleAssetNameIdMap = {
@@ -18,6 +20,7 @@ const moduleAssetNameIdMap = {
   voteDelegate: `${modules.dpos}:${assets.voteDelegate}`,
   registerDelegate: `${modules.dpos}:${assets.registerDelegate}`,
   registerMultisignatureGroup: `${modules.multiSignature}:${assets.registerMultisignatureGroup}`,
+  reclaimLSK: `${modules.legacyAccount}:${assets.reclaimLSK}`,
 };
 
 const moduleAssetMap = {
@@ -40,6 +43,10 @@ const moduleAssetMap = {
   [moduleAssetNameIdMap.registerMultisignatureGroup]: {
     maxFee: 5e8,
     icon: 'registerMultisignatureGroup',
+  },
+  [moduleAssetNameIdMap.reclaimLSK]: {
+    maxFee: 1e7,
+    icon: 'txDefault',
   },
 };
 

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -103,24 +103,24 @@ export const getAccount = async ({
 
   return {
     summary: {
-      address: '02a1de92405edeaac13913bd089b07eb73cbd762',
-      legacyAddress: '2841524825665420181L',
+      address: 'lskdxc4ta5j43jp9ro3f8zqbxta9fn6jwzjucw7yt',
+      legacyAddress: '5059876081639179984L',
       balance: '0', // balance in the new blockchain
       isMigrated: true, // shows only when found by the public key
       // true = account is migrated from the legacy blockchain
       // false = account is created in the current blockchain
-      publicKey: '968ba2fa993ea9dc27ed740da0daf49eddd740dbd7cb1cb4fc5db3a20baf341b',
+      publicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
       isDelegate: false,
       isMultisignature: false,
     },
     token: {
       balance: '0', // balance in the new blockchain
     },
-    sequence: { nonce: 1 },
+    sequence: { nonce: 38 },
     keys: {},
     dpos: { },
     legacy: { // only if the reclaim wasn't made yet
-      address: '2841524825665420181L', // Legacy address in hex format
+      address: '5059876081639179984L', // Legacy address in hex format
       balance: '151146419900', // balance to reclaim
     },
   };

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -6,7 +6,7 @@ import { extractAddressFromPublicKey, getBase32AddressFromAddress, getAddressFro
 import { splitModuleAndAssetIds } from '@utils/moduleAssets';
 
 const {
-  transfer, voteDelegate, registerDelegate, unlockToken,
+  transfer, voteDelegate, registerDelegate, unlockToken, reclaimLSK,
 } = MODULE_ASSETS_NAME_ID_MAP;
 /**
  * Gets the amount of a given transaction
@@ -70,6 +70,13 @@ const transformTransaction = (transaction) => {
           amount: Number(vote.amount),
           delegateAddress: getBase32AddressFromAddress(vote.delegateAddress),
         })),
+      };
+      break;
+    }
+
+    case reclaimLSK: {
+      transformedTransaction.asset = {
+        amount: String(transaction.asset.amount),
       };
       break;
     }

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -76,7 +76,7 @@ const transformTransaction = (transaction) => {
 
     case reclaimLSK: {
       transformedTransaction.asset = {
-        amount: String(transaction.asset.amount),
+        amount: transaction.asset.amount,
       };
       break;
     }
@@ -158,6 +158,13 @@ const createTransactionObject = (tx, moduleAssetId) => {
     case unlockToken: {
       transaction.asset = {
         unlockObjects: tx.unlockObjects,
+      };
+      break;
+    }
+
+    case reclaimLSK: {
+      transaction.asset = {
+        amount: BigInt(amount),
       };
       break;
     }

--- a/src/utils/transaction.test.js
+++ b/src/utils/transaction.test.js
@@ -161,5 +161,39 @@ describe('API: LSK Transactions', () => {
 
       expect(transformTransaction(tx)).toMatchObject(expectedTransaction);
     });
+
+    it('should transform a reclaimLSK transaction', () => {
+      const [moduleID, assetID] = splitModuleAndAssetIds(
+        MODULE_ASSETS_NAME_ID_MAP.reclaimLSK,
+      );
+      const tx = {
+        moduleID,
+        assetID,
+        fee: 0.1,
+        nonce: 1,
+        id: Buffer.from('123', 'hex'),
+        senderPublicKey: accounts.genesis.summary.publicKey,
+        asset: {
+          amount: '100',
+        },
+      };
+
+      const expectedTransaction = {
+        id: '12',
+        moduleAssetId: '1000:0',
+        fee: '0.1',
+        nonce: '1',
+        sender: {
+          publicKey: '0fe9a3f1a21b5530f27f87a414b549e79a940bf24fdf2b2f05e7f22aeeecc86a',
+          address: 'lskdxc4ta5j43jp9ro3f8zqbxta9fn6jwzjucw7yt',
+        },
+        signatures: undefined,
+        asset: {
+          amount: '100',
+        },
+      };
+
+      expect(transformTransaction(tx)).toMatchObject(expectedTransaction);
+    });
   });
 });


### PR DESCRIPTION
### What was the problem?
This PR resolves #3471

### How was it solved?
- [x] Add the new type to `moduleAssets` file.
- [x] Support the new transactions fee calculation
- [x] Broadcast the new transaction type -> broadcast it successful. The error I receive is "There's no corresponding legacy account" which is expected.

Since the tx doesn't go though, I can't check:
- After confirmed, the wallet should update account balance:
- Remove the `legacy.balance` value form the stored account.

### How was it tested?
- Added unit test
- I've created a view to test the tx, once approved, I'll revert [this](https://github.com/LiskHQ/lisk-desktop/pull/3482/commits/6cd927db5dcdadd83ec7ee790466ad3c836a6eeb) commit.
