### PR TITLE
Prevent login without passphrase - Closes #4025

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -282,6 +282,7 @@
   "Min": "Min",
   "Minimize": "Minimize",
   "Missed slot": "Missed slot",
+  "Modify recovery phrase derivation path": "Modify recovery phrase derivation path",
   "More filters": "More filters",
   "Multisignature account details": "Multisignature account details",
   "Multisignatures": "Multisignatures",

--- a/src/components/screens/login/login.js
+++ b/src/components/screens/login/login.js
@@ -56,7 +56,9 @@ const Login = ({
   const onFormSubmit = (e) => {
     e.preventDefault();
     Piwik.trackingEvent('Login', 'button', 'Login submission');
-    login({ passphrase: passphrase.value });
+    if (passphrase.value) {
+      login({ passphrase: passphrase.value });
+    }
   };
 
   const handleKeyPress = (e) => {

--- a/src/components/screens/login/login.js
+++ b/src/components/screens/login/login.js
@@ -56,7 +56,7 @@ const Login = ({
   const onFormSubmit = (e) => {
     e.preventDefault();
     Piwik.trackingEvent('Login', 'button', 'Login submission');
-    if (passphrase.value) {
+    if (passphrase.value && passphrase.isValid) {
       login({ passphrase: passphrase.value });
     }
   };

--- a/src/components/screens/login/login.test.js
+++ b/src/components/screens/login/login.test.js
@@ -8,7 +8,6 @@ import { defaultDerivationPath } from '@utils/explicitBipKeyDerivation';
 import { settingsUpdated } from '@actions';
 import Login from './login';
 import accounts from '../../../../test/constants/accounts';
-import login from '.';
 
 jest.mock('@toolbox/flashMessage/holder', () => ({
   addMessage: jest.fn(),

--- a/src/components/screens/login/login.test.js
+++ b/src/components/screens/login/login.test.js
@@ -8,6 +8,7 @@ import { defaultDerivationPath } from '@utils/explicitBipKeyDerivation';
 import { settingsUpdated } from '@actions';
 import Login from './login';
 import accounts from '../../../../test/constants/accounts';
+import login from '.';
 
 jest.mock('@toolbox/flashMessage/holder', () => ({
   addMessage: jest.fn(),
@@ -45,6 +46,8 @@ describe('Login', () => {
     },
   };
 
+  let props;
+
   const history = {
     location: {
       pathname: '',
@@ -58,24 +61,24 @@ describe('Login', () => {
     url: routes.login.path,
   };
 
-  const props = {
-    network,
-    match,
-    account,
-    history,
-    settings,
-    t: data => data,
-    login: jest.fn(),
-    onAccountUpdated: jest.fn(),
-    accountsRetrieved: jest.fn(),
-    settingsUpdated: jest.fn(),
-    liskAPIClient: jest.fn(),
-  };
-
   const { passphrase } = accounts.genesis;
 
   beforeEach(() => {
     jest.restoreAllMocks();
+    props = {
+      network,
+      match,
+      account,
+      history,
+      settings,
+      t: data => data,
+      login: jest.fn(),
+      onAccountUpdated: jest.fn(),
+      accountsRetrieved: jest.fn(),
+      settingsUpdated: jest.fn(),
+      liskAPIClient: jest.fn(),
+    };
+
     localStorage.getItem = jest.fn().mockReturnValue(JSON.stringify(undefined));
     wrapper = mount(<Login {...props} />);
   });
@@ -128,6 +131,16 @@ describe('Login', () => {
       expect(props.login).toHaveBeenCalledWith({
         passphrase: accounts.delegate.passphrase,
       });
+    });
+
+    it('should not login if passphrase is empty', () => {
+      const clipboardData = {
+        getData: () => '',
+      };
+      wrapper.find('passphraseInput input').first().simulate('paste', { clipboardData });
+      wrapper.update();
+      wrapper.find('button.login-button').simulate('submit');
+      expect(props.login).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4025 

### How was it solved?

Ensuring passphrase is not empty before triggering log in.

### How was it tested?

Visually.
