### PR TITLE
Validate non-unique public keys on register multi-signature account - Closes #4182

### DIFF
--- a/i18n/locales/en/common.json
+++ b/i18n/locales/en/common.json
@@ -154,6 +154,7 @@
   "Don’t have a Lisk account yet? ": "Don’t have a Lisk account yet? ",
   "Download": "Download",
   "Download completed": "Download completed",
+  "Duplicate public keys detected.": "Duplicate public keys detected.",
   "Each LSK is worth one vote.": "Each LSK is worth one vote.",
   "Edit": "Edit",
   "Edit bookmark": "Edit bookmark",

--- a/src/components/screens/multiSignature/form/form.js
+++ b/src/components/screens/multiSignature/form/form.js
@@ -67,6 +67,19 @@ const validators = [
       || optional.some(item => !regex.publicKey.test(item)),
     message: t => t('Please enter a valid public key for each member.'),
   },
+  {
+    pattern: (mandatory, optional) => {
+      const validationResult = mandatory.concat(optional).reduce((prev, { publicKey }) => {
+        if (prev.prevKey === publicKey && !prev.notValid) {
+          return { notValid: true, prevKey: publicKey };
+        }
+        return { notValid: prev.notValid, prevKey: publicKey };
+      }, { notValid: false, prevKey: '' });
+
+      return validationResult.notValid;
+    },
+    message: t => t('Duplicate public keys detected.'),
+  },
 ];
 
 export const validateState = ({
@@ -192,9 +205,9 @@ const Editor = ({
     }
   }, [requiredSignatures]);
 
-  const feedback = validateState({
+  const feedback = useMemo(() => validateState({
     mandatoryKeys, optionalKeys, requiredSignatures, t,
-  });
+  }), [mandatoryKeys, optionalKeys, requiredSignatures]);
 
   return (
     <section className={styles.wrapper}>

--- a/src/components/screens/multiSignature/form/form.js
+++ b/src/components/screens/multiSignature/form/form.js
@@ -69,7 +69,7 @@ const validators = [
   },
   {
     pattern: (mandatory, optional) => {
-      const validationResult = mandatory.concat(optional).reduce((prev, { publicKey }) => {
+      const validationResult = mandatory.concat(optional).reduce((prev, publicKey) => {
         if (prev.prevKey === publicKey && !prev.notValid) {
           return { notValid: true, prevKey: publicKey };
         }

--- a/src/components/screens/multiSignature/form/form.test.js
+++ b/src/components/screens/multiSignature/form/form.test.js
@@ -183,4 +183,15 @@ describe('validateState', () => {
     const error = 'Maximum number of members is {{MAX_MULTI_SIG_MEMBERS}}.';
     expect(validateState(params).messages).toContain(error);
   });
+  it('should return error if there are duplicate public keys', () => {
+    const pbk = accounts.genesis.summary.publicKey;
+    const params = {
+      mandatoryKeys: new Array(2).fill(pbk),
+      optionalKeys: [],
+      requiredSignatures: 2,
+      t: str => str,
+    };
+    const error = 'Duplicate public keys detected.';
+    expect(validateState(params).messages).toContain(error);
+  });
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #4182

### How was it solved?

- [ ] Added a validation that checks for non-uniqueness in public keys in the list of multi-signature members.
- [ ] Write unit test.

### How was it tested?

Visually
