### PR TITLE
 Fix recovery passphrase warning disappearance - Closes #3857 

### DIFF
--- a/src/components/screens/login/login.js
+++ b/src/components/screens/login/login.js
@@ -100,7 +100,6 @@ const Login = ({
               <DiscreetModeToggle className={styles.discreetMode} />
               <RecoveryPhrase
                 t={t}
-                account={account}
                 isRecoveryPhraseMode={isRecoveryPhraseMode}
                 setIsRecoveryPhrase={setIsRecoveryPhrase}
                 derivationPath={derivationPath}

--- a/src/components/screens/login/recoveryPhrase/index.js
+++ b/src/components/screens/login/recoveryPhrase/index.js
@@ -3,7 +3,6 @@ import CheckBox from '@toolbox/checkBox';
 import { Input } from '@toolbox/inputs';
 import WarningMessage from '@shared/warningMessage';
 import FlashMessageHolder from '@toolbox/flashMessage/holder';
-import { isEmpty } from '@utils/helpers';
 import styles from './recoveryPhrase.css';
 
 const addWarningMessage = (t) => {
@@ -27,9 +26,8 @@ const removeWarningMessage = () => {
 };
 
 const RecoveryPhrase = ({
-  t, account,
+  t, derivationPath, setDerivationPath,
   isRecoveryPhraseMode, setIsRecoveryPhrase,
-  derivationPath, setDerivationPath,
 }) => {
   const [showCustomDerivationPath, setShowCustomDerivationPath] = useState(false);
 
@@ -41,11 +39,7 @@ const RecoveryPhrase = ({
     }
   }, [isRecoveryPhraseMode]);
 
-  useEffect(() => {
-    if (!isEmpty(account)) {
-      removeWarningMessage();
-    }
-  }, [account]);
+  useEffect(() => removeWarningMessage, []);
 
   return (
     <>
@@ -85,4 +79,4 @@ const RecoveryPhrase = ({
   );
 };
 
-export default RecoveryPhrase;
+export default React.memo(RecoveryPhrase);


### PR DESCRIPTION
### What was the problem?

This PR resolves #3857

### How was it solved?
The `RecoveryPhrase` component was getting re-rendered unnecessarily. This was because the reference to `account` property gets updated with every new block event.
Account was passed to the `RecoveryPhrase` to check if the login was successful and remove the message. I did that on `componentWillUnmount` without passing the account. Also to prevent any noop re-render cycles due to property reference changes, I wrapped `RecoveryPhrase` in `React.memo`.

### How was it tested?
Check the recovery mode. Wait for a few blocks. did the message disappear?
