### PR TITLE
Enable e2e test for mainnet login - Closes #4095

### DIFF
--- a/test/cypress/features/login.feature
+++ b/test/cypress/features/login.feature
@@ -1,13 +1,12 @@
 Feature: Login
-  # @todo: would be re-insisted when #4089 has been resolved
-  #
-  # Scenario: Log in to Mainnet (Network switcher is not enabled)
-  #   Given Network switcher is disabled
-  #   Given I am on Login page
-  #   When I enter the passphrase of mainnet_guy
-  #   When I login
-  #   Then I should be connected to mainnet
-  #   Given  I wait 4 seconds
+
+  Scenario: Log in to Mainnet (Network switcher is not enabled)
+    Given Network switcher is disabled
+    Given I am on Login page
+    When I enter the passphrase of mainnet_guy
+    When I login
+    Then I should be connected to mainnet
+    Given  I wait 4 seconds
 
   Scenario: Log in to Testnet
     Given Network switcher is disabled


### PR DESCRIPTION
### What was the problem?

This PR resolves #4095

### How was it solved?

- [x] uncomment mainnet login e2e test step
- [x] locally test that mainnet login e2e passes

### How was it tested?

on Jenkins
