### PR TITLE
Temporarily hide HW sign-in link - closes #3698

### DIFF
--- a/src/components/screens/dashboard/recentTransactions/index.js
+++ b/src/components/screens/dashboard/recentTransactions/index.js
@@ -9,10 +9,10 @@ export default withData({
     apiUtil: (network, { token, ...params }) => getTransactions({ network, params }, token),
     getApiParams: (state) => {
       const token = state.settings.token.active;
-      const address = state.account.info ? state.account.info[token].summary.address : '';
+      const senderAddress = state.account.info ? state.account.info[token].summary.address : '';
       return {
         token,
-        address,
+        senderAddress,
         network: state.network,
       };
     },

--- a/src/components/screens/login/login.js
+++ b/src/components/screens/login/login.js
@@ -13,7 +13,7 @@ import Piwik from '@utils/piwik';
 import { PrimaryButton } from '@toolbox/buttons';
 import PassphraseInput from '@toolbox/passphraseInput';
 import DiscreetModeToggle from '@shared/discreetModeToggle';
-import Icon from '@toolbox/icon/index';
+// import Icon from '@toolbox/icon/index';
 import NetworkSelector from './networkSelector';
 import styles from './login.css';
 
@@ -105,8 +105,8 @@ class Login extends React.Component {
 
   // eslint-disable-next-line complexity
   render() {
-    const { t, network, settings } = this.props;
-    const canHWSignIn = !network.networks?.LSK;
+    const { t, settings } = this.props;
+    // const canHWSignIn = !network.networks?.LSK;
 
     return (
       <>
@@ -156,7 +156,7 @@ class Login extends React.Component {
                 >
                   {t('Sign in')}
                 </PrimaryButton>
-                {
+                {/* {
                   canHWSignIn
                     ? (
                       <Link
@@ -167,7 +167,7 @@ class Login extends React.Component {
                         {t('Sign in with a hardware wallet')}
                       </Link>
                     ) : null
-                }
+                } */}
 
               </div>
             </form>


### PR DESCRIPTION
### What was the problem?
This PR resolves #3698

### How was it solved?
Hid the HW link. I've created a [ticket](#3699) to reinstate this and assigned it to [v2.1.0](https://github.com/LiskHQ/lisk-desktop/projects/72).
 
 Also:
  - Fixed the wrong `getTransactions` parameters.

### How was it tested?
Manually
