### PR TITLE
Fix dividers of the transaction details screen

### DIFF
--- a/src/components/screens/transactionDetails/layoutSchema.js
+++ b/src/components/screens/transactionDetails/layoutSchema.js
@@ -20,7 +20,7 @@ const restComponents = [TransactionId, Fee, SignedAndRemainingMembersList];
 const LayoutSchema = {
   [transfer]: {
     components: [...baseComponents, Recipient, Amount, Message, ...timeComponents],
-    className: '',
+    className: styles.transferLayout,
   },
   [`${transfer}-preview`]: {
     components: [...previewBaseComponents, Recipient, Amount, Message, ...restComponents],

--- a/src/components/screens/transactionDetails/layoutSchema.js
+++ b/src/components/screens/transactionDetails/layoutSchema.js
@@ -12,48 +12,50 @@ const {
   // reclaimLSK,
 } = MODULE_ASSETS_NAME_ID_MAP;
 
-const baseComponents = [Sender, Confirmations, TransactionId, Fee, Date, BlockId, BlockHeight];
-const previewBaseComponents = [Sender, TransactionId, Fee, SignedAndRemainingMembersList];
+const baseComponents = [Illustration, Sender];
+const timeComponents = [TransactionId, Date, BlockId, BlockHeight, Fee, Confirmations];
+const previewBaseComponents = [Illustration, Sender];
+const restComponents = [TransactionId, Fee, SignedAndRemainingMembersList];
 
 const LayoutSchema = {
   [transfer]: {
-    components: [...baseComponents, Recipient, Illustration, Amount, Message],
+    components: [...baseComponents, Recipient, Amount, Message, ...timeComponents],
     className: '',
   },
   [`${transfer}-preview`]: {
-    components: [...previewBaseComponents, Recipient, Illustration, Amount, Message],
+    components: [...previewBaseComponents, Recipient, Amount, Message, ...restComponents],
     className: styles.transferPreview,
   },
   [voteDelegate]: {
-    components: [...baseComponents, Illustration, TransactionVotes],
+    components: [...baseComponents, ...timeComponents, TransactionVotes],
     className: styles.voteLayout,
   },
   [`${voteDelegate}-preview`]: {
-    components: [...previewBaseComponents, Illustration, TransactionVotes],
+    components: [...previewBaseComponents, TransactionVotes, ...restComponents],
     className: styles.votePreview,
   },
   [registerDelegate]: {
-    components: [...baseComponents, Illustration],
+    components: [...baseComponents, ...timeComponents],
     className: styles.registerDelegate,
   },
   [`${registerDelegate}-preview`]: {
-    components: [...previewBaseComponents, Illustration],
+    components: [...previewBaseComponents, ...restComponents],
     className: styles.registerDelegatePreview,
   },
   [registerMultisignatureGroup]: {
-    components: [...baseComponents, RequiredSignatures, Members],
+    components: [...baseComponents, ...timeComponents, Members, RequiredSignatures],
     className: styles.multiSigLayout,
   },
   [`${registerMultisignatureGroup}-preview`]: {
-    components: [...previewBaseComponents, Illustration, Members, RequiredSignatures],
+    components: [...previewBaseComponents, Members, RequiredSignatures, ...restComponents],
     className: styles.multiSigRegisterPreview,
   },
   [unlockToken]: {
-    components: [...baseComponents, Illustration, Amount],
+    components: [...baseComponents, Amount, ...timeComponents],
     className: styles.unlockToken,
   },
   [`${unlockToken}-preview`]: {
-    components: [...previewBaseComponents, Illustration, Amount],
+    components: [...previewBaseComponents, Amount, ...restComponents],
     className: styles.unlockTokenPreview,
   },
   default: {

--- a/src/components/screens/transactionDetails/transactionDetails.css
+++ b/src/components/screens/transactionDetails/transactionDetails.css
@@ -130,8 +130,7 @@
       "amount amount"
       "transactionId date"
       "blockId blockHeight"
-      "fee confirmations"
-      "signedAndRemainingMembersList signedAndRemainingMembersList";
+      "fee confirmations";
 
     & > * {
       &:nth-last-child(2) {

--- a/src/components/screens/transactionDetails/transactionDetails.css
+++ b/src/components/screens/transactionDetails/transactionDetails.css
@@ -40,6 +40,14 @@
     }
   }
 
+  & .transferLayout {
+    & > * {
+      &:nth-last-child(2) {
+        border-bottom: none;
+      }
+    }
+  }
+
   & .generalLayout {
     grid-template-areas:
       "illustration illustration"
@@ -79,7 +87,13 @@
       "sender sender"
       "transactionId date"
       "blockId blockHeight"
-      "confirmations fee";
+      "fee confirmations";
+
+    & > * {
+      &:nth-last-child(2) {
+        border-bottom: none;
+      }
+    }
   }
 
   & .transferPreview {
@@ -118,6 +132,12 @@
       "blockId blockHeight"
       "fee confirmations"
       "signedAndRemainingMembersList signedAndRemainingMembersList";
+
+    & > * {
+      &:nth-last-child(2) {
+        border-bottom: none;
+      }
+    }
   }
 
   & .unlockTokenPreview {

--- a/src/components/screens/transactionDetails/transactionDetails.css
+++ b/src/components/screens/transactionDetails/transactionDetails.css
@@ -22,10 +22,10 @@
       "illustration illustration"
       "sender sender"
       "recipient recipient"
+      "amount message"
       "transactionId date"
       "blockId blockHeight"
-      "amount fee"
-      "confirmations message";
+      "fee confirmations";
 
     & > * {
       width: 100%;
@@ -47,18 +47,20 @@
       "recipient recipient"
       "transactionId date"
       "blockId blockHeight"
-      "amount fee"
-      "confirmations message";
+      "fee confirmations"
+      "blockId blockHeight"
+      "amount message";
   }
 
   & .multiSigLayout {
     grid-template-areas:
+      "illustration illustration"
       "sender sender"
       "date transactionId"
       "fee confirmations"
       "blockId blockHeight"
-      "requiredSignatures requiredSignatures"
-      "members members";
+      "members members"
+      "requiredSignatures requiredSignatures";
   }
 
   & .voteLayout {
@@ -67,8 +69,8 @@
       "sender sender"
       "transactionId date"
       "blockId blockHeight"
-      "votes votes"
-      "fee confirmations";
+      "fee confirmations"
+      "votes votes";
   }
 
   & .registerDelegate {
@@ -85,8 +87,8 @@
       "illustration illustration"
       "sender sender"
       "recipient recipient"
-      "transactionId fee"
       "amount message"
+      "transactionId fee"
       "signedAndRemainingMembersList signedAndRemainingMembersList";
   }
 
@@ -94,8 +96,8 @@
     grid-template-areas:
       "illustration illustration"
       "sender sender"
-      "transactionId fee"
       "votes votes"
+      "transactionId fee"
       "signedAndRemainingMembersList signedAndRemainingMembersList";
   }
 
@@ -107,12 +109,23 @@
       "signedAndRemainingMembersList signedAndRemainingMembersList";
   }
 
+  & .unlockToken {
+    grid-template-areas:
+      "illustration illustration"
+      "sender sender"
+      "amount amount"
+      "transactionId date"
+      "blockId blockHeight"
+      "fee confirmations"
+      "signedAndRemainingMembersList signedAndRemainingMembersList";
+  }
+
   & .unlockTokenPreview {
     grid-template-areas:
       "illustration illustration"
       "sender sender"
-      "transactionId fee"
       "amount amount"
+      "transactionId fee"
       "signedAndRemainingMembersList signedAndRemainingMembersList";
   }
 
@@ -120,8 +133,8 @@
     grid-template-areas:
       "illustration illustration"
       "sender sender"
-      "members members"
       "requiredSignatures requiredSignatures"
+      "members members"
       "transactionId fee"
       "signedAndRemainingMembersList signedAndRemainingMembersList";
   }

--- a/src/components/screens/votingQueue/summary/summary.js
+++ b/src/components/screens/votingQueue/summary/summary.js
@@ -38,7 +38,7 @@ const Summary = ({
   t, removed = {}, edited = {}, added = {},
   fee, account, prevStep, nextStep, transactions, ...props
 }) => {
-  const transaction = transactions.transactionsCreated[0];
+  const transaction = transactions.transactionsCreated[transactions.transactionsCreated.length - 1];
   const {
     locked, unlockable,
   } = getResultProps({ added, removed, edited });


### PR DESCRIPTION
### What was the problem?
This PR resolves some issue described in #3580

### How was it solved?
- [x] The divider lines in tx summary and tx details view need a review (CSS issue)
- [x] The copy vote tx button sometimes copies the last send tx : We were using the first member of `ransactions.transactionsCreated`. In multisig groups, the transactions create are never directly broadcasted, therefore this array doesn't get cleaned. next time that you initiated a new transaction, the `TransactionSummary` component should get the last (most recent) member of this array. We were using the first (oldest) member.

### How was it tested?
Visually
