### PR TITLE
Fix username checker in the register delegate window - Closes #4051 

### DIFF
--- a/src/components/screens/registerDelegate/form/form.js
+++ b/src/components/screens/registerDelegate/form/form.js
@@ -96,7 +96,7 @@ const SelectNameAndFee = ({
   };
 
   const isUsernameFree = (username) => {
-    clearTimeout(timeout);
+    clearTimeout(timeout.current);
 
     timeout.current = setTimeout(() => {
       getDelegate({ network, params: { username } })


### PR DESCRIPTION
### What was the problem?

This PR resolves #4051

### How was it solved?

The debouncer wasn't clearing the timeout correctly.  I couldn't reproduce the issue. but this seems to be a runtime issue caused by the debouncer. 

### How was it tested?
Manually.
