### PR TITLE
Lisk desktop tests fail when lisk-client is update beyond 5.0.1 - Closes #3804

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -18,6 +18,7 @@ const config = {
     fallback: {
       net: false,
       fs: false,
+      os: false,
       crypto: require.resolve('crypto-browserify'),
       stream: require.resolve('stream-browserify'),
       path: require.resolve('path-browserify'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@ledgerhq/hw-transport-node-hid": "5.50.0",
         "@ledgerhq/hw-transport-u2f": "5.33.1-alpha.3",
-        "@liskhq/lisk-client": "5.0.1",
+        "@liskhq/lisk-client": "5.2.0-alpha.1",
         "@testing-library/react-hooks": "5.1.2",
         "await-to-js": "2.1.1",
         "bignumber.js": "8.0.1",
@@ -4244,17 +4244,18 @@
       "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
     },
     "node_modules/@liskhq/lisk-api-client": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-api-client/-/lisk-api-client-5.0.3.tgz",
-      "integrity": "sha512-ww4Rpb4V+WaSJe4co5WczpWuLB5ix97PXQgCHsCYijzVfsRGpaWjwp3PsyjleosFlLRKS2NytXyjhWkFkB/XDA==",
+      "version": "5.1.4-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-api-client/-/lisk-api-client-5.1.4-alpha.1.tgz",
+      "integrity": "sha512-zWBHfCiTWC1psnJTkUGxygHIXx8B0vTOP/lYSkVypuWZilDkW0dWXJBGmFsa8qAxaYDnMFogj8/kKdBEkIzorw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-codec": "^0.1.1",
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-transactions": "^5.0.2",
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-transactions": "^5.2.0-alpha.1",
         "isomorphic-ws": "4.0.1",
-        "pm2-axon": "4.0.0",
-        "pm2-axon-rpc": "0.6.0",
-        "ws": "7.4.0"
+        "pm2-axon": "4.0.1",
+        "pm2-axon-rpc": "0.7.1",
+        "ws": "7.4.6"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
@@ -4262,18 +4263,19 @@
       }
     },
     "node_modules/@liskhq/lisk-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-client/-/lisk-client-5.0.1.tgz",
-      "integrity": "sha512-Fq6tRuOCp8ZY/9fnG6KvvJhq6FT4CUr7CZx/qu5C5hzp0cOsSXVtq3829+FekkruQOEpsys5meDm8JoJBdW9ZQ==",
+      "version": "5.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-client/-/lisk-client-5.2.0-alpha.1.tgz",
+      "integrity": "sha512-l8zfAofN7nPKP3Zt4fAhZ4md46MKwc6w2OJ62CkyYgmQEwW8ZNyMY6Bn48hVy+eiCRDWtoKfIxyf8mr9bavtNQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-api-client": "^5.0.1",
-        "@liskhq/lisk-codec": "^0.1.0",
-        "@liskhq/lisk-cryptography": "^3.0.0",
-        "@liskhq/lisk-passphrase": "^3.0.1",
-        "@liskhq/lisk-transactions": "^5.0.0",
-        "@liskhq/lisk-tree": "^0.1.0",
-        "@liskhq/lisk-utils": "^0.1.0",
-        "@liskhq/lisk-validator": "^0.5.0",
+        "@liskhq/lisk-api-client": "^5.1.4-alpha.1",
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-passphrase": "^3.1.0",
+        "@liskhq/lisk-transactions": "^5.2.0-alpha.1",
+        "@liskhq/lisk-tree": "^0.2.1-alpha.1",
+        "@liskhq/lisk-utils": "^0.2.0",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1",
         "buffer": "6.0.3"
       },
       "engines": {
@@ -4282,12 +4284,13 @@
       }
     },
     "node_modules/@liskhq/lisk-codec": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-codec/-/lisk-codec-0.1.1.tgz",
-      "integrity": "sha512-otW7UlNRlgeZSz5Pj2lIzq2lbVclVOBgX/o0qtnGFa0+73bryiU17deymlqYYoCPAam9uVE3MFedu2sgpAlEYQ==",
+      "version": "0.2.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-codec/-/lisk-codec-0.2.1-alpha.1.tgz",
+      "integrity": "sha512-G0Q8GKZgmHARcTT5RuHp6UedHvnmLlxSFvzpwOB/AMAgaGGSvHvq4GvAF+XbhVUa097bum8ZzDL+rjO2OXCN4g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-utils": "^0.1.0",
-        "@liskhq/lisk-validator": "^0.5.1"
+        "@liskhq/lisk-utils": "^0.2.0",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
@@ -4295,9 +4298,10 @@
       }
     },
     "node_modules/@liskhq/lisk-cryptography": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-3.0.1.tgz",
-      "integrity": "sha512-jtYbRUMMjALICQI6MW7yvD7q1guVSADmD+JlhoNh64Ja6ff8ILm+zgQ7MCCp7j2r6pfsfIQzdsRxZhtHWBhfvA==",
+      "version": "3.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-cryptography/-/lisk-cryptography-3.2.0-alpha.1.tgz",
+      "integrity": "sha512-mXoCexnSbQRFooNkYdmjT3F9KZ39jCqAqxo7Y5v7PXh9r3nPo4pvSqYbz61EN/TzkEHBB671brrhyVZhTVm+QQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "buffer-reverse": "1.0.1",
         "ed2curve": "0.3.0",
@@ -4309,15 +4313,16 @@
         "npm": ">=6.12.0"
       },
       "optionalDependencies": {
-        "sodium-native": "3.2.0"
+        "sodium-native": "3.2.1"
       }
     },
     "node_modules/@liskhq/lisk-passphrase": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-passphrase/-/lisk-passphrase-3.0.1.tgz",
-      "integrity": "sha512-x6gh0nA+cM9ldNaTG34fpyIGR3to0LJF1AKKElizrv0wesKO3+nIGssXY+HrPkXxreoUa/Ktid8LmDiSr3h2/w==",
+      "version": "3.1.0",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-passphrase/-/lisk-passphrase-3.1.0.tgz",
+      "integrity": "sha512-xylTDLNhyaZB9/9E6QvDv7uLi5iQodTGNOto4/nI5E2EteOBIc1F4/nb8dpccI1dxYIg9CXIGV8zXIQkV6RpGQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bip39": "3.0.2"
+        "bip39": "3.0.3"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
@@ -4325,13 +4330,14 @@
       }
     },
     "node_modules/@liskhq/lisk-transactions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-5.0.2.tgz",
-      "integrity": "sha512-cPSe7rPUJb5g3VypenMS0j9572son9SWgV4LtL1Mkl0YtRkLNRaUYb4SrQahHWv3IHQQ6gxem9MXkedMV4IqqQ==",
+      "version": "5.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-transactions/-/lisk-transactions-5.2.0-alpha.1.tgz",
+      "integrity": "sha512-XeFJCW5CpEbflCBVL7CiaDOzumqzepRenA3HFz2Vk5TK8AqjrrkUeXd4uqaANctFI3Ap1cHiigbU0Ms/JUFWZQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-codec": "^0.1.1",
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-validator": "^0.5.1"
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
@@ -4339,12 +4345,13 @@
       }
     },
     "node_modules/@liskhq/lisk-tree": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-tree/-/lisk-tree-0.1.1.tgz",
-      "integrity": "sha512-fnNqaTywcJyK4qDjoHLl7h86cgqSQO8rO+gu0CnBJPCdETIhO7LTAnAOGHi4uEVuUWsvK+l33ky8BI+zZjG+rQ==",
+      "version": "0.2.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-tree/-/lisk-tree-0.2.1-alpha.1.tgz",
+      "integrity": "sha512-07hrZ4jyohx/MLH7+984VLEsCZN4iFRCcJFIATtw5bgKksjQUyL0qaXVW3/YaSeEdKWR2GmPlXNxUcRdAUF5EA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-utils": "^0.1.0"
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-utils": "^0.2.0"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
@@ -4352,9 +4359,10 @@
       }
     },
     "node_modules/@liskhq/lisk-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-utils/-/lisk-utils-0.1.0.tgz",
-      "integrity": "sha512-PR36Rxk6Nhg8Z6vvEIOpbeTuISaw23It6WhVyxEibH2RN2UPpUwDWR60BcIqZtR1FCK5vEcDMTvBXu1FgawbdA==",
+      "version": "0.2.0",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-utils/-/lisk-utils-0.2.0.tgz",
+      "integrity": "sha512-BtrtugsNfnZD91iB7NJLE9lRmqcoIwUS/ww4p3OT7O6XLJXO9RvevoOBFAhjVFsDP82wxx8zR9+SkkDmkOQ21w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "4.5.0"
       },
@@ -4364,37 +4372,70 @@
       }
     },
     "node_modules/@liskhq/lisk-validator": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-validator/-/lisk-validator-0.5.1.tgz",
-      "integrity": "sha512-mIFRetkasdU7QoaoOmRWxHZaUXvKXWjAgA3wwn8wnSANArSVtWyM23xvfDVBLzPFRnMH9LfvSt66U8uYkGdIPg==",
+      "version": "0.6.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-validator/-/lisk-validator-0.6.1-alpha.1.tgz",
+      "integrity": "sha512-SGkCwkIoxiY8hkQEYIcjUrT13j8mb+5SxzUkUTP9BYOP42CVyqQSCxMVQHpJgq/oRgSu9+IAZXpYDHpAVmxcQg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@types/node": "12.12.11",
-        "@types/semver": "7.1.0",
-        "@types/validator": "12.0.1",
-        "ajv": "6.12.0",
-        "debug": "4.1.1",
-        "semver": "7.1.3",
-        "validator": "12.2.0"
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "ajv": "8.1.0",
+        "ajv-formats": "2.0.2",
+        "debug": "4.3.1",
+        "semver": "7.3.5",
+        "validator": "13.5.2"
       },
       "engines": {
         "node": ">=12.13.0 <=12",
         "npm": ">=6.12.0"
       }
     },
-    "node_modules/@liskhq/lisk-validator/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+    "node_modules/@liskhq/lisk-validator/node_modules/ajv": {
+      "version": "8.1.0",
+      "resolved": "https://npm.lisk.io/ajv/-/ajv-8.1.0.tgz",
+      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
+      "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.1"
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@liskhq/lisk-validator/node_modules/ajv-formats": {
+      "version": "2.0.2",
+      "resolved": "https://npm.lisk.io/ajv-formats/-/ajv-formats-2.0.2.tgz",
+      "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@liskhq/lisk-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://npm.lisk.io/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/@liskhq/lisk-validator/node_modules/semver": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
+      "version": "7.3.5",
+      "resolved": "https://npm.lisk.io/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11241,14 +11282,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
-    "node_modules/@types/semver": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
-      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -11302,11 +11335,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
-    },
-    "node_modules/@types/validator": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-12.0.1.tgz",
-      "integrity": "sha512-l57fIANZLMe8DArz+SDb+7ATXnDm15P7u2wHBw5mb0aSMd+UuvmvhouBF2hdLgQPDMJ39sh9g2MJO4GkZ0VAdQ=="
     },
     "node_modules/@types/verror": {
       "version": "1.10.4",
@@ -11991,13 +12019,15 @@
     },
     "node_modules/amp": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
-      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0="
+      "resolved": "https://npm.lisk.io/amp/-/amp-0.3.1.tgz",
+      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0=",
+      "license": "MIT"
     },
     "node_modules/amp-message": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
+      "resolved": "https://npm.lisk.io/amp-message/-/amp-message-0.1.2.tgz",
       "integrity": "sha1-p48cmJlQh602GSpBKY5NtJ49/EU=",
+      "license": "MIT",
       "dependencies": {
         "amp": "0.3.1"
       }
@@ -14031,9 +14061,10 @@
       "integrity": "sha1-XbBBataCJxLwd4NuJVe4aXwMfJk="
     },
     "node_modules/bip39": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "version": "3.0.3",
+      "resolved": "https://npm.lisk.io/bip39/-/bip39-3.0.3.tgz",
+      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "license": "ISC",
       "dependencies": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -14043,8 +14074,9 @@
     },
     "node_modules/bip39/node_modules/@types/node": {
       "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+      "resolved": "https://npm.lisk.io/@types%2fnode/-/node-11.11.6.tgz",
+      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==",
+      "license": "MIT"
     },
     "node_modules/bip66": {
       "version": "1.1.5",
@@ -14792,8 +14824,9 @@
     },
     "node_modules/buffer-reverse": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
+      "resolved": "https://npm.lisk.io/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A=",
+      "license": "MIT"
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -19037,8 +19070,9 @@
     },
     "node_modules/ed2curve": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "resolved": "https://npm.lisk.io/ed2curve/-/ed2curve-0.3.0.tgz",
       "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
+      "license": "Unlicense",
       "dependencies": {
         "tweetnacl": "1.x.x"
       }
@@ -26446,8 +26480,9 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "resolved": "https://npm.lisk.io/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
@@ -31264,27 +31299,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -33772,9 +33786,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "version": "4.3.0",
+      "resolved": "https://npm.lisk.io/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
+      "license": "MIT",
       "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
@@ -35831,13 +35846,14 @@
       }
     },
     "node_modules/pm2-axon": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-4.0.0.tgz",
-      "integrity": "sha512-A8dy0C57cRIm+kX58HrMcnvUdg8EdwCuCmavDdmFE4eoUE+5zfwGbDfZKCBVLNpDwjXPuXQQYZi3wQt/5xC8DQ==",
+      "version": "4.0.1",
+      "resolved": "https://npm.lisk.io/pm2-axon/-/pm2-axon-4.0.1.tgz",
+      "integrity": "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg==",
+      "license": "MIT",
       "dependencies": {
         "amp": "~0.3.1",
         "amp-message": "~0.1.1",
-        "debug": "^4.2",
+        "debug": "^4.3.1",
         "escape-string-regexp": "^4.0.0"
       },
       "engines": {
@@ -35845,28 +35861,22 @@
       }
     },
     "node_modules/pm2-axon-rpc": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.6.0.tgz",
-      "integrity": "sha512-xjYR0y1HpOopJ09VL2Qd5H1LajVN+QLPVZ1G+GesbORJDAZiStMhwECtOzm/Gx5ANQxL0usW8WZsElMfQq2hbw==",
+      "version": "0.7.1",
+      "resolved": "https://npm.lisk.io/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
+      "integrity": "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==",
+      "license": "MIT",
       "dependencies": {
-        "debug": "^3.0"
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=5"
       }
     },
-    "node_modules/pm2-axon-rpc/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/pm2-axon/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "resolved": "https://npm.lisk.io/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -42954,10 +42964,11 @@
       "dev": true
     },
     "node_modules/sodium-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-      "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+      "version": "3.2.1",
+      "resolved": "https://npm.lisk.io/sodium-native/-/sodium-native-3.2.1.tgz",
+      "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "ini": "^1.3.5",
@@ -45499,8 +45510,9 @@
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "resolved": "https://npm.lisk.io/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -46536,9 +46548,10 @@
       }
     },
     "node_modules/validator": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ==",
+      "version": "13.5.2",
+      "resolved": "https://npm.lisk.io/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
@@ -48979,9 +48992,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.6",
+      "resolved": "https://npm.lisk.io/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -52674,118 +52688,133 @@
       "integrity": "sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA=="
     },
     "@liskhq/lisk-api-client": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-api-client/-/lisk-api-client-5.0.3.tgz",
-      "integrity": "sha512-ww4Rpb4V+WaSJe4co5WczpWuLB5ix97PXQgCHsCYijzVfsRGpaWjwp3PsyjleosFlLRKS2NytXyjhWkFkB/XDA==",
+      "version": "5.1.4-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-api-client/-/lisk-api-client-5.1.4-alpha.1.tgz",
+      "integrity": "sha512-zWBHfCiTWC1psnJTkUGxygHIXx8B0vTOP/lYSkVypuWZilDkW0dWXJBGmFsa8qAxaYDnMFogj8/kKdBEkIzorw==",
       "requires": {
-        "@liskhq/lisk-codec": "^0.1.1",
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-transactions": "^5.0.2",
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-transactions": "^5.2.0-alpha.1",
         "isomorphic-ws": "4.0.1",
-        "pm2-axon": "4.0.0",
-        "pm2-axon-rpc": "0.6.0",
-        "ws": "7.4.0"
+        "pm2-axon": "4.0.1",
+        "pm2-axon-rpc": "0.7.1",
+        "ws": "7.4.6"
       }
     },
     "@liskhq/lisk-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-client/-/lisk-client-5.0.1.tgz",
-      "integrity": "sha512-Fq6tRuOCp8ZY/9fnG6KvvJhq6FT4CUr7CZx/qu5C5hzp0cOsSXVtq3829+FekkruQOEpsys5meDm8JoJBdW9ZQ==",
+      "version": "5.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-client/-/lisk-client-5.2.0-alpha.1.tgz",
+      "integrity": "sha512-l8zfAofN7nPKP3Zt4fAhZ4md46MKwc6w2OJ62CkyYgmQEwW8ZNyMY6Bn48hVy+eiCRDWtoKfIxyf8mr9bavtNQ==",
       "requires": {
-        "@liskhq/lisk-api-client": "^5.0.1",
-        "@liskhq/lisk-codec": "^0.1.0",
-        "@liskhq/lisk-cryptography": "^3.0.0",
-        "@liskhq/lisk-passphrase": "^3.0.1",
-        "@liskhq/lisk-transactions": "^5.0.0",
-        "@liskhq/lisk-tree": "^0.1.0",
-        "@liskhq/lisk-utils": "^0.1.0",
-        "@liskhq/lisk-validator": "^0.5.0",
+        "@liskhq/lisk-api-client": "^5.1.4-alpha.1",
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-passphrase": "^3.1.0",
+        "@liskhq/lisk-transactions": "^5.2.0-alpha.1",
+        "@liskhq/lisk-tree": "^0.2.1-alpha.1",
+        "@liskhq/lisk-utils": "^0.2.0",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1",
         "buffer": "6.0.3"
       }
     },
     "@liskhq/lisk-codec": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-codec/-/lisk-codec-0.1.1.tgz",
-      "integrity": "sha512-otW7UlNRlgeZSz5Pj2lIzq2lbVclVOBgX/o0qtnGFa0+73bryiU17deymlqYYoCPAam9uVE3MFedu2sgpAlEYQ==",
+      "version": "0.2.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-codec/-/lisk-codec-0.2.1-alpha.1.tgz",
+      "integrity": "sha512-G0Q8GKZgmHARcTT5RuHp6UedHvnmLlxSFvzpwOB/AMAgaGGSvHvq4GvAF+XbhVUa097bum8ZzDL+rjO2OXCN4g==",
       "requires": {
-        "@liskhq/lisk-utils": "^0.1.0",
-        "@liskhq/lisk-validator": "^0.5.1"
+        "@liskhq/lisk-utils": "^0.2.0",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1"
       }
     },
     "@liskhq/lisk-cryptography": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-3.0.1.tgz",
-      "integrity": "sha512-jtYbRUMMjALICQI6MW7yvD7q1guVSADmD+JlhoNh64Ja6ff8ILm+zgQ7MCCp7j2r6pfsfIQzdsRxZhtHWBhfvA==",
+      "version": "3.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-cryptography/-/lisk-cryptography-3.2.0-alpha.1.tgz",
+      "integrity": "sha512-mXoCexnSbQRFooNkYdmjT3F9KZ39jCqAqxo7Y5v7PXh9r3nPo4pvSqYbz61EN/TzkEHBB671brrhyVZhTVm+QQ==",
       "requires": {
         "buffer-reverse": "1.0.1",
         "ed2curve": "0.3.0",
-        "sodium-native": "3.2.0",
+        "sodium-native": "3.2.1",
         "tweetnacl": "1.0.3",
         "varuint-bitcoin": "1.1.2"
       }
     },
     "@liskhq/lisk-passphrase": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-passphrase/-/lisk-passphrase-3.0.1.tgz",
-      "integrity": "sha512-x6gh0nA+cM9ldNaTG34fpyIGR3to0LJF1AKKElizrv0wesKO3+nIGssXY+HrPkXxreoUa/Ktid8LmDiSr3h2/w==",
+      "version": "3.1.0",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-passphrase/-/lisk-passphrase-3.1.0.tgz",
+      "integrity": "sha512-xylTDLNhyaZB9/9E6QvDv7uLi5iQodTGNOto4/nI5E2EteOBIc1F4/nb8dpccI1dxYIg9CXIGV8zXIQkV6RpGQ==",
       "requires": {
-        "bip39": "3.0.2"
+        "bip39": "3.0.3"
       }
     },
     "@liskhq/lisk-transactions": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-5.0.2.tgz",
-      "integrity": "sha512-cPSe7rPUJb5g3VypenMS0j9572son9SWgV4LtL1Mkl0YtRkLNRaUYb4SrQahHWv3IHQQ6gxem9MXkedMV4IqqQ==",
+      "version": "5.2.0-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-transactions/-/lisk-transactions-5.2.0-alpha.1.tgz",
+      "integrity": "sha512-XeFJCW5CpEbflCBVL7CiaDOzumqzepRenA3HFz2Vk5TK8AqjrrkUeXd4uqaANctFI3Ap1cHiigbU0Ms/JUFWZQ==",
       "requires": {
-        "@liskhq/lisk-codec": "^0.1.1",
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-validator": "^0.5.1"
+        "@liskhq/lisk-codec": "^0.2.1-alpha.1",
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-validator": "^0.6.1-alpha.1"
       }
     },
     "@liskhq/lisk-tree": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-tree/-/lisk-tree-0.1.1.tgz",
-      "integrity": "sha512-fnNqaTywcJyK4qDjoHLl7h86cgqSQO8rO+gu0CnBJPCdETIhO7LTAnAOGHi4uEVuUWsvK+l33ky8BI+zZjG+rQ==",
+      "version": "0.2.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-tree/-/lisk-tree-0.2.1-alpha.1.tgz",
+      "integrity": "sha512-07hrZ4jyohx/MLH7+984VLEsCZN4iFRCcJFIATtw5bgKksjQUyL0qaXVW3/YaSeEdKWR2GmPlXNxUcRdAUF5EA==",
       "requires": {
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@liskhq/lisk-utils": "^0.1.0"
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "@liskhq/lisk-utils": "^0.2.0"
       }
     },
     "@liskhq/lisk-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-utils/-/lisk-utils-0.1.0.tgz",
-      "integrity": "sha512-PR36Rxk6Nhg8Z6vvEIOpbeTuISaw23It6WhVyxEibH2RN2UPpUwDWR60BcIqZtR1FCK5vEcDMTvBXu1FgawbdA==",
+      "version": "0.2.0",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-utils/-/lisk-utils-0.2.0.tgz",
+      "integrity": "sha512-BtrtugsNfnZD91iB7NJLE9lRmqcoIwUS/ww4p3OT7O6XLJXO9RvevoOBFAhjVFsDP82wxx8zR9+SkkDmkOQ21w==",
       "requires": {
         "lodash.clonedeep": "4.5.0"
       }
     },
     "@liskhq/lisk-validator": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@liskhq/lisk-validator/-/lisk-validator-0.5.1.tgz",
-      "integrity": "sha512-mIFRetkasdU7QoaoOmRWxHZaUXvKXWjAgA3wwn8wnSANArSVtWyM23xvfDVBLzPFRnMH9LfvSt66U8uYkGdIPg==",
+      "version": "0.6.1-alpha.1",
+      "resolved": "https://npm.lisk.io/@liskhq%2flisk-validator/-/lisk-validator-0.6.1-alpha.1.tgz",
+      "integrity": "sha512-SGkCwkIoxiY8hkQEYIcjUrT13j8mb+5SxzUkUTP9BYOP42CVyqQSCxMVQHpJgq/oRgSu9+IAZXpYDHpAVmxcQg==",
       "requires": {
-        "@liskhq/lisk-cryptography": "^3.0.1",
-        "@types/node": "12.12.11",
-        "@types/semver": "7.1.0",
-        "@types/validator": "12.0.1",
-        "ajv": "6.12.0",
-        "debug": "4.1.1",
-        "semver": "7.1.3",
-        "validator": "12.2.0"
+        "@liskhq/lisk-cryptography": "^3.2.0-alpha.1",
+        "ajv": "8.1.0",
+        "ajv-formats": "2.0.2",
+        "debug": "4.3.1",
+        "semver": "7.3.5",
+        "validator": "13.5.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+        "ajv": {
+          "version": "8.1.0",
+          "resolved": "https://npm.lisk.io/ajv/-/ajv-8.1.0.tgz",
+          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
           "requires": {
-            "ms": "^2.1.1"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
+        "ajv-formats": {
+          "version": "2.0.2",
+          "resolved": "https://npm.lisk.io/ajv-formats/-/ajv-formats-2.0.2.tgz",
+          "integrity": "sha512-Brah4Uo5/U8v76c6euTwtjVFFaVishwnJrQBYpev1JRh4vjA1F4HY3UzQez41YUCszUCXKagG8v6eVRBHV1gkw==",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://npm.lisk.io/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
         "semver": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
-          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+          "version": "7.3.5",
+          "resolved": "https://npm.lisk.io/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -58329,14 +58358,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
-    "@types/semver": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
-      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/sinonjs__fake-timers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
@@ -58389,11 +58410,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
-    },
-    "@types/validator": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-12.0.1.tgz",
-      "integrity": "sha512-l57fIANZLMe8DArz+SDb+7ATXnDm15P7u2wHBw5mb0aSMd+UuvmvhouBF2hdLgQPDMJ39sh9g2MJO4GkZ0VAdQ=="
     },
     "@types/verror": {
       "version": "1.10.4",
@@ -59000,12 +59016,12 @@
     },
     "amp": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
+      "resolved": "https://npm.lisk.io/amp/-/amp-0.3.1.tgz",
       "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0="
     },
     "amp-message": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
+      "resolved": "https://npm.lisk.io/amp-message/-/amp-message-0.1.2.tgz",
       "integrity": "sha1-p48cmJlQh602GSpBKY5NtJ49/EU=",
       "requires": {
         "amp": "0.3.1"
@@ -60665,9 +60681,9 @@
       "integrity": "sha1-XbBBataCJxLwd4NuJVe4aXwMfJk="
     },
     "bip39": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.2.tgz",
-      "integrity": "sha512-J4E1r2N0tUylTKt07ibXvhpT2c5pyAFgvuA5q1H9uDy6dEGpjV8jmymh3MTYJDLCNbIVClSB9FbND49I6N24MQ==",
+      "version": "3.0.3",
+      "resolved": "https://npm.lisk.io/bip39/-/bip39-3.0.3.tgz",
+      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
       "requires": {
         "@types/node": "11.11.6",
         "create-hash": "^1.1.0",
@@ -60677,7 +60693,7 @@
       "dependencies": {
         "@types/node": {
           "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "resolved": "https://npm.lisk.io/@types%2fnode/-/node-11.11.6.tgz",
           "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
         }
       }
@@ -61326,7 +61342,7 @@
     },
     "buffer-reverse": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+      "resolved": "https://npm.lisk.io/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
       "integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
     },
     "buffer-xor": {
@@ -64761,7 +64777,7 @@
     },
     "ed2curve": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
+      "resolved": "https://npm.lisk.io/ed2curve/-/ed2curve-0.3.0.tgz",
       "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
       "requires": {
         "tweetnacl": "1.x.x"
@@ -70662,7 +70678,7 @@
     },
     "isomorphic-ws": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "resolved": "https://npm.lisk.io/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "requires": {}
     },
@@ -74451,13 +74467,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
-        },
-        "ws": {
-          "version": "7.4.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-          "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
-          "dev": true,
-          "requires": {}
         }
       }
     },
@@ -76535,9 +76544,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
-      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==",
+      "version": "4.3.0",
+      "resolved": "https://npm.lisk.io/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
       "optional": true
     },
     "node-hid": {
@@ -78165,39 +78174,29 @@
       }
     },
     "pm2-axon": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-4.0.0.tgz",
-      "integrity": "sha512-A8dy0C57cRIm+kX58HrMcnvUdg8EdwCuCmavDdmFE4eoUE+5zfwGbDfZKCBVLNpDwjXPuXQQYZi3wQt/5xC8DQ==",
+      "version": "4.0.1",
+      "resolved": "https://npm.lisk.io/pm2-axon/-/pm2-axon-4.0.1.tgz",
+      "integrity": "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg==",
       "requires": {
         "amp": "~0.3.1",
         "amp-message": "~0.1.1",
-        "debug": "^4.2",
+        "debug": "^4.3.1",
         "escape-string-regexp": "^4.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "resolved": "https://npm.lisk.io/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
     "pm2-axon-rpc": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.6.0.tgz",
-      "integrity": "sha512-xjYR0y1HpOopJ09VL2Qd5H1LajVN+QLPVZ1G+GesbORJDAZiStMhwECtOzm/Gx5ANQxL0usW8WZsElMfQq2hbw==",
+      "version": "0.7.1",
+      "resolved": "https://npm.lisk.io/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
+      "integrity": "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==",
       "requires": {
-        "debug": "^3.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "debug": "^4.3.1"
       }
     },
     "pn": {
@@ -83784,9 +83783,9 @@
       }
     },
     "sodium-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-3.2.0.tgz",
-      "integrity": "sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==",
+      "version": "3.2.1",
+      "resolved": "https://npm.lisk.io/sodium-native/-/sodium-native-3.2.1.tgz",
+      "integrity": "sha512-EgDZ/Z7PxL2kCasKk7wnRkV8W9kvwuIlHuHXAxkQm3FF0MgVsjyLBXGjSRGhjE6u7rhSpk3KaMfFM23bfMysIQ==",
       "optional": true,
       "requires": {
         "ini": "^1.3.5",
@@ -85886,7 +85885,7 @@
     },
     "tweetnacl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "resolved": "https://npm.lisk.io/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type": {
@@ -86668,9 +86667,9 @@
       }
     },
     "validator": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+      "version": "13.5.2",
+      "resolved": "https://npm.lisk.io/validator/-/validator-13.5.2.tgz",
+      "integrity": "sha512-mD45p0rvHVBlY2Zuy3F3ESIe1h5X58GPfAtslBjY7EtTqGquZTj+VX/J4RnHWN8FKq0C9WRVt1oWAcytWRuYLQ=="
     },
     "value-equal": {
       "version": "0.4.0",
@@ -88692,9 +88691,9 @@
       }
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.6",
+      "resolved": "https://npm.lisk.io/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-node-hid": "5.50.0",
     "@ledgerhq/hw-transport-u2f": "5.33.1-alpha.3",
-    "@liskhq/lisk-client": "5.0.1",
+    "@liskhq/lisk-client": "5.2.0-alpha.1",
     "@testing-library/react-hooks": "5.1.2",
     "await-to-js": "2.1.1",
     "bignumber.js": "8.0.1",


### PR DESCRIPTION
### What was the problem?

This PR resolves #3804

### How was it solved?

With the latest version of lisk-client the buffer issue has been resolved by exporting nodejs verions by default
Update webpack to to ignore os fallback to false since we do not use lisk-api-client

### How was it tested?

- npm ci
- npm run test
- npm run dev
