### PR TITLE
Automatically connect to Mainnet if network switcher is not activated - Closes #3546

### DIFF
--- a/src/components/screens/login/networkSelector/networkSelector.js
+++ b/src/components/screens/login/networkSelector/networkSelector.js
@@ -164,14 +164,15 @@ class NetworkSelector extends React.Component {
             validationError: '',
             connected: true,
             networkLabel: newNetwork.name,
-            address: network !== networks.customNode.code ? '' : address,
+            address: network !== networks.customNode.code ? '' : nodeURL,
+            isValidationLoading: false,
+            isFirstTime: false,
           });
           if (network === networks.customNode.code && this.childRef.state.shownDropdown) {
             this.childRef.toggleDropdown();
           }
           this.props.networkStatusUpdated({ online: true });
           this.changeNetwork(networks.customNode.code);
-          this.setState({ isValidationLoading: false, isFirstTime: false });
           this.props.history.push(nextPath);
         } else {
           throw new Error();


### PR DESCRIPTION
### What was the problem?
This PR resolves #3546

### How was it solved?
I default to mainnet when the app runs first time and the network switcher is off.

