### PR TITLE
Handle empty schema for transaction signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@hookform/resolvers": "2.8.8",
         "@json-rpc-tools/utils": "1.7.6",
         "@ledgerhq/hw-transport-node-hid": "6.27.12",
-        "@liskhq/lisk-client": "6.0.0-alpha.15",
+        "@liskhq/lisk-client": "6.0.0-alpha.16",
         "@tanstack/react-query": "4.0.10",
         "@tanstack/react-query-devtools": "4.2.1",
         "@walletconnect/sign-client": "2.0.0-rc.4",
@@ -2564,7 +2564,7 @@
       "version": "1.1.3",
       "resolved": "https://npm.lisk.com/@gar%2fpromisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@hapi/bourne": {
       "version": "2.1.0",
@@ -5080,14 +5080,14 @@
       "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
     },
     "node_modules/@liskhq/lisk-api-client": {
-      "version": "6.0.0-alpha.15",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.15.tgz",
-      "integrity": "sha512-Ktgjq8AnK25o7T2Chk9nwkOaUbifdOGtHIGCK5cmDo47pswUillW1tlfUHUrh6/oM3c5bvUOpmW6dur7snWyAw==",
+      "version": "6.0.0-alpha.16",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.16.tgz",
+      "integrity": "sha512-BznpTSGs6BgC8a8wyolP0sPJP3tzdRejcck7MJkyRbGBpYAMoSfw3Brlzq86yk5mIH1HQzvKNbHDKQH3FjYnzQ==",
       "dependencies": {
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
-        "@liskhq/lisk-transactions": "^6.0.0-alpha.11",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6",
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
+        "@liskhq/lisk-transactions": "^6.0.0-alpha.12",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7",
         "isomorphic-ws": "4.0.1",
         "ws": "8.11.0",
         "zeromq": "6.0.0-beta.6"
@@ -5097,65 +5097,19 @@
         "npm": ">=8.1.0"
       }
     },
-    "node_modules/@liskhq/lisk-api-client/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-api-client/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-      "dependencies": {
-        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "buffer-reverse": "1.0.1",
-        "ed2curve": "0.3.0",
-        "hash-wasm": "4.9.0",
-        "tweetnacl": "1.0.3",
-        "varuint-bitcoin": "1.1.2"
-      },
-      "engines": {
-        "node": ">=16.14.1 <=16",
-        "npm": ">=8.1.0"
-      },
-      "peerDependencies": {
-        "@chainsafe/blst": "0.2.6",
-        "sodium-native": "3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@chainsafe/blst": {
-          "optional": true
-        },
-        "sodium-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@liskhq/lisk-api-client/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
     "node_modules/@liskhq/lisk-client": {
-      "version": "6.0.0-alpha.15",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.15.tgz",
-      "integrity": "sha512-ffC5NelS9C2UJCrEQvEfdCqf531EYMzW+nY8wFRtQzN/ZK02mNpuO6L5pLFTWunQBbrSbawk3KW8aRZuTpb1kw==",
+      "version": "6.0.0-alpha.16",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.16.tgz",
+      "integrity": "sha512-rkrW9pk8Bd83OoMQ5ojL8R5/i48tmIBb/9RYr/hNj5wC22CHRp+ktSh5EYPoFnigT5awBeJ2wfNm/5zC9PD0+g==",
       "dependencies": {
-        "@liskhq/lisk-api-client": "^6.0.0-alpha.15",
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-api-client": "^6.0.0-alpha.16",
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "@liskhq/lisk-transactions": "^6.0.0-alpha.11",
-        "@liskhq/lisk-tree": "^0.3.0-alpha.9",
+        "@liskhq/lisk-transactions": "^6.0.0-alpha.12",
+        "@liskhq/lisk-tree": "^0.3.0-alpha.10",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7",
         "buffer": "6.0.3"
       },
       "engines": {
@@ -5163,82 +5117,24 @@
         "npm": ">=8.1.0"
       }
     },
-    "node_modules/@liskhq/lisk-client/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-client/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-      "dependencies": {
-        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "buffer-reverse": "1.0.1",
-        "ed2curve": "0.3.0",
-        "hash-wasm": "4.9.0",
-        "tweetnacl": "1.0.3",
-        "varuint-bitcoin": "1.1.2"
-      },
-      "engines": {
-        "node": ">=16.14.1 <=16",
-        "npm": ">=8.1.0"
-      },
-      "peerDependencies": {
-        "@chainsafe/blst": "0.2.6",
-        "sodium-native": "3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@chainsafe/blst": {
-          "optional": true
-        },
-        "sodium-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@liskhq/lisk-client/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-    },
     "node_modules/@liskhq/lisk-codec": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-AM7Juadk4+zKz67DQFmvTFrjTQqqyCNK7BLxQ+WgAv5sdJPgcujSfLaKTSoL7hoLiE6Z4l0NMrDaU0ZMlJI2vQ==",
+      "version": "0.3.0-alpha.9",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.9.tgz",
+      "integrity": "sha512-KDgODq54d5zuA9hT7bnDAjVxrsZZhqnP6LRgM/oqvmFHAgcZb4AKk4jmEhLLINWwj0LvK70Jd96tYbn6/ZbUwQ==",
       "dependencies": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6"
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7"
       },
       "engines": {
         "node": ">=16.14.1 <=16",
         "npm": ">=8.1.0"
       }
     },
-    "node_modules/@liskhq/lisk-codec/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-codec/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
+    "node_modules/@liskhq/lisk-cryptography": {
+      "version": "4.0.0-alpha.7",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.7.tgz",
+      "integrity": "sha512-/dlVsJzjJ2z4IlbfVf87gWqB5p3xESqQKt8cRP94XZ38VmsQF2PpuZEEuyGEM9IbOYzT7kpdfQ+Fz7X7ZWiWuQ==",
       "dependencies": {
         "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
         "buffer-reverse": "1.0.1",
@@ -5264,7 +5160,7 @@
         }
       }
     },
-    "node_modules/@liskhq/lisk-codec/node_modules/tweetnacl": {
+    "node_modules/@liskhq/lisk-cryptography/node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
@@ -5282,123 +5178,31 @@
       }
     },
     "node_modules/@liskhq/lisk-transactions": {
-      "version": "6.0.0-alpha.11",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.11.tgz",
-      "integrity": "sha512-XJws8QMr6kZoXZ3dVLKEn6lKWuEh90CFdz7RWAxbdCLw2BKWoNzK+haXC6djIPTrgHhIVsQukHDf/9HcIVbtmA==",
+      "version": "6.0.0-alpha.12",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.12.tgz",
+      "integrity": "sha512-nPJR22tOG9LtojMiq5KVWfoYK1Cc8WJ7iHJgoboIvufD5PV1Zq1CZ5NQhx3ZZlOPffcs7OtVSOF32twheh2BWQ==",
       "dependencies": {
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6"
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7"
       },
       "engines": {
         "node": ">=16.14.1 <=16",
         "npm": ">=8.1.0"
       }
-    },
-    "node_modules/@liskhq/lisk-transactions/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-transactions/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-      "dependencies": {
-        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "buffer-reverse": "1.0.1",
-        "ed2curve": "0.3.0",
-        "hash-wasm": "4.9.0",
-        "tweetnacl": "1.0.3",
-        "varuint-bitcoin": "1.1.2"
-      },
-      "engines": {
-        "node": ">=16.14.1 <=16",
-        "npm": ">=8.1.0"
-      },
-      "peerDependencies": {
-        "@chainsafe/blst": "0.2.6",
-        "sodium-native": "3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@chainsafe/blst": {
-          "optional": true
-        },
-        "sodium-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@liskhq/lisk-transactions/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/@liskhq/lisk-tree": {
-      "version": "0.3.0-alpha.9",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.9.tgz",
-      "integrity": "sha512-nilsdzCCdXGT1ONEMdh5/DGSII7oS0l5ZZ38zCdOmkL+UG5RKjelVw3N8JSPFpHPliNX3J/2sTY3s/BhTi43xw==",
+      "version": "0.3.0-alpha.10",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.10.tgz",
+      "integrity": "sha512-coT0XqI09r4r1Mx73CpzCCMEt0AJicODTHel0X2bhxlieIf7U6afcK0Zorv19teOps4IBc66X7rb9hAcC1hVDw==",
       "dependencies": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4"
       },
       "engines": {
         "node": ">=16.14.1 <=16",
         "npm": ">=8.1.0"
       }
-    },
-    "node_modules/@liskhq/lisk-tree/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-tree/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-      "dependencies": {
-        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "buffer-reverse": "1.0.1",
-        "ed2curve": "0.3.0",
-        "hash-wasm": "4.9.0",
-        "tweetnacl": "1.0.3",
-        "varuint-bitcoin": "1.1.2"
-      },
-      "engines": {
-        "node": ">=16.14.1 <=16",
-        "npm": ">=8.1.0"
-      },
-      "peerDependencies": {
-        "@chainsafe/blst": "0.2.6",
-        "sodium-native": "3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@chainsafe/blst": {
-          "optional": true
-        },
-        "sodium-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@liskhq/lisk-tree/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/@liskhq/lisk-utils": {
       "version": "0.3.0-alpha.4",
@@ -5413,11 +5217,11 @@
       }
     },
     "node_modules/@liskhq/lisk-validator": {
-      "version": "0.7.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.6.tgz",
-      "integrity": "sha512-l+OmCMNx7/ACIn1/U5PgXTa4LyEDL+q80Xq+5e9p/uxuy5noJhEFUtDqttPsLOtqjUYZWGq/pzSdGuQSNrbokg==",
+      "version": "0.7.0-alpha.7",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.7.tgz",
+      "integrity": "sha512-2rJopUelN2kefPjNsb88Jvkwl9PMp3Wl4jCL4Ce3Ogdk18fXwZfL1LeZQ3yOCc0bF9BAP8qG+K7c33SxKFo+nQ==",
       "dependencies": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "ajv": "8.1.0",
         "ajv-formats": "2.1.1",
         "debug": "4.3.4",
@@ -5427,47 +5231,6 @@
       "engines": {
         "node": ">=16.14.1 <=16",
         "npm": ">=8.1.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-validator/node_modules/@chainsafe/blst": {
-      "version": "0.2.6",
-      "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-      "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "node-gyp": "^8.4.0"
-      }
-    },
-    "node_modules/@liskhq/lisk-validator/node_modules/@liskhq/lisk-cryptography": {
-      "version": "4.0.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-      "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-      "dependencies": {
-        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "buffer-reverse": "1.0.1",
-        "ed2curve": "0.3.0",
-        "hash-wasm": "4.9.0",
-        "tweetnacl": "1.0.3",
-        "varuint-bitcoin": "1.1.2"
-      },
-      "engines": {
-        "node": ">=16.14.1 <=16",
-        "npm": ">=8.1.0"
-      },
-      "peerDependencies": {
-        "@chainsafe/blst": "0.2.6",
-        "sodium-native": "3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "@chainsafe/blst": {
-          "optional": true
-        },
-        "sodium-native": {
-          "optional": true
-        }
       }
     },
     "node_modules/@liskhq/lisk-validator/node_modules/lru-cache": {
@@ -5494,11 +5257,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@liskhq/lisk-validator/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/@liskhq/lisk-validator/node_modules/yallist": {
       "version": "4.0.0",
@@ -5635,7 +5393,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/@npmcli%2ffs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -5645,7 +5403,7 @@
       "version": "6.0.0",
       "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5657,7 +5415,7 @@
       "version": "7.3.8",
       "resolved": "https://npm.lisk.com/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5672,13 +5430,13 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
       "resolved": "https://npm.lisk.com/@npmcli%2fmove-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -5691,7 +5449,7 @@
       "version": "1.0.4",
       "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -7412,7 +7170,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -7560,7 +7318,7 @@
       "version": "6.0.2",
       "resolved": "https://npm.lisk.com/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -7572,7 +7330,7 @@
       "version": "4.2.1",
       "resolved": "https://npm.lisk.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
       "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -7586,7 +7344,7 @@
       "version": "1.1.2",
       "resolved": "https://npm.lisk.com/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7595,7 +7353,7 @@
       "version": "3.1.0",
       "resolved": "https://npm.lisk.com/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -7608,7 +7366,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7941,7 +7699,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/arch": {
       "version": "2.2.0",
@@ -10099,7 +9857,7 @@
       "version": "15.3.0",
       "resolved": "https://npm.lisk.com/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -10128,7 +9886,7 @@
       "version": "7.2.3",
       "resolved": "https://npm.lisk.com/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10148,7 +9906,7 @@
       "version": "6.0.0",
       "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10160,7 +9918,7 @@
       "version": "1.0.4",
       "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -10172,7 +9930,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -10187,7 +9945,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
@@ -10785,7 +10543,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -10969,7 +10727,7 @@
       "version": "2.2.0",
       "resolved": "https://npm.lisk.com/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11266,7 +11024,7 @@
       "version": "1.1.3",
       "resolved": "https://npm.lisk.com/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -15506,7 +15264,7 @@
       "version": "2.0.3",
       "resolved": "https://npm.lisk.com/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -18056,7 +17814,7 @@
       "version": "2.1.0",
       "resolved": "https://npm.lisk.com/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -18081,7 +17839,7 @@
       "version": "1.0.0",
       "resolved": "https://npm.lisk.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "1.2.13",
@@ -18281,7 +18039,7 @@
       "version": "7.1.3",
       "resolved": "https://npm.lisk.com/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -19431,7 +19189,7 @@
       "version": "4.1.1",
       "resolved": "https://npm.lisk.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/http-deceiver": {
       "version": "1.2.7",
@@ -19708,7 +19466,7 @@
       "version": "5.0.1",
       "resolved": "https://npm.lisk.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -19730,7 +19488,7 @@
       "version": "1.2.1",
       "resolved": "https://npm.lisk.com/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -20154,7 +19912,7 @@
       "version": "0.1.4",
       "resolved": "https://npm.lisk.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -20183,7 +19941,7 @@
       "version": "1.0.4",
       "resolved": "https://npm.lisk.com/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -20374,7 +20132,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
@@ -20776,7 +20534,7 @@
       "version": "1.0.1",
       "resolved": "https://npm.lisk.com/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/is-map": {
       "version": "2.0.2",
@@ -21191,7 +20949,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/isobject": {
       "version": "3.0.1",
@@ -28140,7 +27898,7 @@
       "version": "9.1.0",
       "resolved": "https://npm.lisk.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -28167,7 +27925,7 @@
       "version": "1.1.2",
       "resolved": "https://npm.lisk.com/@tootallnate%2fonce/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 6"
       }
@@ -28176,7 +27934,7 @@
       "version": "4.0.1",
       "resolved": "https://npm.lisk.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -28190,7 +27948,7 @@
       "version": "6.0.0",
       "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -28202,7 +27960,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -28741,7 +28499,7 @@
       "version": "3.3.6",
       "resolved": "https://npm.lisk.com/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -28753,7 +28511,7 @@
       "version": "1.0.2",
       "resolved": "https://npm.lisk.com/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -28765,7 +28523,7 @@
       "version": "1.4.1",
       "resolved": "https://npm.lisk.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -28782,7 +28540,7 @@
       "version": "1.0.5",
       "resolved": "https://npm.lisk.com/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -28794,7 +28552,7 @@
       "version": "1.2.4",
       "resolved": "https://npm.lisk.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -28806,7 +28564,7 @@
       "version": "1.0.3",
       "resolved": "https://npm.lisk.com/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -28818,13 +28576,13 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
       "resolved": "https://npm.lisk.com/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -28837,7 +28595,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -29598,7 +29356,7 @@
       "version": "8.4.1",
       "resolved": "https://npm.lisk.com/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -29632,7 +29390,7 @@
       "version": "3.0.1",
       "resolved": "https://npm.lisk.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
       "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -29645,7 +29403,7 @@
       "version": "4.0.4",
       "resolved": "https://npm.lisk.com/gauge/-/gauge-4.0.4.tgz",
       "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -29664,7 +29422,7 @@
       "version": "7.2.3",
       "resolved": "https://npm.lisk.com/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -29684,7 +29442,7 @@
       "version": "6.0.0",
       "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -29696,7 +29454,7 @@
       "version": "6.0.2",
       "resolved": "https://npm.lisk.com/npmlog/-/npmlog-6.0.2.tgz",
       "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -29711,7 +29469,7 @@
       "version": "7.3.8",
       "resolved": "https://npm.lisk.com/semver/-/semver-7.3.8.tgz",
       "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -29726,7 +29484,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/node-hid": {
       "version": "2.1.1",
@@ -29822,7 +29580,7 @@
       "version": "5.0.0",
       "resolved": "https://npm.lisk.com/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -34963,13 +34721,13 @@
       "version": "1.0.1",
       "resolved": "https://npm.lisk.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://npm.lisk.com/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -37033,7 +36791,7 @@
       "version": "0.12.0",
       "resolved": "https://npm.lisk.com/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -37067,7 +36825,7 @@
       "version": "3.0.2",
       "resolved": "https://npm.lisk.com/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -38144,7 +37902,7 @@
       "version": "4.2.0",
       "resolved": "https://npm.lisk.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -38467,7 +38225,7 @@
       "version": "2.7.1",
       "resolved": "https://npm.lisk.com/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -38481,7 +38239,7 @@
       "version": "6.2.1",
       "resolved": "https://npm.lisk.com/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -38709,7 +38467,7 @@
       "version": "8.0.1",
       "resolved": "https://npm.lisk.com/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -39752,7 +39510,7 @@
       "version": "6.1.13",
       "resolved": "https://npm.lisk.com/tar/-/tar-6.1.13.tgz",
       "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -39805,7 +39563,7 @@
       "version": "4.0.3",
       "resolved": "https://npm.lisk.com/minipass/-/minipass-4.0.3.tgz",
       "integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -39814,7 +39572,7 @@
       "version": "1.0.4",
       "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -39826,7 +39584,7 @@
       "version": "4.0.0",
       "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/temp-file": {
       "version": "3.4.0",
@@ -40851,7 +40609,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -40860,7 +40618,7 @@
       "version": "2.0.2",
       "resolved": "https://npm.lisk.com/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }
@@ -43502,7 +43260,7 @@
       "version": "2.0.2",
       "resolved": "https://npm.lisk.com/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -45562,7 +45320,7 @@
       "version": "1.1.3",
       "resolved": "https://npm.lisk.com/@gar%2fpromisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "devOptional": true
+      "dev": true
     },
     "@hapi/bourne": {
       "version": "2.1.0",
@@ -47545,131 +47303,58 @@
       "integrity": "sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w=="
     },
     "@liskhq/lisk-api-client": {
-      "version": "6.0.0-alpha.15",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.15.tgz",
-      "integrity": "sha512-Ktgjq8AnK25o7T2Chk9nwkOaUbifdOGtHIGCK5cmDo47pswUillW1tlfUHUrh6/oM3c5bvUOpmW6dur7snWyAw==",
+      "version": "6.0.0-alpha.16",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-api-client/-/lisk-api-client-6.0.0-alpha.16.tgz",
+      "integrity": "sha512-BznpTSGs6BgC8a8wyolP0sPJP3tzdRejcck7MJkyRbGBpYAMoSfw3Brlzq86yk5mIH1HQzvKNbHDKQH3FjYnzQ==",
       "requires": {
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
-        "@liskhq/lisk-transactions": "^6.0.0-alpha.11",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6",
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
+        "@liskhq/lisk-transactions": "^6.0.0-alpha.12",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7",
         "isomorphic-ws": "4.0.1",
         "ws": "8.11.0",
         "zeromq": "6.0.0-beta.6"
-      },
-      "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
       }
     },
     "@liskhq/lisk-client": {
-      "version": "6.0.0-alpha.15",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.15.tgz",
-      "integrity": "sha512-ffC5NelS9C2UJCrEQvEfdCqf531EYMzW+nY8wFRtQzN/ZK02mNpuO6L5pLFTWunQBbrSbawk3KW8aRZuTpb1kw==",
+      "version": "6.0.0-alpha.16",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-client/-/lisk-client-6.0.0-alpha.16.tgz",
+      "integrity": "sha512-rkrW9pk8Bd83OoMQ5ojL8R5/i48tmIBb/9RYr/hNj5wC22CHRp+ktSh5EYPoFnigT5awBeJ2wfNm/5zC9PD0+g==",
       "requires": {
-        "@liskhq/lisk-api-client": "^6.0.0-alpha.15",
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-api-client": "^6.0.0-alpha.16",
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-        "@liskhq/lisk-transactions": "^6.0.0-alpha.11",
-        "@liskhq/lisk-tree": "^0.3.0-alpha.9",
+        "@liskhq/lisk-transactions": "^6.0.0-alpha.12",
+        "@liskhq/lisk-tree": "^0.3.0-alpha.10",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7",
         "buffer": "6.0.3"
-      },
-      "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
       }
     },
     "@liskhq/lisk-codec": {
-      "version": "0.3.0-alpha.8",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.8.tgz",
-      "integrity": "sha512-AM7Juadk4+zKz67DQFmvTFrjTQqqyCNK7BLxQ+WgAv5sdJPgcujSfLaKTSoL7hoLiE6Z4l0NMrDaU0ZMlJI2vQ==",
+      "version": "0.3.0-alpha.9",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-codec/-/lisk-codec-0.3.0-alpha.9.tgz",
+      "integrity": "sha512-KDgODq54d5zuA9hT7bnDAjVxrsZZhqnP6LRgM/oqvmFHAgcZb4AKk4jmEhLLINWwj0LvK70Jd96tYbn6/ZbUwQ==",
       "requires": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6"
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7"
+      }
+    },
+    "@liskhq/lisk-cryptography": {
+      "version": "4.0.0-alpha.7",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.7.tgz",
+      "integrity": "sha512-/dlVsJzjJ2z4IlbfVf87gWqB5p3xESqQKt8cRP94XZ38VmsQF2PpuZEEuyGEM9IbOYzT7kpdfQ+Fz7X7ZWiWuQ==",
+      "requires": {
+        "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
+        "buffer-reverse": "1.0.1",
+        "ed2curve": "0.3.0",
+        "hash-wasm": "4.9.0",
+        "tweetnacl": "1.0.3",
+        "varuint-bitcoin": "1.1.2"
       },
       "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
         "tweetnacl": {
           "version": "1.0.3",
           "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -47686,84 +47371,22 @@
       }
     },
     "@liskhq/lisk-transactions": {
-      "version": "6.0.0-alpha.11",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.11.tgz",
-      "integrity": "sha512-XJws8QMr6kZoXZ3dVLKEn6lKWuEh90CFdz7RWAxbdCLw2BKWoNzK+haXC6djIPTrgHhIVsQukHDf/9HcIVbtmA==",
+      "version": "6.0.0-alpha.12",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-transactions/-/lisk-transactions-6.0.0-alpha.12.tgz",
+      "integrity": "sha512-nPJR22tOG9LtojMiq5KVWfoYK1Cc8WJ7iHJgoboIvufD5PV1Zq1CZ5NQhx3ZZlOPffcs7OtVSOF32twheh2BWQ==",
       "requires": {
-        "@liskhq/lisk-codec": "^0.3.0-alpha.8",
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
-        "@liskhq/lisk-validator": "^0.7.0-alpha.6"
-      },
-      "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
+        "@liskhq/lisk-codec": "^0.3.0-alpha.9",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
+        "@liskhq/lisk-validator": "^0.7.0-alpha.7"
       }
     },
     "@liskhq/lisk-tree": {
-      "version": "0.3.0-alpha.9",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.9.tgz",
-      "integrity": "sha512-nilsdzCCdXGT1ONEMdh5/DGSII7oS0l5ZZ38zCdOmkL+UG5RKjelVw3N8JSPFpHPliNX3J/2sTY3s/BhTi43xw==",
+      "version": "0.3.0-alpha.10",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-tree/-/lisk-tree-0.3.0-alpha.10.tgz",
+      "integrity": "sha512-coT0XqI09r4r1Mx73CpzCCMEt0AJicODTHel0X2bhxlieIf7U6afcK0Zorv19teOps4IBc66X7rb9hAcC1hVDw==",
       "requires": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "@liskhq/lisk-utils": "^0.3.0-alpha.4"
-      },
-      "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
-        }
       }
     },
     "@liskhq/lisk-utils": {
@@ -47775,11 +47398,11 @@
       }
     },
     "@liskhq/lisk-validator": {
-      "version": "0.7.0-alpha.6",
-      "resolved": "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.6.tgz",
-      "integrity": "sha512-l+OmCMNx7/ACIn1/U5PgXTa4LyEDL+q80Xq+5e9p/uxuy5noJhEFUtDqttPsLOtqjUYZWGq/pzSdGuQSNrbokg==",
+      "version": "0.7.0-alpha.7",
+      "resolved": "https://npm.lisk.com/@liskhq%2flisk-validator/-/lisk-validator-0.7.0-alpha.7.tgz",
+      "integrity": "sha512-2rJopUelN2kefPjNsb88Jvkwl9PMp3Wl4jCL4Ce3Ogdk18fXwZfL1LeZQ3yOCc0bF9BAP8qG+K7c33SxKFo+nQ==",
       "requires": {
-        "@liskhq/lisk-cryptography": "^4.0.0-alpha.6",
+        "@liskhq/lisk-cryptography": "^4.0.0-alpha.7",
         "ajv": "8.1.0",
         "ajv-formats": "2.1.1",
         "debug": "4.3.4",
@@ -47787,30 +47410,6 @@
         "validator": "13.7.0"
       },
       "dependencies": {
-        "@chainsafe/blst": {
-          "version": "0.2.6",
-          "resolved": "https://npm.lisk.com/@chainsafe%2fblst/-/blst-0.2.6.tgz",
-          "integrity": "sha512-7mzE9IRjG0TZKPit83GT4XPSgMnqmMT4AAeUTyTj/IwO4FDPQ3fJVheT6i9LaH3I4Y18oaL68G9j+Uh3mEEAYg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "node-fetch": "^2.6.1",
-            "node-gyp": "^8.4.0"
-          }
-        },
-        "@liskhq/lisk-cryptography": {
-          "version": "4.0.0-alpha.6",
-          "resolved": "https://npm.lisk.com/@liskhq%2flisk-cryptography/-/lisk-cryptography-4.0.0-alpha.6.tgz",
-          "integrity": "sha512-gvRdf4w+bTS6r0LDpMJkC1BEHnHe1HUvRp84nurgck1xGOuNbz5rA4njJihf+QEEfWOu3F7lDy4fCUoYh3ln6w==",
-          "requires": {
-            "@liskhq/lisk-passphrase": "^4.0.0-alpha.2",
-            "buffer-reverse": "1.0.1",
-            "ed2curve": "0.3.0",
-            "hash-wasm": "4.9.0",
-            "tweetnacl": "1.0.3",
-            "varuint-bitcoin": "1.1.2"
-          }
-        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -47826,11 +47425,6 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "resolved": "https://npm.lisk.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
-          "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
         },
         "yallist": {
           "version": "4.0.0",
@@ -47939,7 +47533,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/@npmcli%2ffs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -47949,7 +47543,7 @@
           "version": "6.0.0",
           "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -47958,7 +47552,7 @@
           "version": "7.3.8",
           "resolved": "https://npm.lisk.com/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -47967,7 +47561,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -47975,7 +47569,7 @@
       "version": "1.1.2",
       "resolved": "https://npm.lisk.com/@npmcli%2fmove-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -47985,7 +47579,7 @@
           "version": "1.0.4",
           "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -49474,7 +49068,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "devOptional": true
+      "dev": true
     },
     "accepts": {
       "version": "1.3.8",
@@ -49579,7 +49173,7 @@
       "version": "6.0.2",
       "resolved": "https://npm.lisk.com/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -49588,7 +49182,7 @@
       "version": "4.2.1",
       "resolved": "https://npm.lisk.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
       "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",
@@ -49599,7 +49193,7 @@
           "version": "1.1.2",
           "resolved": "https://npm.lisk.com/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -49607,7 +49201,7 @@
       "version": "3.1.0",
       "resolved": "https://npm.lisk.com/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -49617,7 +49211,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/indent-string/-/indent-string-4.0.0.tgz",
           "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -49877,7 +49471,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/aproba/-/aproba-2.0.0.tgz",
       "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==",
-      "devOptional": true
+      "dev": true
     },
     "arch": {
       "version": "2.2.0",
@@ -51627,7 +51221,7 @@
       "version": "15.3.0",
       "resolved": "https://npm.lisk.com/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -51653,7 +51247,7 @@
           "version": "7.2.3",
           "resolved": "https://npm.lisk.com/glob/-/glob-7.2.3.tgz",
           "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -51667,7 +51261,7 @@
           "version": "6.0.0",
           "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -51676,13 +51270,13 @@
           "version": "1.0.4",
           "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "devOptional": true
+          "dev": true
         },
         "p-map": {
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/p-map/-/p-map-4.0.0.tgz",
           "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "aggregate-error": "^3.0.0"
           }
@@ -51691,7 +51285,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -52161,7 +51755,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "devOptional": true
+      "dev": true
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -52308,7 +51902,7 @@
       "version": "2.2.0",
       "resolved": "https://npm.lisk.com/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "devOptional": true
+      "dev": true
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -52533,7 +52127,7 @@
       "version": "1.1.3",
       "resolved": "https://npm.lisk.com/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-      "devOptional": true
+      "dev": true
     },
     "colorette": {
       "version": "2.0.19",
@@ -55917,7 +55511,7 @@
       "version": "2.0.3",
       "resolved": "https://npm.lisk.com/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "devOptional": true
+      "dev": true
     },
     "errno": {
       "version": "0.1.8",
@@ -57912,7 +57506,7 @@
       "version": "2.1.0",
       "resolved": "https://npm.lisk.com/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -57931,7 +57525,7 @@
       "version": "1.0.0",
       "resolved": "https://npm.lisk.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "devOptional": true
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.13",
@@ -58076,7 +57670,7 @@
       "version": "7.1.3",
       "resolved": "https://npm.lisk.com/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -59019,7 +58613,7 @@
       "version": "4.1.1",
       "resolved": "https://npm.lisk.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "devOptional": true
+      "dev": true
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -59251,7 +58845,7 @@
       "version": "5.0.1",
       "resolved": "https://npm.lisk.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -59267,7 +58861,7 @@
       "version": "1.2.1",
       "resolved": "https://npm.lisk.com/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ms": "^2.0.0"
       }
@@ -59570,7 +59164,7 @@
       "version": "0.1.4",
       "resolved": "https://npm.lisk.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "devOptional": true
+      "dev": true
     },
     "indent-string": {
       "version": "3.2.0",
@@ -59593,7 +59187,7 @@
       "version": "1.0.4",
       "resolved": "https://npm.lisk.com/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "devOptional": true
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -59750,7 +59344,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "devOptional": true
+      "dev": true
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -60028,7 +59622,7 @@
       "version": "1.0.1",
       "resolved": "https://npm.lisk.com/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
-      "devOptional": true
+      "dev": true
     },
     "is-map": {
       "version": "2.0.2",
@@ -60319,7 +59913,7 @@
       "version": "2.0.0",
       "resolved": "https://npm.lisk.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "devOptional": true
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -65856,7 +65450,7 @@
       "version": "9.1.0",
       "resolved": "https://npm.lisk.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -65880,13 +65474,13 @@
           "version": "1.1.2",
           "resolved": "https://npm.lisk.com/@tootallnate%2fonce/-/once-1.1.2.tgz",
           "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-          "devOptional": true
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "4.0.1",
           "resolved": "https://npm.lisk.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
           "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "@tootallnate/once": "1",
             "agent-base": "6",
@@ -65897,7 +65491,7 @@
           "version": "6.0.0",
           "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -65906,7 +65500,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -66319,7 +65913,7 @@
       "version": "3.3.6",
       "resolved": "https://npm.lisk.com/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       },
@@ -66328,7 +65922,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -66336,7 +65930,7 @@
       "version": "1.0.2",
       "resolved": "https://npm.lisk.com/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -66345,7 +65939,7 @@
       "version": "1.4.1",
       "resolved": "https://npm.lisk.com/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "encoding": "^0.1.12",
         "minipass": "^3.1.0",
@@ -66357,7 +65951,7 @@
       "version": "1.0.5",
       "resolved": "https://npm.lisk.com/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -66366,7 +65960,7 @@
       "version": "1.2.4",
       "resolved": "https://npm.lisk.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -66375,7 +65969,7 @@
       "version": "1.0.3",
       "resolved": "https://npm.lisk.com/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -66384,7 +65978,7 @@
       "version": "2.1.2",
       "resolved": "https://npm.lisk.com/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -66394,7 +65988,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -66992,7 +66586,7 @@
       "version": "8.4.1",
       "resolved": "https://npm.lisk.com/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -67010,7 +66604,7 @@
           "version": "3.0.1",
           "resolved": "https://npm.lisk.com/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
           "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^3.6.0"
@@ -67020,7 +66614,7 @@
           "version": "4.0.4",
           "resolved": "https://npm.lisk.com/gauge/-/gauge-4.0.4.tgz",
           "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.3",
@@ -67036,7 +66630,7 @@
           "version": "7.2.3",
           "resolved": "https://npm.lisk.com/glob/-/glob-7.2.3.tgz",
           "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -67050,7 +66644,7 @@
           "version": "6.0.0",
           "resolved": "https://npm.lisk.com/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -67059,7 +66653,7 @@
           "version": "6.0.2",
           "resolved": "https://npm.lisk.com/npmlog/-/npmlog-6.0.2.tgz",
           "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
@@ -67071,7 +66665,7 @@
           "version": "7.3.8",
           "resolved": "https://npm.lisk.com/semver/-/semver-7.3.8.tgz",
           "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "devOptional": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -67080,7 +66674,7 @@
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -67171,7 +66765,7 @@
       "version": "5.0.0",
       "resolved": "https://npm.lisk.com/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -71098,13 +70692,13 @@
       "version": "1.0.1",
       "resolved": "https://npm.lisk.com/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "devOptional": true
+      "dev": true
     },
     "promise-retry": {
       "version": "2.0.1",
       "resolved": "https://npm.lisk.com/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -72764,7 +72358,7 @@
       "version": "0.12.0",
       "resolved": "https://npm.lisk.com/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
-      "devOptional": true
+      "dev": true
     },
     "reusify": {
       "version": "1.0.4",
@@ -72788,7 +72382,7 @@
       "version": "3.0.2",
       "resolved": "https://npm.lisk.com/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -73646,7 +73240,7 @@
       "version": "4.2.0",
       "resolved": "https://npm.lisk.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "devOptional": true
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -73933,7 +73527,7 @@
       "version": "2.7.1",
       "resolved": "https://npm.lisk.com/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -73943,7 +73537,7 @@
       "version": "6.2.1",
       "resolved": "https://npm.lisk.com/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -74135,7 +73729,7 @@
       "version": "8.0.1",
       "resolved": "https://npm.lisk.com/ssri/-/ssri-8.0.1.tgz",
       "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "minipass": "^3.1.1"
       }
@@ -74978,7 +74572,7 @@
       "version": "6.1.13",
       "resolved": "https://npm.lisk.com/tar/-/tar-6.1.13.tgz",
       "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -74992,19 +74586,19 @@
           "version": "4.0.3",
           "resolved": "https://npm.lisk.com/minipass/-/minipass-4.0.3.tgz",
           "integrity": "sha512-OW2r4sQ0sI+z5ckEt5c1Tri4xTgZwYDxpE54eqWlQloQRoWtXjqt9udJ5Z4dSv7wK+nfFI7FRXyCpBSft+gpFw==",
-          "devOptional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://npm.lisk.com/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "devOptional": true
+          "dev": true
         },
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://npm.lisk.com/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "devOptional": true
+          "dev": true
         }
       }
     },
@@ -75856,7 +75450,7 @@
       "version": "1.1.1",
       "resolved": "https://npm.lisk.com/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "unique-slug": "^2.0.0"
       }
@@ -75865,7 +75459,7 @@
       "version": "2.0.2",
       "resolved": "https://npm.lisk.com/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
       }
@@ -77951,7 +77545,7 @@
       "version": "2.0.2",
       "resolved": "https://npm.lisk.com/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@hookform/resolvers": "2.8.8",
     "@json-rpc-tools/utils": "1.7.6",
     "@ledgerhq/hw-transport-node-hid": "6.27.12",
-    "@liskhq/lisk-client": "6.0.0-alpha.15",
+    "@liskhq/lisk-client": "6.0.0-alpha.16",
     "@tanstack/react-query": "4.0.10",
     "@tanstack/react-query-devtools": "4.2.1",
     "@walletconnect/sign-client": "2.0.0-rc.4",


### PR DESCRIPTION
### What was the problem?

This PR resolves #4831

### How was it solved?

- :arrow_up: Bump version
- SDK resolved the empty schema issue, so no source code changes required from desktop

### How was it tested?

- Try to send unlock transaction, modify `isFormValid: unlockedAmount > 0,` to `isFormValid: true,` to test the fee computation works with empty schema
- Without upgrading to `alpha.16` the above logic will fail