### PR TITLE
Do not show the isLoading icon when a search has completed

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -381,7 +381,7 @@
   "Nonce": "Nonce",
   "Not empty": "Not empty",
   "Nothing available to unlock": "Nothing available to unlock",
-  "Nothing has been found. Make sure to double check the ID you typed.": "Nothing has been found. Make sure to double check the ID you typed.",
+  "Nothing has been found for your search": "Nothing has been found for your search",
   "Now that you have enough tokens on your new account, please continue to send the reclaim transaction.": "Now that you have enough tokens on your new account, please continue to send the reclaim transaction.",
   "Now you can send it to the blockchain. You may also copy or download it, if you wish to send the transaction using another device later.": "Now you can send it to the blockchain. You may also copy or download it, if you wish to send the transaction using another device later.",
   "Number": "Number",

--- a/src/modules/search/components/SearchBar/SearchBar.js
+++ b/src/modules/search/components/SearchBar/SearchBar.js
@@ -113,7 +113,7 @@ const SearchBar = ({ className, history }) => {
     ? t('A bit more. Make sure to type at least 3 characters.')
     : null;
   feedback = isEmptyResults
-    ? t('Nothing has been found. Make sure to double check the ID you typed.')
+    ? t('Nothing has been found for your search')
     : feedback;
 
   return (

--- a/src/modules/search/hooks/useSearch.js
+++ b/src/modules/search/hooks/useSearch.js
@@ -5,7 +5,6 @@ import { useValidators } from '@pos/validator/hooks/queries';
 import { useBlocks } from '@block/hooks/queries/useBlocks';
 
 function getIsLoading(queryRes) {
-  // TODO: Function to be replaced with isInitialLoading when upgrading react-query to +v4.26
   return queryRes.isLoading && queryRes.isFetching;
 }
 

--- a/src/modules/search/hooks/useSearch.js
+++ b/src/modules/search/hooks/useSearch.js
@@ -4,6 +4,11 @@ import { useTransactions } from '@transaction/hooks/queries';
 import { useValidators } from '@pos/validator/hooks/queries';
 import { useBlocks } from '@block/hooks/queries/useBlocks';
 
+function getIsLoading(queryRes) {
+  // TODO: Function to be replaced with isInitialLoading when upgrading react-query to +v4.26
+  return queryRes.isLoading && queryRes.isFetching;
+}
+
 // eslint-disable-next-line complexity,max-statements
 export const useSearch = (search = '') => {
   const isAddress = validateAddress(search) === 0;
@@ -32,10 +37,16 @@ export const useSearch = (search = '') => {
   });
 
   const isLoading =
-    validators.isLoading || transactions.isLoading || addresses.isLoading || blocks.isLoading;
+    getIsLoading(validators) ||
+    getIsLoading(transactions) ||
+    getIsLoading(addresses) ||
+    getIsLoading(blocks);
 
   const isFetched =
-  (isValidator  && validators.isFetched) || (isTxId  && transactions.isFetched) || (isAddress  && addresses.isFetched) || (isBlockHeight  && blocks.isFetched);
+    (isValidator && validators.isFetched) ||
+    (isTxId && transactions.isFetched) ||
+    (isAddress && addresses.isFetched) ||
+    (isBlockHeight && blocks.isFetched);
 
   return {
     addresses: addresses.data?.data ?? [],

--- a/src/modules/search/hooks/useSearch.test.js
+++ b/src/modules/search/hooks/useSearch.test.js
@@ -101,6 +101,7 @@ describe('useSearch hook', () => {
 
   it('should return loading state', async () => {
     const resultState = (loading) => ({
+      isFetching: loading,
       isLoading: loading,
       isFetched: !loading,
     });

--- a/tests/cypress/features/search/search.js
+++ b/tests/cypress/features/search/search.js
@@ -13,5 +13,5 @@ And(/^I search for transaction ([^s]+)$/, function (string) {
 });
 
 Then(/^I should see no results$/, function () {
-  cy.get(ss.searchMessage).eq(0).should('have.text', 'Nothing has been found. Make sure to double check the ID you typed.');
+  cy.get(ss.searchMessage).eq(0).should('have.text', 'Nothing has been found for your search');
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #4617

### How was it solved?

By checking both for queryRes.isLoading && queryRes.isFetching to return a loading spinner state to searchbar

### How was it tested?

Manually
