### PR TITLE
Fix account retrieval logic in the votes tab of the wallet page - Closes #4115

### DIFF
--- a/src/components/screens/wallet/votes/votes.js
+++ b/src/components/screens/wallet/votes/votes.js
@@ -17,7 +17,7 @@ const getMessages = t => ({
 });
 
 const Votes = ({
-  votes, accounts, address, t, history, sentVotes = {},
+  votes, accounts, address, t, history,
 }) => {
   const [filterValue, setFilterValue] = useState('');
   const messages = getMessages(t);
@@ -33,15 +33,15 @@ const Votes = ({
 
   useEffect(() => {
     votes.loadData({ address });
-  }, [address, sentVotes]);
+  }, [address]);
 
   // Fetch delegate profiles to define rank, productivity and delegate weight
   useEffect(() => {
-    const addressList = Object.keys(sentVotes);
+    const addressList = votes.data.map(item => item.address);
     if (isEmpty(accounts.data) && addressList.length) {
       accounts.loadData({ addressList, isDelegate: true });
     }
-  }, [sentVotes]);
+  }, [votes.data]);
 
   const areLoading = accounts.isLoading || votes.isLoading;
   const filteredVotes = votes.data.filter((vote) => {

--- a/src/components/screens/wallet/votes/votes.test.js
+++ b/src/components/screens/wallet/votes/votes.test.js
@@ -10,6 +10,10 @@ describe('Votes Tab Component', () => {
       data: [],
       loadData: jest.fn(),
     },
+    emptyVotes: {
+      data: [],
+      loadData: jest.fn(),
+    },
     accounts: {
       data: {},
       loadData: jest.fn(),
@@ -51,15 +55,20 @@ describe('Votes Tab Component', () => {
     const loadData = jest.fn();
     wrapper = setup({
       ...props,
-      votes: { ...props.votes, isLoading: true },
+      votes: { ...votes, isLoading: true },
       accounts: { data: [], loadData },
-      sentVotes: {
-        lskwhocotuu6bwnhwgjt859ugp467f8kuhdo5xfd6: [],
-        skaqeqqvkxzvt8g6kbukma8pu5cwpe6w2fjc5amc: [],
-      },
     });
     expect(loadData).toBeCalledWith({
-      addressList: ['lskwhocotuu6bwnhwgjt859ugp467f8kuhdo5xfd6', 'skaqeqqvkxzvt8g6kbukma8pu5cwpe6w2fjc5amc'],
+      addressList: ['lsk0',
+        'lsk1',
+        'lsk2',
+        'lsk3',
+        'lsk4',
+        'lsk5',
+        'lsk6',
+        'lsk7',
+        'lsk8',
+        'lsk9'],
       isDelegate: true,
     });
   });
@@ -67,7 +76,7 @@ describe('Votes Tab Component', () => {
     const loadData = jest.fn();
     wrapper = setup({
       ...props,
-      votes: { ...props.votes, isLoading: true },
+      votes: { ...props.emptyVotes, isLoading: true },
       accounts: { data: [], loadData },
     });
     expect(loadData).not.toHaveBeenCalled();


### PR DESCRIPTION
### What was the problem?

This PR resolves #4115 

### How was it solved?

- Fetch `sentVotes` from the correct endpoint.

### How was it tested?

Added unit tests
