### PR TITLE
Cherry pick e2e test changes from development to release/2.2.0 - Closes #4084

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ cypress.log
 ## Commercial fonts
 src/assets/fonts/basier-circle/
 src/assets/fonts/gilroy/
+
+## Cypress
+test/cypress/cypress
+test/cypress/screenshots
+test/cypress/videos

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
 								install -D test/dev_config_and_db/genesis_block.json ~/.lisk/lisk-core/config/devnet/genesis_block.json
 								./lisk-core/bin/lisk-core blockchain:import --force test/dev_config_and_db/tokens_unlocked_dev_blockchain.db.tar.gz
 								./lisk-core/bin/lisk-core forger-info:import --force test/dev_config_and_db/forger.db.tar.gz
-								nohup ./lisk-core/bin/lisk-core start --network=devnet --api-ws --api-ws-host=0.0.0.0 --api-ws-port=8080 --enable-forger-plugin --enable-http-api-plugin >lisk-core.out 2>lisk-core.err &
+								nohup ./lisk-core/bin/lisk-core start --network=devnet --api-ws --api-ws-host=0.0.0.0 --api-ws-port=8080 --enable-http-api-plugin >lisk-core.out 2>lisk-core.err &
 								echo $! >lisk-core.pid
 
 								# wait for core to be up and running

--- a/src/components/shared/transactionInfo/voteDelegate.js
+++ b/src/components/shared/transactionInfo/voteDelegate.js
@@ -33,7 +33,7 @@ const VoteDelegate = ({
   const addedLength = Object.keys(added).length;
   const editedLength = Object.keys(edited).length;
   const removedLength = Object.keys(removed).length;
-  const sentVotes = account.dpos?.sentVotes?.length ?? 0;
+  const sentVotes = account?.dpos?.sentVotes?.length ?? 0;
 
   return (
     <>

--- a/src/store/actions/blocks.js
+++ b/src/store/actions/blocks.js
@@ -78,7 +78,7 @@ export const forgersRetrieved = () => async (dispatch, getState) => {
     forgers = data.map((forger, index) => {
       forger.rank = delegates.data.find(
         delegate => forger.address === delegate.summary.address,
-      ).dpos?.delegate?.rank;
+      )?.dpos?.delegate?.rank;
       indexBook[forger.address] = index;
       if (haveForgedInRound.indexOf(forger.username) > -1) {
         return { ...forger, state: 'forging' };

--- a/src/store/actions/voting.js
+++ b/src/store/actions/voting.js
@@ -49,9 +49,9 @@ export const voteEdited = data => async (dispatch, getState) => {
     if (vote.username) {
       return vote;
     }
-    const account = await getAccount({
+    const account = (await getAccount({
       network, params: { address: vote.address },
-    }, settings.token.active);
+    }, settings.token.active)) || {};
     const username = account.dpos?.delegate?.username ?? '';
 
     return { ...vote, username };

--- a/test/cypress/features/bookmark.feature
+++ b/test/cypress/features/bookmark.feature
@@ -2,6 +2,7 @@ Feature: Add bookmark
 
   Background:
     Given I login as genesis on devnet
+    And I wait 5 seconds
     Given I am on wallet page
     When I click on searchIcon
 

--- a/test/cypress/features/dashboard.feature
+++ b/test/cypress/features/dashboard.feature
@@ -2,6 +2,7 @@ Feature: Dashboard
   Background:
     Given I have a bookmark saved
     Given I login as genesis on devnet
+    And I wait 5 seconds
     Given I am on wallet page
 
   Scenario: Open last transaction and open a bookmark item

--- a/test/cypress/features/delegateReg.feature
+++ b/test/cypress/features/delegateReg.feature
@@ -1,6 +1,7 @@
 Feature: Register delegate
     Background:
         Given I login as genesis on devnet
+        And I wait 5 seconds
 
    Scenario: Register delegate + Header balance is affected
         Given I am on wallet page

--- a/test/cypress/features/txTable_filtering.feature
+++ b/test/cypress/features/txTable_filtering.feature
@@ -2,6 +2,7 @@ Feature: Transaction table filtering
 
   Background:
     Given I login as genesis on devnet
+    And I wait 5 seconds
     Given I am on Wallet page
     And I click on filterTransactionsBtn
 

--- a/test/cypress/features/voting.feature
+++ b/test/cypress/features/voting.feature
@@ -2,6 +2,7 @@ Feature: Vote delegate
 
    Background:
       Given I login as genesis on devnet
+      And I wait 5 seconds
       Given I am on wallet page
       When I click on searchIcon
       And I search for account genesis_69

--- a/test/cypress/features/wallet.feature
+++ b/test/cypress/features/wallet.feature
@@ -2,6 +2,7 @@ Feature: Wallet
 
   Background:
     Given I login as genesis on devnet
+    And I wait 5 seconds
     Given I am on wallet page
     
   Scenario: 30 tx are shown, clicking show more loads more transactions


### PR DESCRIPTION
### What was the problem?

#4084 

### How was it solved?

- [x] Get e2e changes which were on development but not on releasea/2.2.0

### How was it tested?

on jenkins
