### PR TITLE
Fix visual issues in the wallet section - Closes #3654

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -483,6 +483,7 @@
   "There are no transactions.": "There are no transactions.",
   "There is no connection to the {{model}}. Please check the cables if it happened by accident.": "There is no connection to the {{model}}. Please check the cables if it happened by accident.",
   "There was an error in the transaction. Please try again!": "There was an error in the transaction. Please try again!",
+  "This account does not have any transactions.": "This account does not have any transactions.",
   "This account doesn’t have any voters.": "This account doesn’t have any voters.",
   "This account doesn’t have any votes matching searched username.": "This account doesn’t have any votes matching searched username.",
   "This account doesn’t have any votes.": "This account doesn’t have any votes.",

--- a/src/components/screens/dashboard/recentTransactions/recentTransactions.js
+++ b/src/components/screens/dashboard/recentTransactions/recentTransactions.js
@@ -40,7 +40,7 @@ const RecentTransactions = ({ className, t, transactions }) => {
   const [isLoaded, setLoaded] = useState(!!transactions.data.length);
   const settings = useSelector(state => state.settings);
   const currentBlockHeight = useSelector(selectCurrentBlockHeight);
-  const activeToken = tokenMap[settings.token.active];
+  const activeToken = tokenMap[settings.token.active].key;
   const host = account.info && account.info[activeToken] ? account.info[activeToken].summary.address : '';
 
   useEffect(() => {

--- a/src/components/screens/dashboard/recentTransactions/recentTransactions.js
+++ b/src/components/screens/dashboard/recentTransactions/recentTransactions.js
@@ -40,7 +40,7 @@ const RecentTransactions = ({ className, t, transactions }) => {
   const [isLoaded, setLoaded] = useState(!!transactions.data.length);
   const settings = useSelector(state => state.settings);
   const currentBlockHeight = useSelector(selectCurrentBlockHeight);
-  const activeToken = tokenMap[settings.token.active].key;
+  const activeToken = settings.token.active;
   const host = account.info && account.info[activeToken] ? account.info[activeToken].summary.address : '';
 
   useEffect(() => {

--- a/src/components/screens/dashboard/recentTransactions/recentTransactions.test.js
+++ b/src/components/screens/dashboard/recentTransactions/recentTransactions.test.js
@@ -156,7 +156,7 @@ const BitcoinState = {
   account: {
     passphrase: 'test',
     info: {
-      BTC: { address: 'mkakDp2f31btaXdATtAogoqwXcdx1PqqFo' },
+      BTC: { summary: { address: 'mkakDp2f31btaXdATtAogoqwXcdx1PqqFo' } },
     },
   },
   settings: {

--- a/src/components/screens/wallet/delegateProfile/performanceView.js
+++ b/src/components/screens/wallet/delegateProfile/performanceView.js
@@ -43,7 +43,7 @@ const PerformanceView = ({
             id={data.lastForgedHeight}
             exact
           >
-            {data.lastForgedHeight}
+            {data.lastForgedHeight || '-'}
           </NavLink>
         </Item>
         <Item

--- a/src/components/screens/wallet/transactions/index.js
+++ b/src/components/screens/wallet/transactions/index.js
@@ -110,7 +110,8 @@ const Transactions = ({
           header={header(t, activeToken, changeSort)}
           currentSort={sort}
           canLoadMore={canLoadMore}
-          error={transactions.error}
+          error={transactions.error.code !== 404 ? transactions.error : undefined}
+          emptyState={{ message: t('This account does not have any transactions.') }}
         />
       </BoxContent>
     </Box>


### PR DESCRIPTION
### What was the problem?
This PR resolves #3654

### How was it solved?
<!--- Please describe your technical implementation -->
- [x] In wallet page, if there are no transaction then we should display a text informing user that there is no transaction.
- [x] In dashboard page, if there are no transaction then we should display a text informing user that there is no transaction.
- [ ] ~~In wallet page, copy address & copy public key panel transparency should be changed.~~
- [ ] ~~Incoming and outgoing transaction representation is incorrect for down vote and unlock transactions. This should be applied for wallet page and dashboard page~~
- [x] In wallet page --> delegates profile page, can we have '-' if the last forged block is empty
- [ ] ~~In Voting queue page, the text standards are missing~~

### How was it tested?
Manually
