### PR TITLE
Match Node version in .nvmrc & package.json - closes #4248

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/LiskHQ/lisk-desktop"
   },
   "engines": {
-    "node": ">=v12.7.0"
+    "node": ">=v16.14.0"
   },
   "scripts": {
     "dev": "cross-env DEBUG=true NACL_FAST=disable && webpack serve --config ./config/webpack.config.dev",


### PR DESCRIPTION
### What was the problem?

The Node version in .nvmrc and package.json was not match

### How was it solved?

I fixed the node engine version to match with that of the .nvmrc file.

