### PR TITLE
Handle 404 and other errors for the accounts api better - Closes #3487

### DIFF
--- a/src/constants/httpCodes.js
+++ b/src/constants/httpCodes.js
@@ -1,0 +1,7 @@
+const HTTP_CODES = {
+  SUCCESS: 200,
+  NOT_FOUND: 404,
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { HTTP_CODES };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -19,3 +19,4 @@ export { default as externalLinks } from './externalLinks';
 export { default as feedbackLinks } from './feedbackLinks';
 export { default as routes, modals } from './routes';
 export { default as regex } from './regex';
+export * from './httpCodes';

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -1,4 +1,4 @@
-import { tokenMap, regex } from '@constants';
+import { HTTP_CODES, tokenMap, regex } from '@constants';
 import http from '../http';
 import ws from '../ws';
 import { isEmpty } from '../../helpers';
@@ -66,7 +66,7 @@ const getAccountParams = (params) => {
  *
  * @returns {Promise}
  */
-// eslint-disable-next-line max-statements
+// eslint-disable-next-line complexity, max-statements
 export const getAccount = async ({
   network, params, baseUrl,
 }) => {
@@ -87,27 +87,29 @@ export const getAccount = async ({
         const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
         account.summary.publicKey = publicKey;
       }
-
       return account;
     }
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.log('Lisk account not found.');
+    if (e.code === HTTP_CODES.NOT_FOUND) {
+      // eslint-disable-next-line no-console
+      console.log('Lisk account not found.');
 
-    if (params.publicKey || params.passphrase) {
-      const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
-      const account = {
-        summary: {
-          publicKey,
-          balance: 0,
-          address: normParams.address,
-          token: tokenMap.LSK.key,
-        },
-      };
-      return account;
+      if (params.publicKey || params.passphrase) {
+        const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
+        const account = {
+          summary: {
+            publicKey,
+            balance: 0,
+            address: normParams.address,
+            token: tokenMap.LSK.key,
+          },
+        };
+        return account;
+      }
+    } else {
+      throw Error();
     }
   }
-
   throw Error('Error retrieving account');
 };
 

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -83,7 +83,7 @@ export const getAccount = async ({
     if (response.data[0]) {
       const account = { ...response.data[0] };
       const isAccountUninitialized = !account.summary.publicKey;
-      if (isAccountUninitialized) {
+      if (isAccountUninitialized && (params.publicKey || params.passphrase)) {
         const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
         account.summary.publicKey = publicKey;
       }
@@ -94,17 +94,18 @@ export const getAccount = async ({
     // eslint-disable-next-line no-console
     console.log('Lisk account not found.');
 
-    const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
-    const account = {
-      summary: {
-        publicKey,
-        balance: 0,
-        address: normParams.address,
-        token: tokenMap.LSK.key,
-      },
-    };
-
-    return account;
+    if (params.publicKey || params.passphrase) {
+      const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
+      const account = {
+        summary: {
+          publicKey,
+          balance: 0,
+          address: normParams.address,
+          token: tokenMap.LSK.key,
+        },
+      };
+      return account;
+    }
   }
 
   throw Error('Error retrieving account');

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -82,7 +82,7 @@ export const getAccount = async ({
 
     if (response.data[0]) {
       const account = { ...response.data[0] };
-      const isAccountUninitialized = !account.summary?.publicKey;
+      const isAccountUninitialized = !account.summary.publicKey;
       if (isAccountUninitialized) {
         const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
         account.summary.publicKey = publicKey;

--- a/src/utils/api/account/lsk.js
+++ b/src/utils/api/account/lsk.js
@@ -36,6 +36,7 @@ const getAccountParams = (params) => {
     passphrase,
     publicKey,
   } = params;
+
   // Pick username, cause the address is not obtainable from the username
   if (username) return { username };
   // If you have the address, you don't need anything else
@@ -49,17 +50,6 @@ const getAccountParams = (params) => {
   }
   // if none of the above, ignore the params
   return {};
-};
-
-/* istanbul ignore next */
-const getPublicKey = (address, passphrase) => {
-  if (address) {
-    return extractAddressFromPublicKey(address);
-  }
-  if (passphrase) {
-    return extractPublicKey(passphrase);
-  }
-  throw Error('Can not convert undefined to public key');
 };
 
 /**
@@ -92,9 +82,9 @@ export const getAccount = async ({
 
     if (response.data[0]) {
       const account = { ...response.data[0] };
-      const isAccountUninitialized = !account.summary.publicKey;
+      const isAccountUninitialized = !account.summary?.publicKey;
       if (isAccountUninitialized) {
-        const publicKey = params.publicKey ?? getPublicKey(params.address, params.passphrase);
+        const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
         account.summary.publicKey = publicKey;
       }
 
@@ -104,7 +94,7 @@ export const getAccount = async ({
     // eslint-disable-next-line no-console
     console.log('Lisk account not found.');
 
-    const publicKey = params.publicKey ?? getPublicKey(params.address, params.passphrase);
+    const publicKey = params.publicKey ?? extractPublicKey(params.passphrase);
     const account = {
       summary: {
         publicKey,

--- a/src/utils/api/account/lsk.test.js
+++ b/src/utils/api/account/lsk.test.js
@@ -159,12 +159,12 @@ describe('API: LSK Account', () => {
       // Checks with no baseUrl
       await getAccount({
         network,
-        params: { },
+        params: { address: 'lsk123' },
       });
 
       expect(http).toHaveBeenCalledWith({
         network,
-        params: { },
+        params: { address: 'lsk123' },
         baseUrl: undefined,
         path,
       });

--- a/src/utils/api/account/lsk.test.js
+++ b/src/utils/api/account/lsk.test.js
@@ -1,3 +1,4 @@
+import { HTTP_CODES } from '@constants';
 import http from '../http';
 import ws from '../ws';
 import { getAccount, getAccounts } from './lsk';
@@ -95,7 +96,7 @@ describe('API: LSK Account', () => {
     } = accounts.delegate;
 
     it('should call http with right params, prioritizing 1. username', async () => {
-      http.mockImplementation(() => Promise.resolve({ data: [{}] }));
+      http.mockImplementation(() => Promise.resolve({ data: [{ summary: { publicKey } }] }));
       // Checks the baseUrl too
       await getAccount({
         network,
@@ -117,7 +118,7 @@ describe('API: LSK Account', () => {
     });
 
     it('should call http with right params, prioritizing 2. address', async () => {
-      http.mockImplementation(() => Promise.resolve({ data: [{}] }));
+      http.mockImplementation(() => Promise.resolve({ data: [{ summary: { publicKey } }] }));
       // Checks with no baseUrl
       await getAccount({
         network,
@@ -137,7 +138,7 @@ describe('API: LSK Account', () => {
     });
 
     it('should call http with right address, if publicKey passed', async () => {
-      http.mockImplementation(() => Promise.resolve({ data: [{}] }));
+      http.mockImplementation(() => Promise.resolve({ data: [{ summary: { publicKey } }] }));
       // Checks with no baseUrl
       await getAccount({
         network,
@@ -155,7 +156,7 @@ describe('API: LSK Account', () => {
     });
 
     it('should call http without base url if not passed', async () => {
-      http.mockImplementation(() => Promise.resolve({ data: [{}] }));
+      http.mockImplementation(() => Promise.resolve({ data: [{ summary: { publicKey } }] }));
       // Checks with no baseUrl
       await getAccount({
         network,
@@ -171,7 +172,7 @@ describe('API: LSK Account', () => {
     });
 
     it('should call http with right address, if passphrase passed', async () => {
-      http.mockImplementation(() => Promise.resolve({ data: [{}] }));
+      http.mockImplementation(() => Promise.resolve({ data: [{ summary: { publicKey } }] }));
       // Checks the baseUrl too
       await getAccount({
         network,
@@ -190,7 +191,9 @@ describe('API: LSK Account', () => {
     });
 
     it('should return an account if the API returns 404', async () => {
-      http.mockImplementation(() => Promise.reject(Error('Account not found.')));
+      const error = Error('Account not found.');
+      error.code = HTTP_CODES.NOT_FOUND;
+      http.mockImplementation(() => Promise.reject(error));
       // Checks the baseUrl too
       const result = await getAccount({
         network,

--- a/src/utils/api/account/lsk.test.js
+++ b/src/utils/api/account/lsk.test.js
@@ -154,17 +154,17 @@ describe('API: LSK Account', () => {
       });
     });
 
-    it('should call http without parameters', async () => {
+    it('should call http without base url if not passed', async () => {
       http.mockImplementation(() => Promise.resolve({ data: [{}] }));
       // Checks with no baseUrl
       await getAccount({
         network,
-        params: { address: 'lsk123' },
+        params: { passphrase },
       });
 
       expect(http).toHaveBeenCalledWith({
         network,
-        params: { address: 'lsk123' },
+        params: { address },
         baseUrl: undefined,
         path,
       });

--- a/src/utils/api/account/lsk.test.js
+++ b/src/utils/api/account/lsk.test.js
@@ -209,5 +209,59 @@ describe('API: LSK Account', () => {
         },
       });
     });
+
+    it('should use the public key from params if the account is uninitialized', async () => {
+      http.mockImplementation(() => Promise.resolve({
+        data: [{
+          summary: {
+            publicKey: '', address, balance: 0, token: 'LSK',
+          },
+        }],
+      }));
+      // Checks the baseUrl too
+      const result = await getAccount({
+        network,
+        params: {
+          publicKey,
+        },
+        baseUrl,
+      });
+
+      expect(result).toEqual({
+        summary: {
+          address,
+          balance: 0,
+          token: 'LSK',
+          publicKey,
+        },
+      });
+    });
+
+    it('should use extract the public key from params.passphrase if the account is uninitialized', async () => {
+      http.mockImplementation(() => Promise.resolve({
+        data: [{
+          summary: {
+            publicKey: '', address, balance: 0, token: 'LSK',
+          },
+        }],
+      }));
+      // Checks the baseUrl too
+      const result = await getAccount({
+        network,
+        params: {
+          passphrase,
+        },
+        baseUrl,
+      });
+
+      expect(result).toEqual({
+        summary: {
+          address,
+          balance: 0,
+          token: 'LSK',
+          publicKey,
+        },
+      });
+    });
   });
 });

--- a/src/utils/api/http.js
+++ b/src/utils/api/http.js
@@ -29,7 +29,11 @@ const http = ({
       ...restOptions,
     })
       .then((response) => {
-        if (!response.ok) throw Error(response.statusText);
+        if (!response.ok) {
+          const error = Error(response.statusText);
+          error.code = response.status;
+          throw error;
+        }
         return response.json();
       });
   } catch (e) {

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -76,11 +76,11 @@ const transformTransaction = (transaction) => {
 
     case unlockToken: {
       transformedTransaction.asset = {
-        // unlockObjects: transaction.unlockObjects.map(unlockingObject => ({
-        //   delegateAddress: unlockingObject.delegateAddress,
-        //   amount: unlockingObject.amount,
-        //   unvoteHeight: unlockingObject.height.start
-        // })),
+        unlockObjects: transaction.asset.unlockObjects.map(unlockingObject => ({
+          delegateAddress: getBase32AddressFromAddress(unlockingObject.delegateAddress),
+          amount: Number(unlockingObject.amount),
+          unvoteHeight: unlockingObject.height.start,
+        })),
       };
       break;
     }
@@ -150,7 +150,11 @@ const createTransactionObject = (tx, moduleAssetId) => {
 
     case unlockToken: {
       transaction.asset = {
-        unlockObjects: tx.unlockObjects,
+        unlockObjects: tx.unlockingObjects.map(unlockingObject => ({
+          amount: BigInt(unlockingObject.amount),
+          delegateAddress: getAddressFromBase32Address(unlockingObject.delegateAddress),
+          unvoteHeight: unlockingObject.unvoteHeight,
+        })),
       };
       break;
     }


### PR DESCRIPTION
### What was the problem?
This PR resolves #3487

### How was it solved?
- Add http status to the error thrown
- Return empty account only when we get 404
- Add a constants file for http error codes

### How was it tested?
Manually