### PR TITLE
Do not navigate to the unlock page if there's nothing to unlock - Closes #3529

### DIFF
--- a/src/components/screens/lockedBalance/lockedBalance/form.js
+++ b/src/components/screens/lockedBalance/lockedBalance/form.js
@@ -58,8 +58,9 @@ const Form = ({
     const [error, tx] = await to(
       create({
         ...txData,
-        transactionType: MODULE_ASSETS_NAME_ID_MAP.unlockToken,
+        moduleAssetId: MODULE_ASSETS_NAME_ID_MAP.unlockToken,
         network,
+        senderPublicKey: account.summary?.publicKey,
       }, tokenMap.LSK.key),
     );
 

--- a/src/components/screens/wallet/overview/balanceInfo/balanceInfo.css
+++ b/src/components/screens/wallet/overview/balanceInfo/balanceInfo.css
@@ -100,7 +100,10 @@
   @mixin headingNormal normal;
 
   color: var(--color-ink-blue);
-  cursor: pointer;
+
+  &.pointer {
+    cursor: pointer;
+  }
 
   & > img {
     width: 17px;

--- a/src/components/screens/wallet/overview/balanceInfo/index.js
+++ b/src/components/screens/wallet/overview/balanceInfo/index.js
@@ -2,44 +2,17 @@ import React from 'react';
 import { withTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
 
-import { tokenMap } from '@constants';
 import { fromRawLsk } from '@utils/lsk';
-import {
-  calculateBalanceLockedInUnvotes,
-  calculateBalanceLockedInVotes,
-  getActiveTokenAccount,
-} from '@utils/account';
 import { PrimaryButton, SecondaryButton } from '@toolbox/buttons';
 import Box from '@toolbox/box';
 import BoxContent from '@toolbox/box/content';
 import DialogLink from '@toolbox/dialog/link';
-import Icon from '@toolbox/icon';
-import LiskAmount from '../../../../shared/liskAmount';
-import DiscreetMode from '../../../../shared/discreetMode';
-import Converter from '../../../../shared/converter';
+import LiskAmount from '@shared/liskAmount';
+import DiscreetMode from '@shared/discreetMode';
+import Converter from '@shared/converter';
+import SignInTooltipWrapper from '@shared/signInTooltipWrapper';
+import LockedBalanceLink from './unlocking';
 import styles from './balanceInfo.css';
-import SignInTooltipWrapper from '../../../../shared/signInTooltipWrapper';
-
-const LockedBalanceLink = ({ activeToken, isWalletRoute }) => {
-  const host = useSelector(state => getActiveTokenAccount(state));
-  const lockedInVotes = useSelector(state => calculateBalanceLockedInVotes(state.voting));
-  const lockedInUnvotes = activeToken === tokenMap.LSK.key && isWalletRoute && host
-    ? calculateBalanceLockedInUnvotes(host.dpos?.unlocking) : undefined;
-
-  if (lockedInUnvotes + lockedInVotes > 0) {
-    return (
-      <DialogLink
-        className={`${styles.lockedBalance} open-unlock-balance-dialog`}
-        component="lockedBalance"
-      >
-        <Icon name="lock" />
-        {`${fromRawLsk(lockedInUnvotes + lockedInVotes)} ${tokenMap.LSK.key}`}
-      </DialogLink>
-    );
-  }
-
-  return null;
-};
 
 const BalanceInfo = ({
   t, activeToken, balance, isWalletRoute, address, username,

--- a/src/components/screens/wallet/overview/balanceInfo/unlocking.js
+++ b/src/components/screens/wallet/overview/balanceInfo/unlocking.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+
+import { tokenMap } from '@constants';
+import { fromRawLsk } from '@utils/lsk';
+import DialogLink from '@toolbox/dialog/link';
+import {
+  calculateBalanceLockedInUnvotes,
+  calculateBalanceLockedInVotes,
+  getActiveTokenAccount,
+} from '@utils/account';
+import Icon from '@toolbox/icon';
+import styles from './balanceInfo.css';
+
+const Link = ({ sum }) => (
+  <DialogLink
+    className={`${styles.lockedBalance} ${styles.pointer} open-unlock-balance-dialog`}
+    component="lockedBalance"
+  >
+    <Icon name="lock" />
+    {`${fromRawLsk(sum)} ${tokenMap.LSK.key}`}
+  </DialogLink>
+);
+
+const Text = ({ sum }) => (
+  <span
+    className={`${styles.lockedBalance} open-unlock-balance-dialog`}
+    component="lockedBalance"
+  >
+    <Icon name="lock" />
+    {`${fromRawLsk(sum)} ${tokenMap.LSK.key}`}
+  </span>
+);
+
+const LockedBalanceLink = ({ activeToken, isWalletRoute }) => {
+  const host = useSelector(state => getActiveTokenAccount(state));
+  const lockedInVotes = useSelector(state => calculateBalanceLockedInVotes(state.voting));
+  const lockedInUnvotes = activeToken === tokenMap.LSK.key && isWalletRoute && host
+    ? calculateBalanceLockedInUnvotes(host.dpos?.unlocking) : undefined;
+
+  if (lockedInUnvotes > 0) {
+    return (
+      <Link sum={lockedInUnvotes + lockedInVotes} />
+    );
+  }
+  if (lockedInVotes > 0) {
+    return (
+      <Text sum={lockedInVotes} />
+    );
+  }
+  return null;
+};
+
+export default LockedBalanceLink;


### PR DESCRIPTION
### What was the problem?
This PR resolves #3529

### How was it solved?
- Prevented the app from navigating to the unlocking screen if there's nothing to unlock.

### How was it tested?
Visually.
