### PR TITLE
Update wallet/vote tab when votes changed - Closes  #3656

### DIFF
--- a/src/components/screens/wallet/votes/voteRow.js
+++ b/src/components/screens/wallet/votes/voteRow.js
@@ -85,6 +85,7 @@ const VoteRow = ({
 /* istanbul ignore next */
 const areEqual = (prevProps, nextProps) => (
   prevProps.data.address === nextProps.data.address
+  && prevProps.data.amount === nextProps.data.amount
   && (!!prevProps.accounts[nextProps.data.address]
     || !nextProps.accounts[nextProps.data.address])
 );


### PR DESCRIPTION
### What was the problem?
This PR resolves #3656

### How was it solved?
The `React.memo` equality condition had to include prev/next vote amount comparison.

### How was it tested?
<!--- Please describe how you tested your changes -->
