### PR TITLE
Add e2e test for sign in message screen - Closes #4103

### DIFF
--- a/src/components/screens/signMessage/form/index.js
+++ b/src/components/screens/signMessage/form/index.js
@@ -41,7 +41,7 @@ const Form = ({ nextStep, t, history }) => {
         <label className={styles.fieldGroup}>
           <span>{t('Message')}</span>
           <AutoResizeTextarea
-            className={styles.textarea}
+            className={`${styles.textarea} sign-message-input`}
             name="message"
             onChange={onChange}
             value={message}

--- a/src/components/screens/signMessage/status/index.js
+++ b/src/components/screens/signMessage/status/index.js
@@ -42,7 +42,7 @@ const Success = ({
         onCopy={copy}
         text={signature}
       >
-        <PrimaryButton disabled={copied} className={styles.button}>
+        <PrimaryButton disabled={copied} className={`${styles.button} copy-to-clipboard`}>
           {copied ? t('Copied!') : t('Copy to clipboard')}
         </PrimaryButton>
       </CopyToClipboard>

--- a/test/constants/selectors.js
+++ b/test/constants/selectors.js
@@ -241,6 +241,9 @@ const ss = {
   peerRow: '.peer-row',
   showMorePeersBtn: '.peers-box .load-more',
   sortByBtn: '.sort-by',
+  signMessageInput: '.sign-message-input',
+  copyToClipboardBtn: '.copy-to-clipboard',
+  signedResult: '.result',
 };
 
 export default ss;

--- a/test/cypress/features/common/common.js
+++ b/test/cypress/features/common/common.js
@@ -251,4 +251,9 @@ When(/^I sort by (\w+)$/, function (sortParam) {
   cy.get(`${ss.sortByBtn}.${sortParam}`).eq(0).click();
 });
 
+Given(/^I open (\w+) modal$/, function (modal) {
+  cy.visit(`${urls.dashboard}?modal=${modal}`);
+
+});
+
 

--- a/test/cypress/features/sign_message.feature
+++ b/test/cypress/features/sign_message.feature
@@ -1,0 +1,13 @@
+Feature: Sign Message
+ 
+  Scenario: I should get the lisk signed message
+    Given I login as genesis on devnet
+    And I wait 2 seconds
+    And I open signMessage modal
+    When I fill test_Message in signMessageInput field
+    And I click on nextBtn
+    And I click on copyToClipboardBtn
+    Then I should have the signed message in the clipboard
+    And I click on closeDialog
+    
+

--- a/test/cypress/features/sign_message/sign_message.js
+++ b/test/cypress/features/sign_message/sign_message.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+import ss from '../../../constants/selectors';
+import { Then } from 'cypress-cucumber-preprocessor/steps';
+
+Then(/I should have the signed message in the clipboard/, function(){
+  cy.window().then((win) => {
+    const signedMessage = win.document.querySelector(ss.signedResult).innerHTML
+
+    win.navigator.clipboard.readText().then((text) => {
+      expect(text).to.eq(signedMessage);
+    });
+  });
+})


### PR DESCRIPTION
### What was the problem?

This PR resolves #4103

### How was it solved?

By writing test cases to the following;
- [x]  Inputting a message 
- [x] Signing the message
- [x] Verify signed results copied to the clipboard
- [x] Closing the modal dialog

### How was it tested?

on Jenkins
