### PR TITLE
Adapt suscribers to the new API format - closes #3642

### DIFF
--- a/src/store/middlewares/block.js
+++ b/src/store/middlewares/block.js
@@ -29,7 +29,9 @@ const blockListener = ({ getState, dispatch }) => {
     if (activeToken === tokenMap.LSK.key) {
       dispatch({
         type: actionTypes.newBlockCreated,
-        data: { block },
+        data: {
+          block: block.data.length ? block.data[0] : {},
+        },
       });
       dispatch(forgersRetrieved());
     }


### PR DESCRIPTION
### What was the problem?
This PR resolves #3642

### How was it solved?
Adapted the response handler according to Lisk Service docs.

### How was it tested?
Updated the unit tests and tested the app manually.
