### PR TITLE
Fix unable to sort peers by version - Closes #4145

### DIFF
--- a/src/components/screens/monitor/network/index.js
+++ b/src/components/screens/monitor/network/index.js
@@ -35,7 +35,7 @@ import Overview from './overview';
  * -1 for a < b
  */
 export const sortByVersion = (a, b, direction = 'desc') => {
-  if (a.version === b.version) return 0;
+  if (a.networkVersion === b.networkVersion) return 0;
 
   const split = (version) => {
     const arr = version.split(/\.|-/);
@@ -48,8 +48,8 @@ export const sortByVersion = (a, b, direction = 'desc') => {
       },
     );
   };
-  const aParts = split(a.version);
-  const bParts = split(b.version);
+  const aParts = split(a.networkVersion || '');
+  const bParts = split(b.networkVersion || '');
 
   return aParts.reduce((acc, item, index) => {
     if (acc === 0 && item > bParts[index]) acc = 1;
@@ -125,6 +125,6 @@ export default compose(
       ),
     },
   }),
-  withLocalSort('peers', 'height:desc', { version: sortByVersion }),
+  withLocalSort('peers', 'height:desc', { networkVersion: sortByVersion }),
   withTranslation(),
 )(NetworkPure);

--- a/src/components/screens/monitor/network/index.test.js
+++ b/src/components/screens/monitor/network/index.test.js
@@ -12,6 +12,9 @@ describe('sortByVersion', () => {
       ['1.2.3-beta.1', '1.2.3-beta.0'],
       ['1.2.3-rc.1', '1.2.3-rc.0'],
     ].map(versions =>
-      expect(sortByVersion({ version: versions[0] }, { version: versions[1] })).toEqual(-1));
+      expect(sortByVersion(
+        { networkVersion: versions[0] },
+        { networkVersion: versions[1] },
+      )).toEqual(-1));
   });
 });

--- a/src/components/screens/monitor/network/tableHeader.js
+++ b/src/components/screens/monitor/network/tableHeader.js
@@ -35,7 +35,7 @@ export default (changeSort, t) => ([
     classList: grid['col-xs-2'],
     sort: {
       fn: changeSort,
-      key: 'version',
+      key: 'networkVersion',
     },
   },
   {

--- a/test/cypress/features/network.feature
+++ b/test/cypress/features/network.feature
@@ -21,3 +21,9 @@ Feature: Network
     And I wait 1 seconds
     And I sort by height
     Then peers should be sorted in ascending order by height
+ 
+  Scenario: I should see peers sorted in ascending order by networkVersion
+    When I click on showMorePeersBtn
+    And I wait 1 seconds
+    And I sort by networkVersion
+    Then peers should be sorted in ascending order by networkVersion

--- a/test/cypress/features/network/network.js
+++ b/test/cypress/features/network/network.js
@@ -6,13 +6,28 @@ Then(/^I should have (\d+) peers rendered in table$/, function (number) {
   cy.get(ss.peerRow).should('have.length', number);
 });
 
-Then(/^peers should be sorted in (\w+) order by height$/, function (sortOrder) {
-  let prevHeight = sortOrder === 'descending' ? Infinity : -Infinity;
+Then(/^peers should be sorted in (\w+) order by (\w+)$/, function (sortOrder, sortParam) {
+  let prevParamValue = null;
+  switch(sortParam){
+    case 'height':
+      prevParamValue = sortOrder === 'descending' ? Infinity : -Infinity;
 
-  cy.get(`${ss.peerRow}`).each((ele) => {
-    const height = +ele[0].lastElementChild.innerText;
-    expect(height)[sortOrder === 'descending' ? 'lte' : 'gte'](prevHeight);
-    prevHeight = height;
-  })
+      cy.get(`${ss.peerRow}`).each((ele) => {
+        const value = +ele[0].lastElementChild.innerText;
+        expect(value)[sortOrder === 'descending' ? 'lte' : 'gte'](prevParamValue);
+        prevParamValue = value;
+      })
+      break;
+    case 'networkVersion':
+      prevParamValue = sortOrder === 'descending' ? Infinity : -Infinity;
+
+      cy.get(`${ss.peerRow}`).each((ele) => {
+        const value = +ele[0].childNodes[3].innerText;
+        expect(value)[sortOrder === 'descending' ? 'lte' : 'gte'](prevParamValue);
+        prevParamValue = value;
+      })
+      break;
+  }
+
 }); 
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4145

### How was it solved?

- [x] Changing the sorting key from `version` to `networkVersion`
- [x] writing e2e test

### How was it tested?

Visually and on Jenkins
