### PR TITLE
Enable users to access and copy the account public key - Closes #3562

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -101,6 +101,7 @@
   "Copied!": "Copied!",
   "Copy": "Copy",
   "Copy address": "Copy address",
+  "Copy address and public key": "Copy address and public key",
   "Copy entire passphrase": "Copy entire passphrase",
   "Copy link": "Copy link",
   "Copy the address or scan the QR code, to easily request BTC from Lisk or Lisk Mobile users.": "Copy the address or scan the QR code, to easily request BTC from Lisk or Lisk Mobile users.",

--- a/src/components/screens/wallet/overview/accountInfo/actionBar.js
+++ b/src/components/screens/wallet/overview/accountInfo/actionBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import QRCode from 'qrcode.react';
+import { tokenMap } from '@constants';
 import { getAddress } from '@utils/hwManager';
 import { isEmpty } from '@utils/helpers';
 import Icon from '@toolbox/icon';
@@ -27,14 +28,15 @@ const ActionBar = ({
         size="maxContent"
         content={(
           <CopyToClipboard
-            value={address}
+            value={activeToken === tokenMap.BTC.token
+              ? address : `Address: ${address} - Public key: ${account.summary.publicKey}`}
             type="icon"
             copyClassName={styles.copyIcon}
             className={styles.copyIcon}
           />
         )}
       >
-        <p>{t('Copy address')}</p>
+        <p>{activeToken === tokenMap.BTC.token ? t('Copy address') : t('Copy address and public key')}</p>
       </Tooltip>
     </div>
     <div className={`${styles.helperIcon} ${styles.qrCodeWrapper}`}>


### PR DESCRIPTION
### What was the problem?
This PR resolves #3562

### How was it solved?
I suggest to add public key under the copy button in the wallet page. Apps like N26 do this with IBAN-BIC couple. 

### How was it tested?
Visually
