### PR TITLE
Fix wrong information displayed in Delegates Monitor - Closes #3684

### DIFF
--- a/src/components/screens/monitor/delegates/overview/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/overview/forgingDetails.js
@@ -16,8 +16,8 @@ import styles from './overview.css';
 const FORGERS_TO_SHOW = 6;
 
 const getForgingStats = (data, forgedInRound = 0) => {
-  const missedBlock = data.filter(item => item.state === 'missedBlock').length;
-  return [forgedInRound, ROUND_LENGTH - forgedInRound, missedBlock];
+  const missedBlocks = data.filter(item => item.state === 'missedBlock').length;
+  return [forgedInRound, ROUND_LENGTH - forgedInRound, missedBlocks];
 };
 
 const ProgressBar = ({ forgedInRound }) => (

--- a/src/components/screens/monitor/delegates/overview/forgingDetails.js
+++ b/src/components/screens/monitor/delegates/overview/forgingDetails.js
@@ -15,17 +15,9 @@ import styles from './overview.css';
 
 const FORGERS_TO_SHOW = 6;
 
-const getForgingStats = (data, forgedInRound) => {
-  if (forgedInRound === 0) return [0, 103, 0];
-  const states = {
-    forging: 0,
-    awaitingSlot: 0,
-    missedBlock: 0,
-  };
-  data.forEach((item) => {
-    states[item.state] += 1;
-  });
-  return [states.forging, states.awaitingSlot, states.missedBlock];
+const getForgingStats = (data, forgedInRound = 0) => {
+  const missedBlock = data.filter(item => item.state === 'missedBlock').length;
+  return [forgedInRound, ROUND_LENGTH - forgedInRound, missedBlock];
 };
 
 const ProgressBar = ({ forgedInRound }) => (

--- a/src/store/middlewares/block.js
+++ b/src/store/middlewares/block.js
@@ -21,12 +21,13 @@ const blockListener = ({ getState, dispatch }) => {
   blockUnsubscribe();
 
   const callback = (block) => {
-    const { settings, network } = getState();
+    const { settings, network, blocks } = getState();
     const activeToken = settings.token && state.settings.token.active;
     const lastBtcUpdate = network.lastBtcUpdate || 0;
     const now = new Date();
 
-    if (activeToken === tokenMap.LSK.key) {
+    if (activeToken === tokenMap.LSK.key
+      && block.data[0].height !== blocks.latestBlocks[0].height) {
       dispatch({
         type: actionTypes.newBlockCreated,
         data: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #3684

### How was it solved?
- [x] Filter out the new blocked that were emitted multiple times.
- [x] The numbers displayed and slot status and round status graphs must match.

### How was it tested?
Visually
Compare the numbers with the values of the blocks page.
