### PR TITLE
Refactor settings domain to become blockchain agnostic - Closes #4210

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ setup/react/assets/fonts/basierCircle/
 setup/react/assets/fonts/gilroy/
 
 ## Cypress
-tests/cypress/cypress
-tests/cypress/screenshots
-tests/cypress/videos
+test/cypress/cypress
+test/cypress/screenshots
+test/cypress/videos

--- a/packages/common/utilities/login.js
+++ b/packages/common/utilities/login.js
@@ -1,5 +1,5 @@
 import i18next from 'i18next';
-import settings from '@settings/configuration/settings';
+import config from '@settings/configuration/settingConstants';
 
 // https://stackoverflow.com/questions/3809401/what-is-a-good-regular-expression-to-match-a-url
 const pattern = new RegExp(/[-a-zA-Z0-9@:%_+.~#?&/=]{2,256}\.[a-z]{2,4}\b(\/[-a-zA-Z0-9@:%_+.~#?&/=]*)?/gi);
@@ -41,9 +41,9 @@ export const validateUrl = (value) => {
 
 // Ignore coverage because this is only development feature
 export const getAutoLogInData = /* istanbul ignore next */ () => ({
-  [settings.keys.loginKey]: localStorage.getItem(settings.keys.loginKey),
+  [config.keys.loginKey]: localStorage.getItem(config.keys.loginKey),
 });
 
 // Ignore coverage because this is only development feature
 export const shouldAutoLogIn = /* istanbul ignore next */ autoLogin =>
-  !!autoLogin[settings.keys.loginKey] && autoLogin[settings.keys.loginKey] !== '';
+  !!autoLogin[config.keys.loginKey] && autoLogin[config.keys.loginKey] !== '';

--- a/packages/network/store/middleware.js
+++ b/packages/network/store/middleware.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import settings from '@settings/configuration/settings';
+import config from '@settings/configuration/settingConstants';
 import { getAutoLogInData, shouldAutoLogIn } from '@common/utilities/login';
 // eslint-disable-next-line no-unused-vars
 import { networkConfigSet, login, settingsUpdated } from '@common/store/actions';

--- a/packages/settings/configuration/settingConstants.js
+++ b/packages/settings/configuration/settingConstants.js
@@ -1,0 +1,19 @@
+const config = {
+  currencies: ['USD', 'EUR', 'CHF'],
+  keys: {
+    loginKey: 'loginKey',
+    autoLog: 'autoLog',
+    showNetwork: 'showNetwork',
+    channels: 'channels',
+    hardwareAccounts: 'hardwareAccounts',
+    isRequestHowItWorksDisable: 'isRequestHowItWorksDisable',
+    statistics: 'statistics',
+    areTermsOfUseAccepted: 'areTermsOfUseAccepted',
+    discreetMode: 'discreetMode',
+    token: 'token',
+    sideBarExpanded: 'sideBarExpanded',
+    currency: 'currency',
+  },
+
+};
+export default config;

--- a/packages/settings/configuration/settings.js
+++ b/packages/settings/configuration/settings.js
@@ -1,7 +1,0 @@
-const settings = {
-  currencies: ['USD', 'EUR', 'CHF'],
-  keys: {
-    loginKey: 'loginKey',
-  },
-};
-export default settings;

--- a/packages/settings/managers/useSettings.js
+++ b/packages/settings/managers/useSettings.js
@@ -1,0 +1,16 @@
+import { settingsUpdated } from '@settings/store/action';
+import { useDispatch, useSelector } from 'react-redux';
+
+function useSettings(settingKey){
+    const dispatch = useDispatch();
+    const value = useSelector(state => state.settings[settingKey]);
+	
+	const toggleSetting = (settingValue) => {
+		dispatch(settingsUpdated({ [settingKey]: settingValue || !value }));
+	}
+
+    return {toggleSetting, [settingKey]: value}
+}
+
+export default useSettings
+

--- a/packages/settings/setters/selectors/currencySelector.js
+++ b/packages/settings/setters/selectors/currencySelector.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { toast } from 'react-toastify';
+import Select from '@basics/inputs/select';
+import settingConstants from "@settings/configuration/settingConstants"
+import useSettings from "@settings/managers/useSettings"
+import Piwik from '@common/utilities/piwik';
+
+function CurrencySelector({t}) {
+    const {currency, toggleSetting} = useSettings(settingConstants.keys.currency)
+    const onChangeCurrency = (currency) => {
+        Piwik.trackingEvent('Settings', 'button', 'Update settings');
+        toggleSetting(currency)
+        toast(t('Settings saved!'));
+    }
+
+    return(
+        <Select
+            options={settingConstants.currencies.map(currency => ({
+                label: currency, value: currency,
+            }))}
+            selected={currency || settingConstants.currencies[0]}
+            onChange={onChangeCurrency}
+            className="currency"
+            placeholder="Currency"
+        />
+    )
+}
+
+export default CurrencySelector

--- a/packages/settings/setters/toggles/discreteModeToggle.js
+++ b/packages/settings/setters/toggles/discreteModeToggle.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import settingConstants from "@settings/configuration/settingConstants";
+import Toggle from "./toggle";
+
+function DiscreateModeToggle(){
+    return ( 
+        <Toggle
+            setting={settingConstants.keys.discreetMode}
+            icons={['toggleSidebarActive', 'toggleSidebar']}
+            tips={[t('Collapse sidebar'), t('Expand sidebar')]}
+        />
+    )
+}
+
+export default DiscreateModeToggle

--- a/packages/settings/setters/toggles/sideBarToggle.js
+++ b/packages/settings/setters/toggles/sideBarToggle.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import settingConstants from "@settings/configuration/settingConstants";
+import Toggle from "./toggle";
+
+function SideBarToggle(){
+    return ( 
+        <Toggle
+            setting={settingConstants.keys.sideBarExpanded}
+            icons={['discreetModeActive', 'discreetMode']}
+            tips={[t('Disable discreet mode'), t('Enable discreet mode')]}
+        />
+    )
+}
+
+export default SideBarToggle

--- a/packages/settings/store/middleware.js
+++ b/packages/settings/store/middleware.js
@@ -9,6 +9,7 @@ const settings = store => next => (action) => {
   switch (action.type) {
     case actionTypes.networkConfigSet:
       // store.dispatch(pricesRetrieved());
+      if(!action.data) break;
       store.dispatch(settingsUpdated({
         network: {
           name: action.data.name,

--- a/packages/views/screens/managers/settings/settings.js
+++ b/packages/views/screens/managers/settings/settings.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { toast } from 'react-toastify';
 import Piwik from '@common/utilities/piwik';
 import { externalLinks } from '@common/configuration';
-import settingsConst from '@settings/configuration/settings';
+import settingsConst from '@settings/configuration/settingConstants';
 import Box from '@basics/box';
 import BoxHeader from '@basics/box/header';
 import BoxContent from '@basics/box/content';
 import CheckBox from '@basics/inputs/checkBox';
-import Select from '@basics/inputs/select';
 import Dialog from '@basics/dialog/dialog';
 import styles from './settings.css';
+import CurrencySelector from '@settings/setters/selectors/currencySelector';
 
 class Settings extends React.Component {
   constructor() {
@@ -68,17 +68,7 @@ class Settings extends React.Component {
           <BoxContent className={styles.content}>
             <section>
               <h2>{t('Currency')}</h2>
-              <div className={styles.fieldGroup}>
-                <Select
-                  options={currencies.map(currency => ({
-                    label: currency, value: currency,
-                  }))}
-                  selected={activeCurrency}
-                  onChange={this.setCurrency}
-                  className="currency"
-                  placeholder="Currency"
-                />
-              </div>
+              <CurrencySelector t = {t} />
             </section>
             <section>
               <h2>{t('Appearance')}</h2>

--- a/packages/views/shared/converter/index.js
+++ b/packages/views/shared/converter/index.js
@@ -1,6 +1,6 @@
 /* istanbul ignore file */
 import { connect } from 'react-redux';
-import settings from '@settings/configuration/settings';
+import config from '@settings/configuration/settingConstants';
 import { tokenMap } from '@token/configuration/tokens';
 import Converter from './converter';
 
@@ -10,8 +10,8 @@ const mapStateToProps = state => ({
   priceTicker: (state.service && state.service.priceTicker)
     ? state.service.priceTicker
     : {
-      LSK: settings.currencies.reduce((acc, key) => ({ ...acc, [key]: '0' })),
-      BTC: settings.currencies.reduce((acc, key) => ({ ...acc, [key]: '0' })),
+      LSK: config.currencies.reduce((acc, key) => ({ ...acc, [key]: '0' })),
+      BTC: config.currencies.reduce((acc, key) => ({ ...acc, [key]: '0' })),
     },
 });
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -24,7 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 import networks from '../../../packages/network/configuration/networks';
-import settings from '../../../packages/settings/configuration/settings';
+import config from '../../../packages/settings/configuration/settingConstants';
 import { deepMergeObj } from '../../../packages/common/utilities/helpers';
 
 before(() => {
@@ -33,7 +33,7 @@ before(() => {
 });
 
 beforeEach(() => {
-  const settingsWithNetworkSelectorEnabled = { ...settings, showNetwork: true };
+  const settingsWithNetworkSelectorEnabled = { ...config, showNetwork: true };
   const btcSettings = deepMergeObj(
     settingsWithNetworkSelectorEnabled,
     { token: { list: { BTC: true } } },


### PR DESCRIPTION
### What was the problem?

This PR resolves #4210 

### How was it solved?

- [ ] Create proposed folder structure
- [ ] Create a reusable checkbox component in the toggles folder
- [ ] Move light/dark mode to toggles folder
- [ ] Move the discrete mode toggle to the toggles folder
- [ ] Move the sidebar toggle to the toggles folder
- [ ] Create a selectors folder for network selector and currency switcher
- [ ] Change `settings.js` to `config.js` (should be developed with dynamism in mind)
- [ ] Create custom hook within the manager that manages how settings are updated and observed
- [ ] Implement the connected network display in the info items folder
- [ ] Move the settings modal to info items

### How was it tested?

Unit tests
