### PR TITLE
e2e test for network monitor screen - Closes #4098 

### DIFF
--- a/test/constants/selectors.js
+++ b/test/constants/selectors.js
@@ -238,6 +238,9 @@ const ss = {
   backToWalletButton: '.back-to-wallet-button',
   accountsRow: '.accounts-row',
   showMoreAccountsBtn: '.accounts-box .load-more',
+  peerRow: '.peer-row',
+  showMorePeersBtn: '.peers-box .load-more',
+  sortByBtn: '.sort-by',
 };
 
 export default ss;

--- a/test/constants/urls.js
+++ b/test/constants/urls.js
@@ -16,6 +16,7 @@ const urls = {
   delegatesVote: '/delegates/vote',
   signMessage: '/sign-message',
   login: '/login',
+  network: '/network',
 };
 
 export default urls;

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -246,4 +246,9 @@ Then(/^I wait (.*?) seconds$/, function (seconds) {
   cy.wait(Number(seconds) * 1000);
 });
 
+When(/^I sort by (\w+)$/, function (sortParam) {
+  cy.wait(100);
+  cy.get(`${ss.sortByBtn}.${sortParam}`).eq(0).click();
+});
+
 

--- a/test/cypress/features/network.feature
+++ b/test/cypress/features/network.feature
@@ -16,7 +16,7 @@ Feature: Network
     Then I should have 40 peers rendered in table
     And peers should be sorted in descending order by height
 
-    Scenario: I should see peers sorted in ascending order by height
+  Scenario: I should see peers sorted in ascending order by height
     When I click on showMorePeersBtn
     And I wait 1 seconds
     And I sort by height

--- a/test/cypress/features/network.feature
+++ b/test/cypress/features/network.feature
@@ -1,0 +1,23 @@
+Feature: Network
+
+  Background:
+    Given Network switcher is enabled
+    And Network is set to testnet    
+    Given I am on network page
+    And I wait 1 seconds
+
+  Scenario: I should see initally loaded peers sorted by height in descending order
+    Then I should have 20 peers rendered in table
+    And peers should be sorted in descending order by height
+
+  Scenario: I should be able to load more peers sorted by height in descending order
+    And I click on showMorePeersBtn
+    And I wait 1 seconds
+    Then I should have 40 peers rendered in table
+    And peers should be sorted in descending order by height
+
+    Scenario: I should see peers sorted in ascending order by height
+    When I click on showMorePeersBtn
+    And I wait 1 seconds
+    And I sort by height
+    Then peers should be sorted in ascending order by height

--- a/test/cypress/features/network/network.js
+++ b/test/cypress/features/network/network.js
@@ -7,11 +7,11 @@ Then(/^I should have (\d+) peers rendered in table$/, function (number) {
 });
 
 Then(/^peers should be sorted in (\w+) order by height$/, function (sortOrder) {
-  let prevHeight = sortOrder === 'descending'? Infinity : -Infinity;
+  let prevHeight = sortOrder === 'descending' ? Infinity : -Infinity;
 
-  cy.get(`${ss.peerRow}`).each((ele) =>{
-    const height = parseInt(ele[0].lastElementChild.innerText);
-    expect(height)[sortOrder === 'descending'? 'lte': 'gte'](prevHeight);
+  cy.get(`${ss.peerRow}`).each((ele) => {
+    const height = +ele[0].lastElementChild.innerText;
+    expect(height)[sortOrder === 'descending' ? 'lte' : 'gte'](prevHeight);
     prevHeight = height;
   })
 }); 

--- a/test/cypress/features/network/network.js
+++ b/test/cypress/features/network/network.js
@@ -1,0 +1,18 @@
+/* eslint-disable */
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+import { ss } from '../../../constants';
+
+Then(/^I should have (\d+) peers rendered in table$/, function (number) {
+  cy.get(ss.peerRow).should('have.length', number);
+});
+
+Then(/^peers should be sorted in (\w+) order by height$/, function (sortOrder) {
+  let prevHeight = sortOrder === 'descending'? Infinity : -Infinity;
+
+  cy.get(`${ss.peerRow}`).each((ele) =>{
+    const height = parseInt(ele[0].lastElementChild.innerText);
+    expect(height)[sortOrder === 'descending'? 'lte': 'gte'](prevHeight);
+    prevHeight = height;
+  })
+}); 
+


### PR DESCRIPTION
### What was the problem?

This PR resolves #4098 

### How was it solved?
By implementing the following e2e scenarios against testnet;

- [x] e2e scenario to test that peers get rendered.
- [x] e2e scenario to test that initially rendered peers are sorted in descending order by height.
- [x] e2e scenario to test that peers are properly rendered when sorted by height.

### How was it tested?
on Jenkins
