### PR TITLE
Fixed status sorting issue on delegates sanctioned tab - Closes #3989

### DIFF
--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -108,8 +108,6 @@ const DelegatesMonitor = ({
     });
   }
 
-  console.log('>>>> ', sanctionedDelegates);
-
   return (
     <div>
       <DelegatesOverview

--- a/src/components/screens/monitor/delegates/delegates.js
+++ b/src/components/screens/monitor/delegates/delegates.js
@@ -108,6 +108,8 @@ const DelegatesMonitor = ({
     });
   }
 
+  console.log('>>>> ', sanctionedDelegates);
+
   return (
     <div>
       <DelegatesOverview

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -194,22 +194,24 @@ describe('Delegates monitor page', () => {
     expect(wrapper.find('a.delegate-row')).toHaveLength(blocks.forgers.length);
   });
 
-  it('properly sorts  delegates by their status', () => {
+  it('properly sorts delegates by their status', () => {
     initSanctionedProps();
     wrapper = setup(props);
     switchTab('sanctioned');
+
     const sortByBtn = wrapper.find('span.sort-by');
     const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());
     statuses.forEach((status, index) => {
       expect(status).equal(index === 1 ? 'Punished' : 'Banned');
     });
 
-    sortByBtn.simulate('click');
+    sortByBtn.last().simulate('click');
 
     statuses.forEach((status, index) => {
       expect(status).equal(index === 2 ? 'Banned' : 'Punished');
     });
-    sortByBtn.simulate('click');
+
+    sortByBtn.last().simulate('click');
 
     statuses.forEach((status, index) => {
       expect(status).equal(index === 2 ? 'Punished' : 'Banned');

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -200,7 +200,7 @@ describe('Delegates monitor page', () => {
     switchTab('sanctioned');
 
     const sortByBtn = wrapper.find('span.sort-by');
-    const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());git
+    const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());
     statuses.forEach((status, index) => {
       expect(status).equal(index === 1 ? 'Punished' : 'Banned');
     });

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -43,6 +43,59 @@ describe('Delegates monitor page', () => {
     });
   };
 
+  function initSanctionedProps() {
+    props.sanctionedDelegates = {
+      isLoading: false,
+      data: [
+        {
+          address: 'lsktaa9xuys6hztyaryvx6msu279mpkn9sz6w5or2',
+          consecutiveMissedBlocks: 220,
+          isBanned: true,
+          lastForgedHeight: 16695471,
+          producedBlocks: 1404,
+          rank: 1563,
+          registrationHeight: 16331164,
+          rewards: '140200000000',
+          status: 'banned',
+          totalVotesReceived: '2170000000000',
+          username: 'ziqi',
+          voteWeight: '0',
+        },
+        {
+          address: 'lsksaca4v9r3uotdzdhje3smwa49rvj2h2sn5yskt',
+          consecutiveMissedBlocks: 0,
+          isBanned: false,
+          lastForgedHeight: 16784595,
+          producedBlocks: 4929,
+          rank: 1503,
+          registrationHeight: 16270293,
+          rewards: '491800000000',
+          status: 'punished',
+          totalVotesReceived: '8771000000000',
+          username: 'liskjp',
+          voteWeight: '0',
+        },
+        {
+          address: 'lskr39gqjxhepd9o5txgmups9zjhjaadfjgm5dc87',
+          consecutiveMissedBlocks: 229,
+          isBanned: true,
+          lastForgedHeight: 16739690,
+          producedBlocks: 2014,
+          rank: 1436,
+          registrationHeight: 16270293,
+          rewards: '201125000000',
+          status: 'banned',
+          totalVotesReceived: '2356000000000',
+          username: 'acheng',
+          voteWeight: '0',
+        },
+      ],
+      loadData: jest.fn(),
+      clearData: jest.fn(),
+      urlSearchParams: {},
+    };
+  }
+
   const { blocks } = store.getState();
 
   beforeEach(() => {
@@ -139,5 +192,27 @@ describe('Delegates monitor page', () => {
   it('renders the forging status', () => {
     wrapper = setup(props);
     expect(wrapper.find('a.delegate-row')).toHaveLength(blocks.forgers.length);
+  });
+
+  it('properly sorts  delegates by their status', () => {
+    initSanctionedProps();
+    wrapper = setup(props);
+    switchTab('sanctioned');
+    const sortByBtn = wrapper.find('span.sort-by');
+    const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());
+    statuses.forEach((status, index) => {
+      expect(status).equal(index === 1 ? 'Punished' : 'Banned');
+    });
+
+    sortByBtn.simulate('click');
+
+    statuses.forEach((status, index) => {
+      expect(status).equal(index === 2 ? 'Banned' : 'Punished');
+    });
+    sortByBtn.simulate('click');
+
+    statuses.forEach((status, index) => {
+      expect(status).equal(index === 2 ? 'Punished' : 'Banned');
+    });
   });
 });

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -211,7 +211,7 @@ describe('Delegates monitor page', () => {
       expect(status).equal(index === 2 ? 'Banned' : 'Punished');
     });
 
-    sortByBtn.last().simulate('click');
+    wrapper.find('span.sort-by').at(1).simulate('click');
 
     statuses.forEach((status, index) => {
       expect(status).equal(index === 2 ? 'Punished' : 'Banned');

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -200,7 +200,7 @@ describe('Delegates monitor page', () => {
     switchTab('sanctioned');
 
     const sortByBtn = wrapper.find('span.sort-by');
-    const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());
+    const statuses = wrapper.find('a.delegate-row > span:first-child ~ span ~ span > span').map(ele => ele.text());git
     statuses.forEach((status, index) => {
       expect(status).equal(index === 1 ? 'Punished' : 'Banned');
     });
@@ -212,7 +212,6 @@ describe('Delegates monitor page', () => {
     });
 
     wrapper.find('span.sort-by').at(1).simulate('click');
-
     statuses.forEach((status, index) => {
       expect(status).equal(index === 2 ? 'Punished' : 'Banned');
     });

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -213,8 +213,8 @@ describe('Delegates monitor page', () => {
 
     sortByBtn.last().simulate('click');
 
-    // statuses.forEach((status, index) => {
-    //   expect(status).equal(index === 2 ? 'Punished' : 'Banned');
-    // });
+    statuses.forEach((status, index) => {
+      expect(status).equal(index === 2 ? 'Punished' : 'Banned');
+    });
   });
 });

--- a/src/components/screens/monitor/delegates/delegates.test.js
+++ b/src/components/screens/monitor/delegates/delegates.test.js
@@ -213,8 +213,8 @@ describe('Delegates monitor page', () => {
 
     sortByBtn.last().simulate('click');
 
-    statuses.forEach((status, index) => {
-      expect(status).equal(index === 2 ? 'Punished' : 'Banned');
-    });
+    // statuses.forEach((status, index) => {
+    //   expect(status).equal(index === 2 ? 'Punished' : 'Banned');
+    // });
   });
 });

--- a/src/components/screens/monitor/delegates/delegatesTable/index.js
+++ b/src/components/screens/monitor/delegates/delegatesTable/index.js
@@ -25,6 +25,7 @@ const TableWrapper = compose(
       }
       return 0;
     },
+    sanctionedStatus: (a, b, direction) => (((direction === 'asc' ? a.status > b.status : b.status > a.status) ? 1 : -1)),
   }),
 )(({
   delegates, handleLoadMore, t, activeTab, blocks,

--- a/src/components/screens/monitor/delegates/delegatesTable/index.js
+++ b/src/components/screens/monitor/delegates/delegatesTable/index.js
@@ -25,7 +25,7 @@ const TableWrapper = compose(
       }
       return 0;
     },
-    sanctionedStatus: (a, b, direction) => (((direction === 'asc' ? a.status > b.status : b.status > a.status) ? 1 : -1)),
+    sanctionedStatus: (a, b, direction) => ((direction === 'asc' ? a.status > b.status : b.status > a.status) ? 1 : -1),
   }),
 )(({
   delegates, handleLoadMore, t, activeTab, blocks,

--- a/src/components/screens/monitor/delegates/delegatesTable/tableHeader.js
+++ b/src/components/screens/monitor/delegates/delegatesTable/tableHeader.js
@@ -106,7 +106,7 @@ export default (activeTab, changeSort, t) => ([
     classList: getStatusClass(activeTab),
     sort: {
       fn: changeSort,
-      key: 'status',
+      key: activeTab === 'sanctioned' ? 'sanctionedStatus' : 'status',
     },
   },
 ]);


### PR DESCRIPTION
### What was the problem?

#3989

### How was it solved?

It was solved by creating a different sort function for sanctioned delegate statues

### How was it tested?

- Switch the network to Devnet
- Navigate to the delegates page
- Clicking on the sanctioned tab shows a list of delegates that have a neutral sorting by status
- Clicking on the `status` column header sorts the delegates by their respective statuses
