### PR TITLE
Move sign multisignature link above the sign message - Closes #3601

### DIFF
--- a/src/components/shared/navigationBars/sideBar/menuLinks.js
+++ b/src/components/shared/navigationBars/sideBar/menuLinks.js
@@ -49,6 +49,12 @@ const menuLinks = t => ([
   ],
   [
     {
+      icon: 'multiSignatureOutline',
+      id: 'signMultiSignTransaction',
+      label: t('Sign multisignature transaction'),
+      modal: 'signMultiSignTransaction',
+    },
+    {
       icon: 'signMessage',
       id: 'signMessage',
       label: t('Sign Message'),
@@ -59,12 +65,6 @@ const menuLinks = t => ([
       id: 'verifyMessage',
       label: t('Verify Message'),
       modal: 'verifyMessage',
-    },
-    {
-      icon: 'multiSignatureOutline',
-      id: 'signMultiSignTransaction',
-      label: t('Sign multisignature transaction'),
-      modal: 'signMultiSignTransaction',
     },
   ],
   [


### PR DESCRIPTION
### What was the problem?
This PR resolves #3601

### How was it solved?
Lifted the menu item in the sidebar.

### How was it tested?
Manually
