### PR TITLE
Sign message using account private key - Closes #3895 

### DIFF
--- a/src/components/screens/signMessage/confirmMessage.js
+++ b/src/components/screens/signMessage/confirmMessage.js
@@ -78,7 +78,7 @@ const ConfirmMessage = ({
     ref.current = setTimeout(() => setCopied(false), 3000);
   };
 
-  const signUsingPassphrase = () => {
+  const signUsingPrivateKey = () => {
     const msgBytes = cryptography.digestMessage(message);
     const signedMessage = cryptography.signDataWithPrivateKey(msgBytes, Buffer.from(account.summary.privateKey, 'hex'));
     const result = cryptography.printSignedMessage({
@@ -104,7 +104,7 @@ const ConfirmMessage = ({
 
   useEffect(() => {
     if (account.loginType === loginTypes.passphrase.code) {
-      setSignature(signUsingPassphrase());
+      setSignature(signUsingPrivateKey());
     } else {
       signUsingHW()
         .then(setSignature)


### PR DESCRIPTION
### What was the problem?

This PR resolves #3895

### How was it solved?
- Replaced `ignMessageWithPassphrase` with a combination of `digestMessage` and `signDataWithPrivateKey`.

### How was it tested?
Since tests are testing the HOC, they still apply even after I refactored the `SignMessage` component. Also tested manually.
