### PR TITLE
Invalid JSON filename on multisignature registration transaction save - Closes #3787

### DIFF
--- a/src/components/screens/multiSignature/result/result.js
+++ b/src/components/screens/multiSignature/result/result.js
@@ -14,7 +14,8 @@ const Result = ({
   const [copied, setCopied] = useState(false);
 
   const onDownload = () => {
-    downloadJSON(transaction, `tx-${transactions.signedTransaction.id}`);
+    const transactionId = transaction.id.toString('hex');
+    downloadJSON(transaction, `tx-${transactionId}`);
   };
 
   const onCopy = () => {


### PR DESCRIPTION
### What was the problem?

This PR resolves #3787 

### How was it solved?

Use correct transaction id for file name when downloading transaction data to sign

### How was it tested?
Manually