### PR TITLE
Show warning tooltip for old bookmark addresses - Closes #3793

### DIFF
--- a/src/components/screens/bookmarks/bookmarks.css
+++ b/src/components/screens/bookmarks/bookmarks.css
@@ -13,6 +13,7 @@
 
   & .content {
     width: 100%;
+    height: 100%;
   }
 
   & .emptyState {

--- a/src/components/screens/bookmarks/list/list.css
+++ b/src/components/screens/bookmarks/list/list.css
@@ -2,10 +2,10 @@
 
 .wrapper {
   width: 100%;
+  height: 100%;
   display: block !important;
   padding: 0 !important;
   border-radius: 6px;
-  overflow: hidden;
 
   & .header {
     height: auto;
@@ -34,6 +34,7 @@
     max-height: 370px;
     overflow-y: scroll;
     margin-bottom: 0;
+    height: 100%;
 
     & header {
       padding-left: var(--horizontal-padding-l);

--- a/src/components/screens/bookmarks/list/list.css
+++ b/src/components/screens/bookmarks/list/list.css
@@ -146,3 +146,7 @@
 .hide {
   visibility: hidden;
 }
+
+.tooltipContainer {
+  right: -27px !important;
+}

--- a/src/components/screens/bookmarks/list/list.js
+++ b/src/components/screens/bookmarks/list/list.js
@@ -240,6 +240,7 @@ export class BookmarksList extends React.Component {
                                     </TertiaryButton>
                                   ) : (
                                     <Tooltip
+                                      tooltipClassName={styles.tooltipContainer}
                                       position="bottom left"
                                       size="maxContent"
                                       indent


### PR DESCRIPTION
### What was the problem?

This PR resolves #3793 

### How was it solved?

-Increasing the height of the container to fill the parent so scroll only starts when it's at 100% height.

### How was it tested?

Visually.