### PR TITLE
Provide users with an easy approach for signing transactions with their second passphrase - Closes #3614

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -425,6 +425,7 @@
   "Send LSK and BTC": "Send LSK and BTC",
   "Send a reclaim transaction": "Send a reclaim transaction",
   "Send entire balance": "Send entire balance",
+  "Send using second passphrase right away": "Send using second passphrase right away",
   "Send {{amount}} {{token}}": "Send {{amount}} {{token}}",
   "Send {{token}}": "Send {{token}}",
   "Send {{token}} here": "Send {{token}} here",

--- a/src/components/screens/lockedBalance/lockedBalance/form.js
+++ b/src/components/screens/lockedBalance/lockedBalance/form.js
@@ -78,7 +78,7 @@ const Form = ({
         type: actionTypes.transactionSignError,
         data: error,
       });
-      nextStep({ error, fee, account });
+      nextStep({ fee, account });
     }
   };
 

--- a/src/components/screens/lockedBalance/lockedBalance/lockedBalance.test.js
+++ b/src/components/screens/lockedBalance/lockedBalance/lockedBalance.test.js
@@ -110,7 +110,7 @@ describe('Unlock LSK modal', () => {
     );
   });
 
-  it('calls nextStep passing error', async () => {
+  it('calls nextStep without passing transactionInfo when error', async () => {
     const error = { message: 'error:test' };
     create.mockImplementation(() =>
       new Promise((_, reject) => {
@@ -121,7 +121,7 @@ describe('Unlock LSK modal', () => {
     act(() => { wrapper.update(); });
     await flushPromises();
     expect(nextStep).toBeCalledWith(
-      expect.objectContaining({ error: expect.any(Object) }),
+      expect.not.objectContaining({ transactionInfo: expect.any(Object) }),
     );
   });
 });

--- a/src/components/screens/lockedBalance/summary/index.js
+++ b/src/components/screens/lockedBalance/summary/index.js
@@ -45,7 +45,7 @@ const Summary = ({
         false,
       );
       if (!err) {
-        transactionDoubleSigned(signedTx);
+        dispatch(transactionDoubleSigned(signedTx));
       }
     }
   }, [secondPass]);

--- a/src/components/screens/lockedBalance/summary/index.js
+++ b/src/components/screens/lockedBalance/summary/index.js
@@ -16,7 +16,6 @@ const moduleAssetId = MODULE_ASSETS_NAME_ID_MAP.unlockToken;
 
 const Summary = ({
   transactionInfo,
-  error,
   fee,
   prevStep,
   t,
@@ -52,13 +51,13 @@ const Summary = ({
 
   const onSubmit = () => {
     if (!account.summary.isMultisignature || secondPass) {
-      Piwik.trackingEvent('RegisterDelegate_SubmitTransaction', 'button', 'Next step');
+      Piwik.trackingEvent('UnlockBalance_SubmitTransaction', 'button', 'Next step');
       if (!transactions.txSignatureError
         && !isEmpty(transactions.signedTransaction)) {
         nextStep();
       } else if (transactions.txSignatureError) {
         nextStep({
-          error,
+          error: transactions.txSignatureError,
         });
       }
     }

--- a/src/components/screens/lockedBalance/summary/index.js
+++ b/src/components/screens/lockedBalance/summary/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { withTranslation } from 'react-i18next';
 import { MODULE_ASSETS_NAME_ID_MAP } from '@constants';
 import TransactionSummary from '@shared/transactionSummary';
@@ -16,6 +16,7 @@ const Summary = ({
   nextStep,
   account,
 }) => {
+  const [secondPass, setSecondPass] = useState('');
   const onSubmit = () => {
     if (!error) {
       nextStep({ transactionInfo });
@@ -45,6 +46,8 @@ const Summary = ({
       createTransaction={(callback) => {
         callback(transactionInfo);
       }}
+      keys={account.keys}
+      setSecondPass={setSecondPass}
     >
       <TransactionInfo
         moduleAssetId={moduleAssetId}

--- a/src/components/screens/lockedBalance/summary/index.js
+++ b/src/components/screens/lockedBalance/summary/index.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { withTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { transactionDoubleSigned } from '@actions';
 import { MODULE_ASSETS_NAME_ID_MAP, actionTypes } from '@constants';
 import TransactionSummary from '@shared/transactionSummary';
 import TransactionInfo from '@shared/transactionInfo';
@@ -14,7 +15,6 @@ import styles from './summary.css';
 const moduleAssetId = MODULE_ASSETS_NAME_ID_MAP.unlockToken;
 
 const Summary = ({
-  transactionDoubleSigned,
   transactionInfo,
   error,
   fee,
@@ -55,20 +55,12 @@ const Summary = ({
       Piwik.trackingEvent('RegisterDelegate_SubmitTransaction', 'button', 'Next step');
       if (!transactions.txSignatureError
         && !isEmpty(transactions.signedTransaction)) {
-        nextStep({
-          transactionInfo,
-        });
+        nextStep();
       } else if (transactions.txSignatureError) {
         nextStep({
           error,
         });
       }
-    }
-
-    if (!error) {
-      nextStep();
-    } else {
-      nextStep({ error });
     }
   };
 

--- a/src/components/screens/lockedBalance/summary/summary.test.js
+++ b/src/components/screens/lockedBalance/summary/summary.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { mountWithRouterAndStore } from '@utils/testHelpers';
 import Summary from './index';
 import accounts from '../../../../../test/constants/accounts';
 
@@ -37,15 +38,35 @@ describe('Delegate Registration Summary', () => {
   });
 
   it('submit user data when click in confirm button', () => {
-    const wrapper = mount(<Summary {...props} />);
+    const wrapper = mountWithRouterAndStore(
+      Summary,
+      props,
+      {},
+      {
+        transactions: {
+          txSignatureError: null,
+          signedTransaction: { id: 1 },
+        },
+      },
+    );
     expect(props.nextStep).not.toBeCalled();
     wrapper.find('button.confirm-button').simulate('click');
-    expect(props.nextStep).toBeCalledWith({ transactionInfo: props.transactionInfo });
+    expect(props.nextStep).toBeCalled();
   });
 
   it('submit user data when click in confirm button but fails', () => {
     const error = {};
-    const wrapper = mount(<Summary {...props} error={error} />);
+    const wrapper = mountWithRouterAndStore(
+      Summary,
+      props,
+      {},
+      {
+        transactions: {
+          txSignatureError: error,
+          signedTransaction: { id: 1 },
+        },
+      },
+    );
     wrapper.find('button.confirm-button').simulate('click');
     expect(props.nextStep).toBeCalledWith({ error });
   });

--- a/src/components/screens/lockedBalance/transactionStatus/transactionStatus.js
+++ b/src/components/screens/lockedBalance/transactionStatus/transactionStatus.js
@@ -5,17 +5,20 @@ import { TransactionResult, getBroadcastStatus } from '@shared/transactionResult
 import statusMessages from './statusMessages';
 import styles from './status.css';
 
-const TransactionStatus = (props) => {
-  const {
-    t, history, transactionInfo, transactions, transactionBroadcasted,
-  } = props;
+const TransactionStatus = ({
+  transactionBroadcasted,
+  transactions,
+  history,
+  error,
+  t,
+}) => {
   const status = getBroadcastStatus(transactions, false); // @todo handle HW errors by #3661
   const onSuccess = () => history.push(routes.wallet.path);
   const template = statusMessages(t, onSuccess)[status.code];
 
   useEffect(() => {
-    if (transactionInfo) transactionBroadcasted(transactionInfo);
-  }, [transactionInfo]);
+    if (!error) transactionBroadcasted(transactions.signedTransaction);
+  }, [error]);
 
   return (
     <div className={`${styles.wrapper} transaction-status`}>

--- a/src/components/screens/reclaimBalance/modal/summary/index.js
+++ b/src/components/screens/reclaimBalance/modal/summary/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import to from 'await-to-js';
 import { useSelector } from 'react-redux';
 import { selectAccount } from '@store/selectors';
@@ -18,7 +18,6 @@ const Summary = ({
 }) => {
   const account = useSelector(selectAccount);
   const network = useSelector(state => state.network);
-  const [secondPass, setSecondPass] = useState('');
   const senderPublicKey = account.info.LSK.summary.publicKey;
   const [
     // eslint-disable-next-line no-unused-vars
@@ -77,8 +76,6 @@ const Summary = ({
       fee={minFee.value}
       token={tokenMap.LSK.key}
       classNames={styles.summaryContainer}
-      keys={account.info.LSK.keys}
-      setSecondPass={setSecondPass}
     >
       <TransactionInfo account={account} moduleAssetId={MODULE_ASSETS_NAME_ID_MAP.reclaimLSK} />
     </TransactionSummary>

--- a/src/components/screens/reclaimBalance/modal/summary/index.js
+++ b/src/components/screens/reclaimBalance/modal/summary/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import to from 'await-to-js';
 import { useSelector } from 'react-redux';
 import { selectAccount } from '@store/selectors';
@@ -18,6 +18,7 @@ const Summary = ({
 }) => {
   const account = useSelector(selectAccount);
   const network = useSelector(state => state.network);
+  const [secondPass, setSecondPass] = useState('');
   const senderPublicKey = account.info.LSK.summary.publicKey;
   const [
     // eslint-disable-next-line no-unused-vars
@@ -76,6 +77,8 @@ const Summary = ({
       fee={minFee.value}
       token={tokenMap.LSK.key}
       classNames={styles.summaryContainer}
+      keys={account.info.LSK.keys}
+      setSecondPass={setSecondPass}
     >
       <TransactionInfo account={account} moduleAssetId={MODULE_ASSETS_NAME_ID_MAP.reclaimLSK} />
     </TransactionSummary>

--- a/src/components/screens/registerDelegate/status/status.js
+++ b/src/components/screens/registerDelegate/status/status.js
@@ -17,14 +17,14 @@ class Status extends React.Component {
   }
 
   componentDidMount() {
-    const { transactionInfo } = this.props;
+    const { transactions } = this.props;
     // istanbul ignore else
-    if (transactionInfo) this.broadcastTransaction();
+    if (transactions.signedTransaction) this.broadcastTransaction();
   }
 
   broadcastTransaction() {
-    const { transactionBroadcasted, transactionInfo } = this.props;
-    transactionBroadcasted(transactionInfo);
+    const { transactionBroadcasted, transactions } = this.props;
+    transactionBroadcasted(transactions.signedTransaction);
   }
 
   // TODO update test coverage in PR #2199

--- a/src/components/screens/registerDelegate/status/status.test.js
+++ b/src/components/screens/registerDelegate/status/status.test.js
@@ -40,17 +40,11 @@ describe('Delegate Registration Status', () => {
 
   it('broadcast the transaction properly', () => {
     const newProps = {
-      transactionInfo: {
-        id: 1,
-        account: accounts.genesis,
-        username: 'my_delegate_account',
-        passphrase: accounts.genesis.passphrase,
-        secondPassphrase: null,
-        recipientId: '123123L',
-        amount: 0,
-        timeOffset: 0,
-      },
       ...props,
+      transactions: {
+        txSignatureError: null,
+        signedTransaction: { id: 1 },
+      },
     };
     wrapper = mount(<Status {...newProps} />);
 

--- a/src/components/screens/registerDelegate/summary/summary.js
+++ b/src/components/screens/registerDelegate/summary/summary.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MODULE_ASSETS_NAME_ID_MAP } from '@constants';
 import TransactionSummary from '@shared/transactionSummary';
 import TransactionInfo from '@shared/transactionInfo';
@@ -16,6 +16,7 @@ const Summary = ({
   transactionInfo,
   error,
 }) => {
+  const [secondPass, setSecondPass] = useState('');
   const onSubmit = () => {
     if (!error) {
       nextStep({ transactionInfo });
@@ -45,6 +46,8 @@ const Summary = ({
       createTransaction={(callback) => {
         callback(transactionInfo);
       }}
+      keys={account.keys}
+      setSecondPass={setSecondPass}
     >
       <TransactionInfo
         nickname={nickname}

--- a/src/components/screens/registerDelegate/summary/summary.js
+++ b/src/components/screens/registerDelegate/summary/summary.js
@@ -20,7 +20,6 @@ const Summary = ({
   t,
   nextStep,
   transactionInfo,
-  error,
 }) => {
   const dispatch = useDispatch();
   const networkIdentifier = useSelector(selectNetworkIdentifier);
@@ -59,7 +58,7 @@ const Summary = ({
         });
       } else if (transactions.txSignatureError) {
         nextStep({
-          error,
+          error: transactions.txSignatureError,
         });
       }
     }

--- a/src/components/screens/registerDelegate/summary/summary.test.js
+++ b/src/components/screens/registerDelegate/summary/summary.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { mountWithRouterAndStore } from '@utils/testHelpers';
 import Summary from './summary';
 import accounts from '../../../../../test/constants/accounts';
 
@@ -36,7 +37,17 @@ describe('Delegate Registration Summary', () => {
   });
 
   it('submit user data when click in confirm button', () => {
-    const wrapper = mount(<Summary {...props} />);
+    const wrapper = mountWithRouterAndStore(
+      Summary,
+      props,
+      {},
+      {
+        transactions: {
+          txSignatureError: null,
+          signedTransaction: { id: 1 },
+        },
+      },
+    );
     expect(props.nextStep).not.toBeCalled();
     wrapper.find('button.confirm-button').simulate('click');
     expect(props.nextStep).toBeCalledWith({ transactionInfo: props.transactionInfo });
@@ -44,7 +55,17 @@ describe('Delegate Registration Summary', () => {
 
   it('submit user data when click in confirm button but fails', () => {
     const error = {};
-    const wrapper = mount(<Summary {...props} error={error} />);
+    const wrapper = mountWithRouterAndStore(
+      Summary,
+      props,
+      {},
+      {
+        transactions: {
+          txSignatureError: error,
+          signedTransaction: { id: 1 },
+        },
+      },
+    );
     wrapper.find('button.confirm-button').simulate('click');
     expect(props.nextStep).toBeCalledWith({ error });
   });

--- a/src/components/screens/send/summary/index.js
+++ b/src/components/screens/send/summary/index.js
@@ -3,7 +3,11 @@ import { connect } from 'react-redux';
 import { withTranslation } from 'react-i18next';
 
 import { getActiveTokenAccount } from '@utils/account';
-import { transactionCreated, resetTransactionResult } from '@actions';
+import {
+  transactionCreated,
+  resetTransactionResult,
+  transactionDoubleSigned,
+} from '@actions';
 import Summary from './summary';
 
 const mapStateToProps = state => ({
@@ -15,6 +19,7 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = {
   transactionCreated,
   resetTransactionResult,
+  transactionDoubleSigned,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Summary));

--- a/src/components/screens/send/summary/summary.js
+++ b/src/components/screens/send/summary/summary.js
@@ -1,37 +1,56 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { loginTypes, MODULE_ASSETS_NAME_ID_MAP } from '@constants';
 import { toRawLsk, fromRawLsk } from '@utils/lsk';
 import { isEmpty } from '@utils/helpers';
+import { selectNetworkIdentifier } from '@store/selectors';
 import Piwik from '@utils/piwik';
 import TransactionSummary from '@shared/transactionSummary';
 import TransactionInfo from '@shared/transactionInfo';
+import { signTransaction, transformTransaction } from '@utils/transaction';
+import { useSelector } from 'react-redux';
 
-class Summary extends React.Component {
-  constructor(props) {
-    super(props);
-    this.prevStep = this.prevStep.bind(this);
-    this.submitTransaction = this.submitTransaction.bind(this);
-  }
+const Summary = ({
+  resetTransactionResult,
+  transactionCreated,
+  isInitialization,
+  transactions,
+  prevStep,
+  nextStep,
+  account,
+  fields,
+  token,
+  t,
+}) => {
+  const networkIdentifier = useSelector(selectNetworkIdentifier);
+  const [secondPass, setSecondPass] = useState('');
+  const [doubleSignedTx, setDoubleSignedTx] = useState(null);
 
-  componentDidMount() {
-    const { fields } = this.props;
-
-    this.props.transactionCreated({
+  useEffect(() => {
+    transactionCreated({
       amount: `${toRawLsk(fields.amount.value)}`,
       data: fields.reference ? fields.reference.value : '',
       recipientAddress: fields.recipient.address,
       fee: toRawLsk(parseFloat(fields.fee.value)),
     });
-  }
+  }, []);
 
-  submitTransaction(fn) {
-    const {
-      account,
-      fields,
-      nextStep,
-      transactions,
-    } = this.props;
+  useEffect(() => {
+    if (secondPass) {
+      const [signedTx, err] = signTransaction(
+        transformTransaction(transactions.signedTransaction),
+        secondPass,
+        networkIdentifier,
+        { data: account },
+        false,
+      );
+      console.log('signedTx', signedTx);
+      if (!err) {
+        setDoubleSignedTx(signedTx);
+      }
+    }
+  }, [secondPass]);
 
+  const submitTransaction = (fn) => {
     if (!account.summary.isMultisignature) {
       Piwik.trackingEvent('Send_SubmitTransaction', 'button', 'Next step');
       if (account.loginType !== loginTypes.passphrase.code
@@ -54,57 +73,54 @@ class Summary extends React.Component {
         });
       }
     } else {
-      fn(transactions.signedTransaction);
+      fn(doubleSignedTx || transactions.signedTransaction);
     }
-  }
+  };
 
-  prevStep() {
+  const goBack = () => {
     Piwik.trackingEvent('Send_Summary', 'button', 'Previous step');
-    this.props.resetTransactionResult();
-    this.props.prevStep({ fields: this.props.fields });
-  }
+    resetTransactionResult();
+    prevStep({ fields });
+  };
 
-  render() {
-    const {
-      fields, t, token, account, isInitialization, transactions,
-    } = this.props;
-    const transaction = transactions.signedTransaction;
-    const amount = transaction?.asset?.amount
-      ? fromRawLsk(transaction?.asset?.amount) : fields.amount.value;
+  const transaction = transactions.signedTransaction;
+  const amount = transaction?.asset?.amount
+    ? fromRawLsk(transaction?.asset?.amount) : fields.amount.value;
 
-    return (
-      <TransactionSummary
-        title={t('Transaction summary')}
-        t={t}
-        account={account}
-        confirmButton={{
-          label: isInitialization ? t('Send') : t('Send {{amount}} {{token}}', { amount, token }),
-          onClick: this.submitTransaction,
-        }}
-        cancelButton={{
-          label: t('Edit transaction'),
-          onClick: this.prevStep,
-        }}
-        showCancelButton={!isInitialization}
-        fee={!account.summary.isMultisignature && fields.fee.value}
+  return (
+    <TransactionSummary
+      title={t('Transaction summary')}
+      t={t}
+      account={account}
+      confirmButton={{
+        label: isInitialization ? t('Send') : t('Send {{amount}} {{token}}', { amount, token }),
+        onClick: submitTransaction,
+      }}
+      cancelButton={{
+        label: t('Edit transaction'),
+        onClick: goBack,
+      }}
+      showCancelButton={!isInitialization}
+      fee={!account.summary.isMultisignature && fields.fee.value}
+      token={token}
+      createTransaction={submitTransaction}
+      keys={account.keys}
+      setSecondPass={setSecondPass}
+    >
+      <TransactionInfo
+        fields={fields}
         token={token}
-        createTransaction={this.submitTransaction}
-      >
-        <TransactionInfo
-          fields={fields}
-          token={token}
-          moduleAssetId={MODULE_ASSETS_NAME_ID_MAP.transfer}
-          transaction={
-            !isEmpty(transaction)
-              ? transaction
-              : { asset: { amount: toRawLsk(fields.amount.value) } }
-          }
-          account={account}
-          isMultisignature={account.summary.isMultisignature}
-        />
-      </TransactionSummary>
-    );
-  }
-}
+        moduleAssetId={MODULE_ASSETS_NAME_ID_MAP.transfer}
+        transaction={
+          !isEmpty(transaction)
+            ? transaction
+            : { asset: { amount: toRawLsk(fields.amount.value) } }
+        }
+        account={account}
+        isMultisignature={account.summary.isMultisignature}
+      />
+    </TransactionSummary>
+  );
+};
 
 export default Summary;

--- a/src/components/screens/send/summary/summary.js
+++ b/src/components/screens/send/summary/summary.js
@@ -10,6 +10,7 @@ import { signTransaction, transformTransaction } from '@utils/transaction';
 import { useSelector } from 'react-redux';
 
 const Summary = ({
+  transactionDoubleSigned,
   resetTransactionResult,
   transactionCreated,
   isInitialization,
@@ -23,7 +24,6 @@ const Summary = ({
 }) => {
   const networkIdentifier = useSelector(selectNetworkIdentifier);
   const [secondPass, setSecondPass] = useState('');
-  const [doubleSignedTx, setDoubleSignedTx] = useState(null);
 
   useEffect(() => {
     transactionCreated({
@@ -43,15 +43,14 @@ const Summary = ({
         { data: account },
         false,
       );
-      console.log('signedTx', signedTx);
       if (!err) {
-        setDoubleSignedTx(signedTx);
+        transactionDoubleSigned(signedTx);
       }
     }
   }, [secondPass]);
 
   const submitTransaction = (fn) => {
-    if (!account.summary.isMultisignature) {
+    if (!account.summary.isMultisignature || secondPass) {
       Piwik.trackingEvent('Send_SubmitTransaction', 'button', 'Next step');
       if (account.loginType !== loginTypes.passphrase.code
           && transactions.txSignatureError) {
@@ -73,7 +72,7 @@ const Summary = ({
         });
       }
     } else {
-      fn(doubleSignedTx || transactions.signedTransaction);
+      fn(transactions.signedTransaction);
     }
   };
 

--- a/src/components/screens/signMultiSignTransaction/helpers.js
+++ b/src/components/screens/signMultiSignTransaction/helpers.js
@@ -1,5 +1,6 @@
 import { MODULE_ASSETS_NAME_ID_MAP } from '@constants';
 import { joinModuleAndAssetIds } from '@utils/moduleAssets';
+import { getKeys } from '@utils/account';
 
 const getNumbersOfSignaturesRequired = ({ keys, isGroupRegistration }) => {
   if (isGroupRegistration) {
@@ -7,14 +8,6 @@ const getNumbersOfSignaturesRequired = ({ keys, isGroupRegistration }) => {
     return keys.mandatoryKeys.length + keys.optionalKeys.length + 1;
   }
   return keys.numberOfSignatures;
-};
-
-export const getKeys = ({ senderAccount, transaction, isGroupRegistration }) => {
-  if (isGroupRegistration) {
-    return transaction.asset;
-  }
-
-  return senderAccount.keys;
 };
 
 const getNonEmptySignatures = (signatures) =>

--- a/src/components/screens/votingQueue/summary/index.js
+++ b/src/components/screens/votingQueue/summary/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import { votesSubmitted } from '@actions';
+import { votesSubmitted, transactionDoubleSigned } from '@actions';
 import { getActiveTokenAccount } from '@utils/account';
 import SummaryComponent from './summary';
 
@@ -18,6 +18,9 @@ const Summary = (props) => {
       t={t}
       account={account}
       transactions={transactions}
+      transactionDoubleSigned={(params) => {
+        dispatch(transactionDoubleSigned(params));
+      }}
       votesSubmitted={(params) => {
         dispatch(votesSubmitted(params));
       }}

--- a/src/components/screens/votingQueue/summary/summary.js
+++ b/src/components/screens/votingQueue/summary/summary.js
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { fromRawLsk } from '@utils/lsk';
 import Piwik from '@utils/piwik';
 import { isEmpty } from '@utils/helpers';
+import { signTransaction, transformTransaction } from '@utils/transaction';
 import TransactionInfo from '@shared/transactionInfo';
 import { MODULE_ASSETS_NAME_ID_MAP } from '@constants';
 import TransactionSummary from '@shared/transactionSummary';
+import { selectNetworkIdentifier } from '@store/selectors';
 import ToggleIcon from '../toggleIcon';
 import VoteStats from '../voteStats';
 
@@ -37,8 +40,9 @@ const getResultProps = ({ added, removed, edited }) => {
 
 const Summary = ({
   t, removed = {}, edited = {}, added = {}, selfUnvote = {},
-  fee, account, prevStep, nextStep, transactions, ...props
+  fee, account, prevStep, nextStep, transactions, transactionDoubleSigned, ...props
 }) => {
+  const networkIdentifier = useSelector(selectNetworkIdentifier);
   const [secondPass, setSecondPass] = useState('');
   const {
     locked, unlockable,
@@ -53,8 +57,23 @@ const Summary = ({
     });
   }, []);
 
+  useEffect(() => {
+    if (secondPass) {
+      const [signedTx, err] = signTransaction(
+        transformTransaction(transactions.signedTransaction),
+        secondPass,
+        networkIdentifier,
+        { data: account },
+        false,
+      );
+      if (!err) {
+        transactionDoubleSigned(signedTx);
+      }
+    }
+  }, [secondPass]);
+
   const submitTransaction = () => {
-    if (!account.summary.isMultisignature) {
+    if (!account.summary.isMultisignature || secondPass) {
       Piwik.trackingEvent('Vote_SubmitTransaction', 'button', 'Next step');
       if (!transactions.txSignatureError
         && !isEmpty(transactions.signedTransaction)) {

--- a/src/components/screens/votingQueue/summary/summary.js
+++ b/src/components/screens/votingQueue/summary/summary.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { fromRawLsk } from '@utils/lsk';
 import Piwik from '@utils/piwik';
 import { isEmpty } from '@utils/helpers';
@@ -39,6 +39,7 @@ const Summary = ({
   t, removed = {}, edited = {}, added = {}, selfUnvote = {},
   fee, account, prevStep, nextStep, transactions, ...props
 }) => {
+  const [secondPass, setSecondPass] = useState('');
   const {
     locked, unlockable,
   } = getResultProps({ added, removed, edited });
@@ -88,6 +89,8 @@ const Summary = ({
       createTransaction={(callback) => {
         callback(transactions.signedTransaction);
       }}
+      keys={account.keys}
+      setSecondPass={setSecondPass}
     >
       <ToggleIcon isNotHeader />
       <div className={styles.headerContainer}>

--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -55,32 +55,29 @@ const NormalActions = ({
   confirmButton,
   hasSecondPass,
   secondPass,
-}) => {
-  console.log(hasSecondPass, { secondPass });
-  return (
-    <div className={styles.primaryActions}>
-      {showCancelButton && (
-        <SecondaryButton
-          className="cancel-button"
-          onClick={cancelButton.onClick}
-        >
-          {cancelButton.label}
-        </SecondaryButton>
-      )}
-      <PrimaryButton
-        className="confirm-button"
-        disabled={
-          (confirmation && !isConfirmed)
-          || confirmButton.disabled
-          || (hasSecondPass && !secondPass)
-        }
-        onClick={confirmButton.onClick}
+}) => (
+  <div className={styles.primaryActions}>
+    {showCancelButton && (
+      <SecondaryButton
+        className="cancel-button"
+        onClick={cancelButton.onClick}
       >
-        {confirmButton.label}
-      </PrimaryButton>
-    </div>
-  );
-};
+        {cancelButton.label}
+      </SecondaryButton>
+    )}
+    <PrimaryButton
+      className="confirm-button"
+      disabled={
+        (confirmation && !isConfirmed)
+        || confirmButton.disabled
+        || (hasSecondPass && !secondPass)
+      }
+      onClick={confirmButton.onClick}
+    >
+      {confirmButton.label}
+    </PrimaryButton>
+  </div>
+);
 
 const Footer = ({
   confirmButton, cancelButton, footerClassName, showCancelButton, hasSecondPass,
@@ -89,8 +86,6 @@ const Footer = ({
   const [copied, setCopied] = useState(false);
   const [useSecondPass, setUseSecondPass] = useState(false);
   const [secondPassPhrase, setSecondPassPhrase] = useState('');
-
-  console.log('secondPassPhrase : ', secondPassPhrase);
 
   const onDownload = (bufferTx = {}) => {
     const transaction = JSON.parse(transactionToJSON(bufferTx));

--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -1,3 +1,4 @@
+// istanbul ignore file
 import React, { useState } from 'react';
 import { PrimaryButton, SecondaryButton, TertiaryButton } from '@toolbox/buttons';
 import { transactionToJSON, downloadJSON } from '@utils/transaction';

--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -1,0 +1,160 @@
+import React, { useState } from 'react';
+import { PrimaryButton, SecondaryButton, TertiaryButton } from '@toolbox/buttons';
+import { transactionToJSON, downloadJSON } from '@utils/transaction';
+import PassphraseInput from '@toolbox/passphraseInput';
+import BoxFooter from '@toolbox/box/footer';
+import copyToClipboard from 'copy-to-clipboard';
+import Icon from '@toolbox/icon';
+import styles from './transactionSummary.css';
+
+const MultisigActions = ({
+  onDownload,
+  onCopy,
+  copied,
+  t,
+  cancelButton,
+  createTransaction,
+}) => (
+  <div className={styles.primaryActions}>
+    <SecondaryButton
+      className="cancel-button"
+      onClick={cancelButton.onClick}
+    >
+      {t('Go back')}
+    </SecondaryButton>
+    <SecondaryButton
+      className="copy-button"
+      onClick={() => {
+        createTransaction(onCopy);
+      }}
+    >
+      <span className={styles.buttonContent}>
+        <Icon name={copied ? 'checkmark' : 'copy'} />
+        {t(copied ? 'Copied' : 'Copy')}
+      </span>
+    </SecondaryButton>
+    <PrimaryButton
+      className="download-button"
+      onClick={() => {
+        createTransaction(onDownload);
+      }}
+    >
+      <span className={styles.buttonContent}>
+        <Icon name="download" />
+        {t('Download')}
+      </span>
+    </PrimaryButton>
+  </div>
+);
+
+const NormalActions = ({
+  showCancelButton,
+  cancelButton,
+  confirmation,
+  isConfirmed,
+  confirmButton,
+  hasSecondPass,
+  secondPass,
+}) => {
+  console.log(hasSecondPass, { secondPass });
+  return (
+    <div className={styles.primaryActions}>
+      {showCancelButton && (
+        <SecondaryButton
+          className="cancel-button"
+          onClick={cancelButton.onClick}
+        >
+          {cancelButton.label}
+        </SecondaryButton>
+      )}
+      <PrimaryButton
+        className="confirm-button"
+        disabled={
+          (confirmation && !isConfirmed)
+          || confirmButton.disabled
+          || (hasSecondPass && !secondPass)
+        }
+        onClick={confirmButton.onClick}
+      >
+        {confirmButton.label}
+      </PrimaryButton>
+    </div>
+  );
+};
+
+const Footer = ({
+  confirmButton, cancelButton, footerClassName, showCancelButton, hasSecondPass,
+  confirmation, isConfirmed, isMultisignature, t, createTransaction, setSecondPass,
+}) => {
+  const [copied, setCopied] = useState(false);
+  const [useSecondPass, setUseSecondPass] = useState(false);
+  const [secondPassPhrase, setSecondPassPhrase] = useState('');
+
+  console.log('secondPassPhrase : ', secondPassPhrase);
+
+  const onDownload = (bufferTx = {}) => {
+    const transaction = JSON.parse(transactionToJSON(bufferTx));
+    downloadJSON(transaction, `tx-${transaction.id}`);
+  };
+
+  const onCopy = (transaction) => {
+    copyToClipboard(transactionToJSON(transaction));
+    setCopied(true);
+  };
+
+  return (
+    <BoxFooter className={`${footerClassName} summary-footer`} direction="horizontal">
+      {
+        isMultisignature && !useSecondPass ? (
+          <MultisigActions
+            onDownload={onDownload}
+            onCopy={onCopy}
+            copied={copied}
+            t={t}
+            cancelButton={cancelButton}
+            createTransaction={createTransaction}
+          />
+        ) : null
+      }
+      {
+        hasSecondPass && !useSecondPass ? (
+          <div className={styles.secondaryActions}>
+            <span className={styles.or}>or</span>
+            <TertiaryButton
+              onClick={() => setUseSecondPass(true)}
+            >
+              {t('Send using second passphrase right away')}
+            </TertiaryButton>
+          </div>
+        ) : null
+      }
+      {
+        hasSecondPass && useSecondPass ? (
+          <div className={styles.secondPassphrase}>
+            <PassphraseInput
+              t={t}
+              onFill={(pass) => { setSecondPassPhrase(pass); setSecondPass(pass); }}
+              inputsLength={12}
+              maxInputsLength={24}
+            />
+          </div>
+        ) : null
+      }
+      {
+        !isMultisignature || (hasSecondPass && useSecondPass) ? (
+          <NormalActions
+            showCancelButton={showCancelButton}
+            cancelButton={cancelButton}
+            confirmation={confirmation}
+            isConfirmed={isConfirmed}
+            confirmButton={confirmButton}
+            hasSecondPass={hasSecondPass}
+            secondPass={secondPassPhrase}
+          />
+        ) : null
+      }
+    </BoxFooter>
+  );
+};
+
+export default Footer;

--- a/src/components/shared/transactionSummary/index.js
+++ b/src/components/shared/transactionSummary/index.js
@@ -1,91 +1,15 @@
-import React, { useState } from 'react';
-import { PrimaryButton, SecondaryButton } from '@toolbox/buttons';
-import { transactionToJSON, downloadJSON } from '@utils/transaction';
+import React from 'react';
 import LiskAmount from '@shared/liskAmount';
 import Box from '@toolbox/box';
 import BoxHeader from '@toolbox/box/header';
 import BoxContent from '@toolbox/box/content';
-import BoxFooter from '@toolbox/box/footer';
 import CheckBox from '@toolbox/checkBox';
 import HardwareWalletIllustration from '@toolbox/hardwareWalletIllustration';
 import Tooltip from '@toolbox/tooltip/tooltip';
-import copyToClipboard from 'copy-to-clipboard';
-import Icon from '@toolbox/icon';
 import { tokenMap } from '@constants';
+import Footer from './footer';
 
 import styles from './transactionSummary.css';
-
-const Footer = ({
-  confirmButton, cancelButton, footerClassName, showCancelButton,
-  confirmation, isConfirmed, isMultisignature, t, createTransaction,
-}) => {
-  const [copied, setCopied] = useState(false);
-
-  const onDownload = (bufferTx = {}) => {
-    const transaction = JSON.parse(transactionToJSON(bufferTx));
-    downloadJSON(transaction, `tx-${transaction.id}`);
-  };
-
-  const onCopy = (transaction) => {
-    copyToClipboard(transactionToJSON(transaction));
-    setCopied(true);
-  };
-
-  return (
-    <BoxFooter className={`${footerClassName} summary-footer`} direction="horizontal">
-      {isMultisignature ? (
-        <>
-          <SecondaryButton
-            className="cancel-button"
-            onClick={cancelButton.onClick}
-          >
-            {t('Go back')}
-          </SecondaryButton>
-          <SecondaryButton
-            className="copy-button"
-            onClick={() => {
-              createTransaction(onCopy);
-            }}
-          >
-            <span className={styles.buttonContent}>
-              <Icon name={copied ? 'checkmark' : 'copy'} />
-              {t(copied ? 'Copied' : 'Copy')}
-            </span>
-          </SecondaryButton>
-          <PrimaryButton
-            className="download-button"
-            onClick={() => {
-              createTransaction(onDownload);
-            }}
-          >
-            <span className={styles.buttonContent}>
-              <Icon name="download" />
-              {t('Download')}
-            </span>
-          </PrimaryButton>
-        </>
-      ) : (
-        <>
-          {showCancelButton && (
-            <SecondaryButton
-              className="cancel-button"
-              onClick={cancelButton.onClick}
-            >
-              {cancelButton.label}
-            </SecondaryButton>
-          )}
-          <PrimaryButton
-            className="confirm-button"
-            disabled={(confirmation && !isConfirmed) || confirmButton.disabled}
-            onClick={confirmButton.onClick}
-          >
-            {confirmButton.label}
-          </PrimaryButton>
-        </>
-      )}
-    </BoxFooter>
-  );
-};
 
 class TransactionSummary extends React.Component {
   constructor(props) {
@@ -142,8 +66,9 @@ class TransactionSummary extends React.Component {
 
   render() {
     const {
-      title, children, confirmButton, cancelButton, account, createTransaction, t,
-      fee, confirmation, classNames, token, footerClassName, showCancelButton = true,
+      title, children, confirmButton, cancelButton, keys,
+      account, createTransaction, t, fee, confirmation, setSecondPass,
+      classNames, token, footerClassName, showCancelButton = true,
     } = this.props;
     const {
       isHardwareWalletConnected, isConfirmed,
@@ -202,7 +127,11 @@ class TransactionSummary extends React.Component {
             isConfirmed={isConfirmed}
             createTransaction={createTransaction}
             isMultisignature={token === tokenMap.LSK.key && account.summary.isMultisignature}
+            hasSecondPass={
+              keys && keys.mandatoryKeys.length === 2 && keys.optionalKeys.length === 0
+            }
             t={t}
+            setSecondPass={setSecondPass}
           />
         )}
       </Box>

--- a/src/components/shared/transactionSummary/transactionSummary.css
+++ b/src/components/shared/transactionSummary/transactionSummary.css
@@ -10,7 +10,7 @@
     margin-top: 16px;
     margin-bottom: 16px;
     display: flex;
-    flex-direction: column;
+    flex-flow: column nowrap !important;
   }
 }
 
@@ -81,4 +81,33 @@
   & > img {
     margin-right: 10px;
   }
+}
+
+.primaryActions {
+  flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+}
+
+.secondaryActions {
+  flex-shrink: 0;
+  width: 100%;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  margin-bottom: calc(-1 * var(--vertical-padding-l));
+
+  & .or {
+    padding-top: var(--vertical-padding-l);
+  }
+}
+
+.secondPassphrase {
+  width: 100%;
+  padding: 0 20px;
+  box-sizing: border-box;
+  margin-bottom: var(--vertical-padding-l);
 }

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -60,6 +60,7 @@ const actionTypes = {
   deviceListUpdated: 'DEVICE_LIST_UPDATED',
   transactionCreatedSuccess: 'TRANSACTION_CREATED_SUCCESS',
   transactionSignError: 'TRANSACTION_SIGN_ERROR',
+  transactionDoubleSigned: 'TRANSACTION_DOUBLE_SIGNED',
   resetTransactionResult: 'RESET_TRANSACTION_RESULTS',
   broadcastedTransactionSuccess: 'BROADCAST_TRANSACTION_SUCCESS',
   broadcastedTransactionError: 'BROADCASTED_TRANSACTION_ERROR',

--- a/src/store/actions/transactions.js
+++ b/src/store/actions/transactions.js
@@ -129,6 +129,11 @@ export const transactionCreated = data => async (dispatch, getState) => {
   });
 };
 
+export const transactionDoubleSigned = data => ({
+  type: actionTypes.transactionDoubleSigned,
+  data,
+});
+
 /**
  * Calls transactionAPI.broadcast function for put the tx object (signed) into the network
  * @param {Object} transaction

--- a/src/store/reducers/transactions.js
+++ b/src/store/reducers/transactions.js
@@ -60,6 +60,7 @@ const transactions = (state = initialState, action) => { // eslint-disable-line 
 
     // Stored the signed transaction to be used for broadcasting or downloading
     case actionTypes.transactionCreatedSuccess:
+    case actionTypes.transactionDoubleSigned:
       return {
         ...state,
         signedTransaction: action.data,

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -13,6 +13,7 @@ const selectBookmark = (state, address) =>
   state.bookmarks[state.settings.token.active].find(item => (item.address === address));
 const selectSettings = state => state.settings;
 const selectServiceUrl = state => state.network.networks?.LSK?.serviceUrl;
+const selectNetworkIdentifier = state => state.network.networks?.LSK?.networkIdentifier;
 const selectCurrentBlockHeight = state => state.blocks.latestBlocks[0]?.height || 0;
 
 export {
@@ -30,4 +31,5 @@ export {
   selectAccountBalance,
   selectServiceUrl,
   selectCurrentBlockHeight,
+  selectNetworkIdentifier,
 };

--- a/src/utils/account.js
+++ b/src/utils/account.js
@@ -226,3 +226,19 @@ export const calculateRemainingAndSignedMembers = (
 
   return { signed, remaining };
 };
+
+/**
+ * Get keys object from account info or multisig tx asset
+ * @param {object} data
+ * @param {object} data.senderAccount - Account info
+ * @param {object} data.transaction - Transaction details
+ * @param {boolean} data.isGroupRegistration - tx moduleAsset check
+ * @returns {object} - Keys, including number and list of mandatory and optional keys
+ */
+export const getKeys = ({ senderAccount, transaction, isGroupRegistration }) => {
+  if (isGroupRegistration) {
+    return transaction.asset;
+  }
+
+  return senderAccount.keys;
+};

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -1,15 +1,19 @@
 /* eslint-disable max-lines */
+import { transactions } from '@liskhq/lisk-client';
 import {
   MODULE_ASSETS_NAME_ID_MAP,
+  moduleAssetSchemas,
 } from '@constants';
 import {
   extractAddressFromPublicKey,
   getBase32AddressFromAddress,
   getAddressFromBase32Address,
+  getKeys,
 } from '@utils/account';
 import { transformStringDateToUnixTimestamp } from '@utils/datetime';
 import { toRawLsk } from '@utils/lsk';
 import { splitModuleAndAssetIds, joinModuleAndAssetIds } from '@utils/moduleAssets';
+import { findNonEmptySignatureIndices } from './helpers';
 
 const {
   transfer, voteDelegate, registerDelegate, unlockToken, reclaimLSK, registerMultisignatureGroup,
@@ -282,8 +286,8 @@ const transactionToJSON = (transaction) => {
   return JSON.stringify(obj);
 };
 
-const containsTransactionType = (transactions = [], type) =>
-  transactions.some(tx => tx.moduleAssetId === type);
+const containsTransactionType = (txs = [], type) =>
+  txs.some(tx => tx.moduleAssetId === type);
 
 /**
  * Adapts transaction filter params to match transactions API method
@@ -365,6 +369,71 @@ const downloadJSON = (data, name) => {
   anchor.setAttribute('download', `${name}.json`);
   anchor.click();
 };
+/**
+ * Signs a given multisignature tx with a given passphrase
+ *
+ * @param {Object} transaction - Transaction object to be signed
+ * @param {String} passphrase - Account passphrase to use for signing
+ * @param {String} networkIdentifier - Current network identifier (from Redux store)
+ * @param {Object} senderAccount
+ * @param {Object} senderAccount.data - Details of the account who has initiated the transaction
+ * @param {Boolean} isFullySigned - Is the tx object fully signed?
+ *
+ * @returns [Object, Object] - Signed transaction and err
+ */
+// eslint-disable-next-line max-statements
+const signTransaction = (
+  transaction,
+  passphrase,
+  networkIdentifier,
+  senderAccount,
+  isFullySigned,
+) => {
+  let signedTransaction;
+  let err;
+
+  const isGroupRegistration = transaction.moduleAssetId
+      === MODULE_ASSETS_NAME_ID_MAP.registerMultisignatureGroup;
+
+  const { mandatoryKeys, optionalKeys } = getKeys({
+    senderAccount: senderAccount.data, transaction, isGroupRegistration,
+  });
+
+  const flatTransaction = flattenTransaction(transaction);
+  const transactionObject = createTransactionObject(flatTransaction, transaction.moduleAssetId);
+  const keys = {
+    mandatoryKeys: mandatoryKeys.map(key => Buffer.from(key, 'hex')),
+    optionalKeys: optionalKeys.map(key => Buffer.from(key, 'hex')),
+  };
+
+  const includeSender = transaction.moduleAssetId
+    === MODULE_ASSETS_NAME_ID_MAP.registerMultisignatureGroup;
+
+  try {
+    signedTransaction = transactions.signMultiSignatureTransaction(
+      moduleAssetSchemas[transaction.moduleAssetId],
+      transactionObject,
+      Buffer.from(networkIdentifier, 'hex'),
+      passphrase,
+      keys,
+      includeSender,
+    );
+
+    // remove unnecessary signatures
+    if (isFullySigned) {
+      const emptySignatureIndices = findNonEmptySignatureIndices(transaction.signatures);
+      emptySignatureIndices.forEach(index => {
+        signedTransaction.signatures[index] = Buffer.from('');
+      });
+    }
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e);
+    err = e;
+  }
+
+  return [signedTransaction, err];
+};
 
 export {
   getTxAmount,
@@ -375,4 +444,5 @@ export {
   containsTransactionType,
   createTransactionObject,
   normalizeTransactionParams,
+  signTransaction,
 };

--- a/src/utils/transaction.js
+++ b/src/utils/transaction.js
@@ -13,7 +13,7 @@ import {
 import { transformStringDateToUnixTimestamp } from '@utils/datetime';
 import { toRawLsk } from '@utils/lsk';
 import { splitModuleAndAssetIds, joinModuleAndAssetIds } from '@utils/moduleAssets';
-import { findNonEmptySignatureIndices } from './helpers';
+import { findNonEmptySignatureIndices } from '@screens/signMultiSignTransaction/helpers';
 
 const {
   transfer, voteDelegate, registerDelegate, unlockToken, reclaimLSK, registerMultisignatureGroup,


### PR DESCRIPTION
### What was the problem?
This PR resolves #3614

### How was it solved?
- [x] Abstract signTx in utils level
- [x] Add second passphrase input to tx summary screen
- [x] Add `transactionDoubleSigned` action
- [x] Update Send summary
- [x] Update Unlock LSK summary
- [x] Update Register delegate summary
- [x] Update Vote summary

### How was it tested?
WIP
