### PR TITLE
Incorrect network used for API calls

### DIFF
--- a/src/modules/network/store/middleware.js
+++ b/src/modules/network/store/middleware.js
@@ -1,23 +1,13 @@
-import networks from '@network/configuration/networks';
 import analytics from 'src/utils/analytics';
 import settingsActionTypes from 'src/modules/settings/store/actionTypes';
 import { settingsUpdated } from 'src/modules/settings/store/actions';
-import { DEFAULT_NETWORK } from 'src/const/config';
 import { networkSelected, networkStatusUpdated, networkConfigSet } from './action';
 import actionTypes from './actionTypes';
 
 const readStoredNetwork = ({ dispatch, getState }) => {
-  const { statistics, statisticsRequest, statisticsFollowingDay, network } = getState().settings;
-
-  const config =
-    network?.name && network?.address
-      ? network
-      : {
-          // This wuold always read the default network from the config
-          name: DEFAULT_NETWORK,
-          address: networks[DEFAULT_NETWORK].serviceUrl,
-        };
-  dispatch(networkSelected(config));
+  const { statistics, statisticsRequest, statisticsFollowingDay, mainChainNetwork } =
+    getState().settings;
+  dispatch(networkSelected({ name: mainChainNetwork?.name }));
   dispatch(networkStatusUpdated({ online: true }));
 
   if (!statistics) {

--- a/src/modules/network/store/reducer.js
+++ b/src/modules/network/store/reducer.js
@@ -1,3 +1,4 @@
+import actionTypesSettings from '@settings/store/actionTypes';
 import actionTypes from './actionTypes';
 
 const initialState = {
@@ -45,6 +46,16 @@ const network = (state = initialState, action) => {
         ...state,
         storedCustomNetwork: '',
       };
+    case actionTypesSettings.settingsUpdated: {
+      const mainChainNetwork = action.data?.mainChainNetwork;
+      if (mainChainNetwork) {
+        return {
+          ...state,
+          name: mainChainNetwork.name,
+        };
+      }
+      return state;
+    }
     case actionTypes.schemasRetrieved:
       return {
         ...state,

--- a/src/modules/token/fungible/hooks/queries/useAppsMetaTokens.js
+++ b/src/modules/token/fungible/hooks/queries/useAppsMetaTokens.js
@@ -2,8 +2,8 @@
 import { useSelector } from 'react-redux';
 import { BLOCKCHAIN_APPS_META_TOKENS } from 'src/const/queries';
 import { LIMIT as limit, API_VERSION } from 'src/const/config';
+import { selectNetworkName } from 'src/redux/selectors';
 import { useCustomInfiniteQuery } from 'src/modules/common/hooks';
-import { getNetworkName } from '@network/utils/getNetwork';
 import { useCurrentApplication } from '@blockchainApplication/manage/hooks';
 import defaultClient from 'src/utils/api/client';
 
@@ -19,8 +19,7 @@ import defaultClient from 'src/utils/api/client';
  * @returns the query object
  */
 export const useAppsMetaTokensConfig = () => {
-  const selectedNetwork = useSelector((state) => state.network);
-  const network = getNetworkName(selectedNetwork);
+  const network = useSelector(selectNetworkName);
   const [{ chainID }] = useCurrentApplication();
   return (customConfig = {}) => ({
     url: `/api/${API_VERSION}/blockchain/apps/meta/tokens`,

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -1,9 +1,6 @@
-const selectAccount = (state) => state.wallet;
 const selectActiveToken = (state) => state.token.active;
-const selectAddress = (state) => state.wallet.info[state.token.active].address;
 const selectLSKAddress = (state) =>
   state.wallet.info ? state.wallet.info.LSK.summary.address : undefined;
-const selectPublicKey = (state) => state.wallet.info[state.token.active].publicKey;
 const selectTransactions = (state) => state.transactions;
 const selectActiveTokenAccount = (state) => {
   if (!state.wallet.info) {
@@ -17,35 +14,21 @@ const selectActiveTokenAccount = (state) => {
 const selectAccountBalance = (
   state // @todo account has multiple balance now
 ) => (state.wallet.info ? state.wallet.info[state.token.active].summary.balance : undefined);
-const selectBookmarks = (state) => state.bookmarks[state.token.active];
-const selectBookmark = (state, address) =>
-  state.bookmarks[state.token.active].find((item) => item.address === address);
 const selectSettings = (state) => state.settings;
 const selectNetwork = (state) => state.network;
-const selectServiceUrl = (state) => state.network.networks?.LSK?.serviceUrl;
-const selectNetworkIdentifier = (state) => state.network.networks?.LSK?.networkIdentifier;
 const selectNetworkName = (state) => state.network.name;
-const selectActiveTokenNetwork = (state) => state.network.networks[state.token.active];
 const selectStaking = (state) => state.staking;
 const selectModuleCommandSchemas = (state) => state.network.networks?.LSK?.moduleCommandSchemas;
 
 export {
   selectStaking,
   selectNetwork,
-  selectBookmark,
   selectSettings,
   selectActiveToken,
   selectTransactions,
-  selectBookmarks,
-  selectAddress,
-  selectAccount,
   selectLSKAddress,
-  selectPublicKey,
   selectActiveTokenAccount,
   selectAccountBalance,
-  selectServiceUrl,
-  selectNetworkIdentifier,
   selectNetworkName,
-  selectActiveTokenNetwork,
   selectModuleCommandSchemas,
 };


### PR DESCRIPTION
### What was the problem?

This PR resolves #4922

### How was it solved?

- Update network reducer with correct network name whenever changing the network in settings
- Removed unused redux selectors
- Removed failsafe of default network to only be in settings/mainChainNetwork, this is the only place where we need to make sure a network is selected.

### How was it tested?

Manually
