### PR TITLE
Account search UI bug

### DIFF
--- a/src/modules/wallet/components/searchBarWallets/walletsAndValidators.css
+++ b/src/modules/wallet/components/searchBarWallets/walletsAndValidators.css
@@ -63,8 +63,8 @@
 
   & .tag {
     @mixin contentNormal bold;
-    white-space: nowrap;
 
+    white-space: nowrap;
     background: var(--color-white-smoke);
     color: var(--color-ink-blue);
     padding: 9px;

--- a/src/modules/wallet/components/searchBarWallets/walletsAndValidators.css
+++ b/src/modules/wallet/components/searchBarWallets/walletsAndValidators.css
@@ -63,6 +63,7 @@
 
   & .tag {
     @mixin contentNormal bold;
+    white-space: nowrap;
 
     background: var(--color-white-smoke);
     color: var(--color-ink-blue);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5077

### How was it solved?

Adding `white-space: nowrap;`

### How was it tested?

1. search for opt1mus in search bar, expected: the validator + rank badge should not be broken up in a new line
