### PR TITLE
Fix uninitialized accounts transfer issue - Closes #3602

### DIFF
--- a/src/store/actions/account.js
+++ b/src/store/actions/account.js
@@ -80,6 +80,9 @@ export const accountDataUpdated = tokensTypes =>
     const [error, info] = await to(getAccounts({ network, params }));
 
     if (info) {
+      // Uninitialized account don't have a public key stored on the blockchain.
+      // but we already have it on the Redux store.
+      info.LSK.summary.publicKey = account.info.LSK.summary.publicKey;
       dispatch({
         type: actionTypes.accountUpdated,
         data: info,

--- a/src/store/actions/account.test.js
+++ b/src/store/actions/account.test.js
@@ -98,7 +98,16 @@ describe('actions: account', () => {
     });
 
     it('should call account API methods on newBlockCreated action when online', async () => {
-      accountApi.getAccount.mockResolvedValue({ balance: 10e8 });
+      accountApi.getAccount.mockResolvedValue({
+        summary: {
+          address: accounts.genesis.summary.address,
+          publicKey: accounts.genesis.summary.publicKey,
+          balance: 10e8,
+        },
+        token: {
+          balance: 10e8,
+        },
+      });
 
       await accountDataUpdated('active')(dispatch, getState);
       expect(dispatch).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
### What was the problem?
This PR resolves #3602

### How was it solved?
Since we update the account data using the information retrieved from the API, and since uninitialized accounts don't have a public key stored on the blockchain; when they receive tokens they can't transfer tokens to other accounts unless they re-login.
I resolved it by replacing the public key using the one stored already in the Redux store.

### How was it tested?
Updated unit tests. Tested manually by creating several new accounts and transferring tokens to them, then making different transactions using them.
