### PR TITLE
Update fallback network to mainnet when cache and settings is not available - Closes #3784

### DIFF
--- a/app/src/modules/storage.js
+++ b/app/src/modules/storage.js
@@ -11,6 +11,7 @@ export const setConfig = ({
 };
 
 export const readConfig = () => {
-  const value = storage.get('config');
+  // Ensure to return empty config if storage does not hold any value
+  const value = storage.get('config') || {};
   win.send({ event: 'configRetrieved', value });
 };

--- a/app/src/modules/storage.test.js
+++ b/app/src/modules/storage.test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { spy } from 'sinon';
+import win from './win';
+import { readConfig } from './storage';
+
+jest.mock('electron-store');
+
+describe('Storage', () => {
+  const winSendSpy = spy(win, 'send');
+
+  afterEach(() => {
+    win.eventStack.length = 0;
+    winSendSpy.restore();
+  });
+
+  describe('readConfig', () => {
+    it('should return empty config if storage has no config set', () => {
+      // Act
+      readConfig();
+
+      // Assert
+      expect(winSendSpy).to.have.been.calledWith({ event: 'configRetrieved', value: {} });
+    });
+  });
+});

--- a/src/utils/api/network/lsk.js
+++ b/src/utils/api/network/lsk.js
@@ -25,7 +25,7 @@ export const getNetworkStatus = ({
   network,
 });
 
-const getServiceUrl = ({ name = networkKeys.mainNet, address = 'http://localhost:4000' }) => {
+const getServiceUrl = ({ name, address = 'http://localhost:4000' }) => {
   if ([networkKeys.mainNet, networkKeys.testNet].includes(name)) {
     return networks[name].serviceUrl;
   }

--- a/src/utils/getNetwork.js
+++ b/src/utils/getNetwork.js
@@ -8,7 +8,7 @@ export const getNetworksList = () =>
       name,
     }));
 
-export const getNetworkName = network => network.name || 'customNode';
+export const getNetworkName = network => network.name || networkKeys.mainNet;
 
 /**
  * Returns human readable error messages

--- a/src/utils/getNetwork.js
+++ b/src/utils/getNetwork.js
@@ -8,6 +8,7 @@ export const getNetworksList = () =>
       name,
     }));
 
+// Return mainnet as back off network name when cache/local storage does not exists
 export const getNetworkName = network => network.name || networkKeys.mainNet;
 
 /**

--- a/src/utils/getNetwork.test.js
+++ b/src/utils/getNetwork.test.js
@@ -16,31 +16,31 @@ describe('Utils: getNetwork', () => {
     });
   });
 
-  describe.skip('getNetworkName', () => {
-    it('should discover mainnet', () => {
-      const network = {
-        name: 'customNode',
-      };
-      expect(getNetworkName(network, 'LSK')).toEqual('mainnet');
+  describe('getNetworkName', () => {
+    it('should return mainnet if network config does not have name set', () => {
+      const network = {};
+      expect(getNetworkName(network)).toEqual('mainnet');
     });
 
-    it('should discover testnet', () => {
+    it('should return customNode', () => {
       const network = {
         name: 'customNode',
       };
-      expect(getNetworkName(network, 'LSK')).toEqual('testnet');
+      expect(getNetworkName(network)).toEqual(network.name);
     });
 
-    it('should mark as customNode otherwise', () => {
+    it('should return testnet', () => {
       const network = {
-        name: 'customNode',
-        networks: {
-          LSK: {
-            nethash: 'sample_hash',
-          },
-        },
+        name: 'testnet',
       };
-      expect(getNetworkName(network, 'LSK')).toEqual('customNode');
+      expect(getNetworkName(network)).toEqual(network.name);
+    });
+
+    it('should return mainnet', () => {
+      const network = {
+        name: 'mainnet',
+      };
+      expect(getNetworkName(network)).toEqual(network.name);
     });
   });
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #3784 

### How was it solved?

- Return mainnet as fallback network name when network cache or setting is not available
- Revert getServiceUrl changes

### How was it tested?

- Added unit tests