### PR TITLE
Fix the incorrect number of blocks on the chart

### DIFF
--- a/src/modules/block/components/blocksOverview/blocksOverview.js
+++ b/src/modules/block/components/blocksOverview/blocksOverview.js
@@ -13,7 +13,7 @@ import styles from './blocksOverview.css';
 
 const BlocksOverview = () => {
   const [activeTab, setActiveTab] = useState(10);
-  const [config, setConfig] = useState({ params: {} });
+  const [config, setConfig] = useState({ params: { limit: 10 } });
   const { data: blocks } = useBlocks({ config });
   const { t } = useTranslation();
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #4445

### How was it solved?

The initial parameters passed to the query hook was wrong. Fixed it.

### How was it tested?

- Tested visually
