### PR TITLE
Fix the accounts page crash - Closes #3567

### DIFF
--- a/src/utils/api/network/lsk.js
+++ b/src/utils/api/network/lsk.js
@@ -18,10 +18,11 @@ const httpPaths = {
  * @returns {Promise}
  */
 export const getNetworkStatus = ({
-  baseUrl,
+  baseUrl, network,
 }) => http({
   baseUrl,
   path: httpPaths.networkStatus,
+  network,
 });
 
 const getServiceUrl = ({ name, address = 'http://localhost:4000' }) => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3567

### How was it solved?
The issue was due to missing `network` parameter in `getNetworkStats` API utility.

### How was it tested?
Visually
