### PR TITLE
Disable send button for an incorrect second passphrase - Closes #4169

### DIFF
--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -39,7 +39,7 @@ const SecondPassInput = ({
 
   useEffect(() => {
     if (secondPass.error === 0) {
-      secondPassphraseStored(secondPass);
+      secondPassphraseStored(secondPass.data);
       setInputStatus('valid');
     } else if (secondPass.error > 0) {
       setInputStatus('invalid');

--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -24,7 +24,7 @@ const Actions = ({
     )}
     <PrimaryButton
       className="confirm-button"
-      disabled={confirmButton.disabled || inputStatus === 'visible'}
+      disabled={confirmButton.disabled || inputStatus === 'visible' || inputStatus === 'invalid'}
       onClick={confirmButton.onClick}
     >
       {isMultisignature ? t('Sign') : confirmButton.label}
@@ -41,6 +41,8 @@ const SecondPassInput = ({
     if (secondPass.error === 0) {
       secondPassphraseStored(secondPass);
       setInputStatus('valid');
+    } else if (secondPass.error > 0) {
+      setInputStatus('invalid');
     }
   }, [secondPass]);
 

--- a/src/components/shared/transactionSummary/footer.js
+++ b/src/components/shared/transactionSummary/footer.js
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { PrimaryButton, SecondaryButton, TertiaryButton } from '@toolbox/buttons';
 import PassphraseInput from '@toolbox/passphraseInput';
+import useSecondPassphrase from '@src/hooks/setSecondPassphrase';
 import BoxFooter from '@toolbox/box/footer';
 import styles from './transactionSummary.css';
 
@@ -34,10 +35,10 @@ const Actions = ({
 const SecondPassInput = ({
   t, secondPassphraseStored, inputStatus, setInputStatus,
 }) => {
-  const [secondPass, set2ndPass] = useState('');
+  const [secondPass, set2ndPass] = useSecondPassphrase();
 
   useEffect(() => {
-    if (secondPass) {
+    if (secondPass.error === 0) {
       secondPassphraseStored(secondPass);
       setInputStatus('valid');
     }

--- a/src/hooks/setSecondPassphrase.js
+++ b/src/hooks/setSecondPassphrase.js
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectActiveTokenAccount } from '@store/selectors';
+import { extractPublicKey } from '@utils/account';
+
+const empty2ndPass = {
+  data: '',
+  error: -1,
+  feedback: [],
+};
+
+const setSecondPassphrase = () => {
+  const [secondPass, set2ndPass] = useState(empty2ndPass);
+  const account = useSelector(selectActiveTokenAccount);
+
+  const validate2ndPass = (data, error) => {
+    const messages = [];
+    if (error) {
+      messages.push(messages);
+    }
+
+    const secondPublicKey = account.keys.mandatoryKeys
+      .filter(item => item !== account.summary.publicKey);
+    const publicKey = extractPublicKey(data);
+
+    // compare them
+    if (!secondPublicKey.length || publicKey !== secondPublicKey[0]) {
+      messages.push('This passphrase does not belong to your account.');
+    }
+    return messages;
+  };
+
+  const setter = (data, error) => {
+    const feedback = validate2ndPass(data, error);
+    set2ndPass({
+      data,
+      error: data === '' ? -1 : feedback.length,
+      feedback,
+    });
+  };
+
+  return [secondPass, setter];
+};
+
+export default setSecondPassphrase;

--- a/src/hooks/setSecondPassphrase.js
+++ b/src/hooks/setSecondPassphrase.js
@@ -17,6 +17,7 @@ const setSecondPassphrase = () => {
     const messages = [];
     if (error) {
       messages.push(messages);
+      return messages;
     }
 
     const secondPublicKey = account.keys.mandatoryKeys

--- a/src/hooks/setSecondPassphrase.test.js
+++ b/src/hooks/setSecondPassphrase.test.js
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useSelector } from 'react-redux';
+import setSecondPassphrase from './setSecondPassphrase';
+import accounts from '../../test/constants/accounts';
+
+jest.mock('@store');
+
+// const mockSelector = jest.fn();
+useSelector.mockReturnValue(accounts.secondPass);
+
+describe('setSecondPassphrase', () => {
+  it('Should return second passphrase with no error message', () => {
+    const result = renderHook(() => setSecondPassphrase());
+    const [state, setState] = result.result.current;
+    expect(state.error).toBe(-1);
+    act(() => {
+      setState(accounts.secondPass.secondPass);
+    });
+    expect(result.result.current[0].error).toBe(0);
+  });
+
+  it('Should return second passphrase with relevant error message', () => {
+    const result = renderHook(() => setSecondPassphrase());
+    const [state, setState] = result.result.current;
+    expect(state.error).toBe(-1);
+    act(() => {
+      setState(accounts.genesis.passphrase);
+    });
+    expect(result.result.current[0].error).toBe(1);
+  });
+});

--- a/src/hooks/setSecondPassphrase.test.js
+++ b/src/hooks/setSecondPassphrase.test.js
@@ -28,4 +28,14 @@ describe('setSecondPassphrase', () => {
     });
     expect(result.result.current[0].error).toBe(1);
   });
+
+  it('Should return second passphrase with an external error message, if provided', () => {
+    const result = renderHook(() => setSecondPassphrase());
+    const [state, setState] = result.result.current;
+    expect(state.error).toBe(-1);
+    act(() => {
+      setState('wrong_pass', 'The pass is invalid');
+    });
+    expect(result.result.current[0].error).toBe(1);
+  });
 });

--- a/src/store/selectors.js
+++ b/src/store/selectors.js
@@ -7,7 +7,16 @@ const selectBTCAddress = state =>
   (state.account.info ? state.account.info.BTC.summary.address : undefined);
 const selectPublicKey = state => state.account.info[state.settings.token.active].publicKey;
 const selectTransactions = state => state.transactions;
-const selectActiveTokenAccount = state => state.account.info[state.settings.token.active];
+const selectActiveTokenAccount = (state) => {
+  if (!state.account.info) {
+    return {};
+  }
+  return {
+    ...state.account.info[state.settings.token.active],
+    passphrase: state.passphrase,
+    hwInfo: state.hwInfo,
+  };
+};
 const selectAccountBalance = state => (
   state.account.info ? state.account.info[state.settings.token.active].summary.balance : undefined);
 const selectBookmarks = state => state.bookmarks[state.settings.token.active];


### PR DESCRIPTION
### What was the problem?

This PR resolves #4169 

### How was it solved?

- [x] Disabling send button when there is a validation error on the second passphrase

### How was it tested?

- Try initiating a transition on a multi-signature account by providing a second passphrase
- providing an invalid passphrase disables the send button
