### PR TITLE
Display the priority and transaction fee tooltips only when required - Closes #3630

### DIFF
--- a/src/components/shared/transactionPriority/transactionPriority.js
+++ b/src/components/shared/transactionPriority/transactionPriority.js
@@ -159,18 +159,22 @@ const TransactionPriority = ({
       <div className={`${styles.col} fee-container`}>
         <span className={`${styles.fieldLabel}`}>
           {t('Transaction fee')}
-          <Tooltip position="left">
-            <p className={styles.tooltipText}>
-              {
-                t(`
-                  You can choose a high, medium, or low transaction priority, each requiring a
-                  corresponding transaction fee. Or you can pay any desired fee of no less than
-                  ${minFee} ${token}. If you don't know what fee to pay, choose
-                  one of the provided transaction priorities.
-                `)
-              }
-            </p>
-          </Tooltip>
+          {
+            tokenRelevantPriorities.some(item => item.value !== 0) ? (
+              <Tooltip position="left">
+                <p className={styles.tooltipText}>
+                  {
+                    t(`
+                      You can choose a high, medium, or low transaction priority, each requiring a
+                      corresponding transaction fee. Or you can pay any desired fee of no less than
+                      ${minFee} ${token}. If you don't know what fee to pay, choose
+                      one of the provided transaction priorities.
+                    `)
+                  }
+                </p>
+              </Tooltip>
+            ) : null
+          }
         </span>
         {
           // eslint-disable-next-line no-nested-ternary


### PR DESCRIPTION
### What was the problem?
This PR resolves #3630

### How was it solved?
I hide the transaction fee tooltip when all priority fees are zero.
So if you see the Low/Medium/High buttons in the send form, then you should see the tooltip of the transaction fee too. And if you only see the Normal button, then you shouldn't see the tooltip either.

### How was it tested?
Manually.
