### PR TITLE
Bug fix for edit vote -  Closes #4223,#4222

### DIFF
--- a/src/components/screens/editVote/index.js
+++ b/src/components/screens/editVote/index.js
@@ -120,8 +120,8 @@ const AddVote = ({
               labelClassname={`${styles.fieldLabel}`}
               placeholder={t('Insert vote amount')}
               useMaxLabel={t('Use maximum amount')}
-              maxToolTipPosition="top"
               useMaxWarning={t('Caution! You are about to send the majority of your balance')}
+              maxToolTipPosition="top"
               name="vote"
             />
           </div>

--- a/src/components/screens/editVote/index.js
+++ b/src/components/screens/editVote/index.js
@@ -110,7 +110,7 @@ const AddVote = ({
             <span className={styles.space} />
           </>
           )}
-          <label className={styles.fieldGroup}>
+          <div className={styles.fieldGroup}>
             <AmountField
               amount={voteAmount}
               onChange={setVoteAmount}
@@ -123,7 +123,7 @@ const AddVote = ({
               useMaxWarning={t('Caution! You are about to send the majority of your balance')}
               name="vote"
             />
-          </label>
+          </div>
         </BoxContent>
         <BoxFooter direction="horizontal">
           {

--- a/src/components/screens/editVote/index.js
+++ b/src/components/screens/editVote/index.js
@@ -120,6 +120,7 @@ const AddVote = ({
               labelClassname={`${styles.fieldLabel}`}
               placeholder={t('Insert vote amount')}
               useMaxLabel={t('Use maximum amount')}
+              maxToolTipPosition="top"
               useMaxWarning={t('Caution! You are about to send the majority of your balance')}
               name="vote"
             />

--- a/src/components/screens/send/form/formBase.js
+++ b/src/components/screens/send/form/formBase.js
@@ -50,6 +50,7 @@ const FormBase = ({
           placeHolder={t('Insert transaction amount')}
           useMaxLabel={t('Send maximum amount')}
           name="amount"
+          maxToolTipPosition="left"
         />
         { children }
       </BoxContent>

--- a/src/components/shared/amountField/amountField.css
+++ b/src/components/shared/amountField/amountField.css
@@ -60,6 +60,18 @@
   white-space: normal;
   width: 200px;
   word-wrap: break-word;
+  margin-left: -5px;
+}
+
+.maxToggleWrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+
+  & > button {
+    padding-right: -0px !important;
+  }
 }
 
 .entireBalanceWarning {

--- a/src/components/shared/amountField/amountField.css
+++ b/src/components/shared/amountField/amountField.css
@@ -70,7 +70,7 @@
   align-items: center;
 
   & > button {
-    padding-right: -0px !important;
+    padding-right: 0px !important;
   }
 }
 

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -28,7 +28,7 @@ export const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
 const AmountField = ({
   amount, maxAmount, onChange, className,
   label, labelClassname, useMaxLabel, placeholder, name,
-  displayConverter, useMaxWarning, maxToolTipPosition, headerStyle,
+  displayConverter, useMaxWarning, maxToolTipPosition,
 }) => {
   const { t } = useTranslation();
   const [showEntireBalanceWarning, setShowEntireBalanceWarning] = useState(false);
@@ -78,7 +78,7 @@ const AmountField = ({
         { label && <span className={labelClassname ? `${styles.customFieldLabel} ${styles.fieldLabel} label` : `${styles.fieldLabel}`}>{label}</span> }
         {
           useMaxLabel && (
-            <div className={`${styles.maxToggleWrapper} ${headerStyle || ''}`}>
+            <div className={styles.maxToggleWrapper}>
               <TertiaryButton
                 onClick={setEntireBalance}
                 className="use-entire-balance-button"

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -36,6 +36,7 @@ const AmountField = ({
 
   const setEntireBalance = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setIsMaximum(true);
     const value = formatAmountBasedOnLocale({
       value: fromRawLsk(maxAmount.value),
@@ -63,17 +64,17 @@ const AmountField = ({
   };
 
   useEffect(() => {
-    if (isMaximum) {
+    if (isMaximum && maxAmount) {
       const value = formatAmountBasedOnLocale({
         value: fromRawLsk(maxAmount.value),
         format: '0.[00000000]',
       });
       onChange({ value }, maxAmount);
     }
-  }, [isMaximum, maxAmount.value]);
+  }, [isMaximum, maxAmount?.value]);
 
   return (
-    <label className={`${styles.fieldGroup} ${amount.error ? styles.error : ''} ${className}`}>
+    <span className={`${styles.fieldGroup} ${amount.error ? styles.error : ''} ${className}`}>
       <div className={labelClassname ? `${styles.customAmountFieldHeader} ${styles.amountFieldHeader}` : `${styles.amountFieldHeader}`} onClick={ignoreClicks}>
         { label && <span className={labelClassname ? `${styles.customFieldLabel} ${styles.fieldLabel} label` : `${styles.fieldLabel}`}>{label}</span> }
         {
@@ -122,7 +123,7 @@ const AmountField = ({
           ignoreClicks={ignoreClicks}
         />
       )}
-    </label>
+    </span>
   );
 };
 

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -36,7 +36,6 @@ const AmountField = ({
 
   const setEntireBalance = (e) => {
     e.preventDefault();
-    e.stopPropagation();
     setIsMaximum(true);
     const value = formatAmountBasedOnLocale({
       value: fromRawLsk(maxAmount.value),

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -28,7 +28,7 @@ export const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
 const AmountField = ({
   amount, maxAmount, onChange, className,
   label, labelClassname, useMaxLabel, placeholder, name,
-  displayConverter, useMaxWarning,
+  displayConverter, useMaxWarning, maxToolTipPosition,
 }) => {
   const { t } = useTranslation();
   const [showEntireBalanceWarning, setShowEntireBalanceWarning] = useState(false);
@@ -85,7 +85,7 @@ const AmountField = ({
             >
               {useMaxLabel}
               <Tooltip
-                position="bottom"
+                position={maxToolTipPosition || 'bottom'}
                 tooltipClassName={`${styles.tooltipContainer}`}
               >
                 <span>{t('Based on your available balance and rounded down to a multiple of 10 LSK, your total remaining balance is {{maxAmount}} LSK', { maxAmount: fromRawLsk(maxAmount.value) })}</span>

--- a/src/components/shared/amountField/index.js
+++ b/src/components/shared/amountField/index.js
@@ -28,7 +28,7 @@ export const MaxAmountWarning = ({ resetInput, message, ignoreClicks }) => {
 const AmountField = ({
   amount, maxAmount, onChange, className,
   label, labelClassname, useMaxLabel, placeholder, name,
-  displayConverter, useMaxWarning, maxToolTipPosition,
+  displayConverter, useMaxWarning, maxToolTipPosition, headerStyle,
 }) => {
   const { t } = useTranslation();
   const [showEntireBalanceWarning, setShowEntireBalanceWarning] = useState(false);
@@ -78,19 +78,21 @@ const AmountField = ({
         { label && <span className={labelClassname ? `${styles.customFieldLabel} ${styles.fieldLabel} label` : `${styles.fieldLabel}`}>{label}</span> }
         {
           useMaxLabel && (
-            <TertiaryButton
-              onClick={setEntireBalance}
-              className="use-entire-balance-button"
-              size="xs"
-            >
-              {useMaxLabel}
+            <div className={`${styles.maxToggleWrapper} ${headerStyle || ''}`}>
+              <TertiaryButton
+                onClick={setEntireBalance}
+                className="use-entire-balance-button"
+                size="xs"
+              >
+                {useMaxLabel}
+              </TertiaryButton>
               <Tooltip
                 position={maxToolTipPosition || 'bottom'}
                 tooltipClassName={`${styles.tooltipContainer}`}
               >
                 <span>{t('Based on your available balance and rounded down to a multiple of 10 LSK, your total remaining balance is {{maxAmount}} LSK', { maxAmount: fromRawLsk(maxAmount.value) })}</span>
               </Tooltip>
-            </TertiaryButton>
+            </div>
           )
         }
       </div>


### PR DESCRIPTION
### What was the problem?

This PR resolves #4223,#4222

### How was it solved?

- [x] Replace the wrapper label with a span within the amount field
- [x] Replaced the wrapper label in edit vote with a div
- [x] Added a check on when maxAmont is undefined in the body of the  useEffect

### How was it tested?

Visually
