### PR TITLE
Set default network and show block height in BTC transaction summary - Closes #3781

### DIFF
--- a/src/components/shared/transactionInfo/send.js
+++ b/src/components/shared/transactionInfo/send.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import AccountVisual from '@toolbox/accountVisual';
 import LiskAmount from '@shared/liskAmount';
+import { toRawLsk } from '@utils/lsk';
 import styles from './transactionInfo.css';
 
 const Send = ({
@@ -26,7 +27,7 @@ const Send = ({
         <label>{t('Amount')}</label>
         <label className="amount-summary">
           <LiskAmount
-            val={transaction.asset?.amount}
+            val={transaction.asset?.amount || toRawLsk(fields.amount.value)}
             token={token}
           />
         </label>

--- a/src/utils/api/network/lsk.js
+++ b/src/utils/api/network/lsk.js
@@ -25,7 +25,7 @@ export const getNetworkStatus = ({
   network,
 });
 
-const getServiceUrl = ({ name, address = 'http://localhost:4000' }) => {
+const getServiceUrl = ({ name = networkKeys.mainNet, address = 'http://localhost:4000' }) => {
   if ([networkKeys.mainNet, networkKeys.testNet].includes(name)) {
     return networks[name].serviceUrl;
   }

--- a/src/utils/api/transaction/btc.js
+++ b/src/utils/api/transaction/btc.js
@@ -27,7 +27,7 @@ const normalizeTransactionsResponse = ({
   network,
   list,
 }) => list.map(({
-  tx, feeSatoshi, confirmations, timestamp,
+  tx, feeSatoshi, confirmations, timestamp, height,
 }) => {
   const extractedAddress = tx.outputs[0].scriptPubKey.addresses[0];
   const recipientAddress = validateAddress(tokenMap.BTC.key, extractedAddress, network) === 0
@@ -37,6 +37,7 @@ const normalizeTransactionsResponse = ({
     id: tx.txid,
     block: {
       timestamp: timestamp ? Number(timestamp) * 1000 : null,
+      height,
     },
     confirmations: confirmations || 0,
     isPending: !confirmations,


### PR DESCRIPTION
### What was the problem?
This PR resolves #3781

### How was it solved?

- Added default network as mainnet
- Added block height to btc transaction details page
 
### How was it tested?

Visually (Not ideal, we need to make sure to introduce tests)