### PR TITLE
Determine non migrated accounts and redirect them to reclaim screen - Closes #3473

### DIFF
--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -119,8 +119,9 @@ export default {
     isPrivate: false,
     forbiddenTokens: [tokenMap.BTC.key],
   },
-  initialization: {
-    path: '/initialization',
+  reclaim: {
+    path: '/reclaim',
+    // @todo import the reclaim screen here
     component: Initialization,
     isPrivate: true,
     forbiddenTokens: [],

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -122,32 +122,12 @@ const autoLogInIfNecessary = async ({ dispatch, getState }) => {
   }
 };
 
-// eslint-disable-next-line max-statements
 const checkAccountInitializationState = (action) => {
-  const search = window.location.href.split('?')[1];
-
-  const initialization = selectSearchParamValue(search, 'initialization');
-  let serverPublicKey = '';
-  let balance = 0;
-  // let redirectUrl = '';
-
   if (action.type === actionTypes.accountLoggedIn) {
-    serverPublicKey = action.data.info.LSK.serverPublicKey;
-    balance = action.data.info.LSK.balance;
-    // redirectUrl = routes.initialization.path;
-  } else if (action.type === actionTypes.accountUpdated) {
-    serverPublicKey = action.data.serverPublicKey;
-    balance = action.data.balance;
-    // redirectUrl = `${routes.wallet.path}?modal=send&initialization=true`;
-  }
-
-  if (serverPublicKey) {
-    if (initialization) {
-      history.push(routes.wallet.path);
-      removeSearchParamsFromUrl(history, ['modal', 'initialization']);
+    const { isMigrated } = action.data.info.LSK.summary;
+    if (isMigrated === false) { // we need to check against false, check against falsy won't work
+      history.push(routes.initialization.path);
     }
-  } else if (hasEnoughBalanceForInitialization(balance)) {
-    // history.push(redirectUrl);
   }
 };
 

--- a/src/store/middlewares/account.js
+++ b/src/store/middlewares/account.js
@@ -2,13 +2,12 @@ import {
   networks, actionTypes, networkKeys, settings, MODULE_ASSETS_NAME_ID_MAP, tokenMap, routes,
 } from '@constants';
 import { fromRawLsk } from '@utils/lsk';
-import { getActiveTokenAccount, hasEnoughBalanceForInitialization } from '@utils/account';
+import { getActiveTokenAccount } from '@utils/account';
 import { getAutoLogInData } from '@utils/login';
 import {
   settingsUpdated, networkSelected, networkStatusUpdated, accountDataUpdated,
   emptyTransactionsData, transactionsRetrieved, votesRetrieved,
 } from '@actions';
-import { removeSearchParamsFromUrl, selectSearchParamValue } from '@utils/searchParams';
 import analytics from '@utils/analytics';
 import { getTransactions } from '@api/transaction';
 import i18n from '../../i18n';

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -303,24 +303,22 @@ describe('Account middleware', () => {
       expect(history.push).not.toHaveBeenCalledWith('initialization');
     });
 
-    it.skip('should redirect to the initialization screen if uninitialsed account logs in with enough balance', () => {
+    it('should not redirect to the reclaim screen if the account is migrated', () => {
       const action = {
         type: actionTypes.accountLoggedIn,
-        data: { info: { LSK: { serverPublicKey: '', balance: '2e8' } } },
+        data: { info: { LSK: { summary: { isMigrated: true } } } },
+      };
+      middleware(store)(next)(action);
+      expect(history.push).not.toHaveBeenCalledWith(routes.initialization.path);
+    });
+
+    it('should redirect to the reclaim screen if the account is not migrated', () => {
+      const action = {
+        type: actionTypes.accountLoggedIn,
+        data: { info: { LSK: { summary: { isMigrated: false } } } },
       };
       middleware(store)(next)(action);
       expect(history.push).toHaveBeenCalledWith(routes.initialization.path);
-    });
-
-    it.skip('should call the modal remove function if actionTypes.accountUpdated is called with enough balance', () => {
-      const action = {
-        type: actionTypes.accountUpdated,
-        data: { serverPublicKey: 'some_key', balance: '2e8' },
-      };
-      middleware(store)(next)(action);
-      expect(addSearchParamsToUrl).not.toHaveBeenCalled();
-      expect(removeSearchParamsFromUrl).toHaveBeenCalled();
-      expect(history.push).toHaveBeenCalledWith(routes.wallet.path);
     });
   });
 });

--- a/src/store/middlewares/account.test.js
+++ b/src/store/middlewares/account.test.js
@@ -7,17 +7,7 @@ import {
 } from '@constants';
 import middleware from './account';
 import * as transactionApi from '@api/transaction';
-import {
-  addSearchParamsToUrl,
-  removeSearchParamsFromUrl,
-} from '../../utils/searchParams';
 import history from '../../history';
-
-jest.mock('../../utils/searchParams', () => ({
-  selectSearchParamValue: jest.fn(() => ({ initialization: true })),
-  removeSearchParamsFromUrl: jest.fn(),
-  addSearchParamsToUrl: jest.fn(),
-}));
 
 jest.mock('../../history');
 
@@ -32,7 +22,6 @@ jest.mock('@actions', () => ({
   votesRetrieved: jest.fn(),
   emptyTransactionsData: jest.fn(),
 }));
-
 
 const liskAPIClientMock = 'DUMMY_LISK_API_CLIENT';
 const storeCreatedAction = {

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -106,7 +106,7 @@ export const getAccount = async ({
       address: '02a1de92405edeaac13913bd089b07eb73cbd762',
       legacyAddress: '2841524825665420181L',
       balance: '0', // balance in the new blockchain
-      isMigrated: true, // shows only when found by the public key
+      isMigrated: false, // shows only when found by the public key
       // true = account is migrated from the legacy blockchain
       // false = account is created in the current blockchain
       publicKey: '968ba2fa993ea9dc27ed740da0daf49eddd740dbd7cb1cb4fc5db3a20baf341b',


### PR DESCRIPTION
### What was the problem?
This PR resolves #3473

### How was it solved?
- Redirect non-migrated account to the `/recalim` route
- Update unit tests

### How was it tested?
Unit test + Manually
