### PR TITLE
Fixed rerender issue on clicking entire balance warning - Closes #4176

### DIFF
--- a/src/components/shared/amountField/amountField.test.js
+++ b/src/components/shared/amountField/amountField.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MaxAmountWarning } from './index';
+
+const props = {
+  resetInput: jest.fn(),
+  message: 'You are about to send your entire balance',
+  ignoreClicks: jest.fn(),
+};
+const wrapper = mount(<MaxAmountWarning {...props} />);
+
+describe('MaxAmountWarning', () => {
+  it('does not rerender the amount validation when the max amount warning is clicked', () => {
+    wrapper.find('.entire-balance-warning').simulate('click');
+    expect(props.ignoreClicks).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the max amount warning when the close button is clicked', () => {
+    wrapper.find('.close-entire-balance-warning').simulate('click');
+    expect(props.resetInput).toHaveBeenCalledTimes(1);
+    expect(wrapper).not.toContain('You are about to send your entire balance');
+  });
+});

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -10,7 +10,7 @@ import Tooltip from '@toolbox/tooltip/tooltip';
 import Converter from '../converter';
 import styles from './amountField.css';
 
-const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
+export const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
   const { t } = useTranslation();
   return (
     <div className={`${styles.entireBalanceWarning} entire-balance-warning`} onClick={ignoreClicks}>

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -10,10 +10,10 @@ import Tooltip from '@toolbox/tooltip/tooltip';
 import Converter from '../converter';
 import styles from './amountField.css';
 
-const MaxAmountWarning = ({ resetInput, message }) => {
+const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
   const { t } = useTranslation();
   return (
-    <div className={`${styles.entireBalanceWarning} entire-balance-warning`}>
+    <div className={`${styles.entireBalanceWarning} entire-balance-warning`} onClick={ignoreClicks}>
       <Icon name="warningYellow" />
       <span>{message || t('You are about to send your entire balance')}</span>
       <div
@@ -105,6 +105,7 @@ const AmountField = ({
         <MaxAmountWarning
           message={useMaxWarning}
           resetInput={resetInput}
+          ignoreClicks={ignoreClicks}
         />
       )}
     </label>


### PR DESCRIPTION
### What was the problem?

This PR resolves #4176

### How was it solved?

Changing the click setup for the warning

### How was it tested?

Manually
