### PR TITLE
Show error modal if dryrun fails

### DIFF
--- a/src/modules/transaction/constants.js
+++ b/src/modules/transaction/constants.js
@@ -5,3 +5,9 @@ export const FEE_TYPES = {
   ESCROW_ACCOUNT_INITIALIZATION: 'escrowAccountInitialization',
   VALIDATOR_REGISTRATION: 'validatorRegistration',
 };
+
+export const TransactionExecutionResult = {
+  INVALID: -1,
+  FAIL: 0,
+  OK: 1,
+};

--- a/src/modules/transaction/store/actions.js
+++ b/src/modules/transaction/store/actions.js
@@ -116,38 +116,19 @@ export const transactionBroadcasted =
       // https://github.com/LiskHQ/lisk-desktop/issues/4698 should handle this logic
     }
 
-    if (error) {
-      dispatch({
-        type: actionTypes.broadcastedTransactionError,
-        data: {
-          error: error.message,
-          transaction,
-        },
-      });
-    } else {
-      if (dryRunResult.data?.result === -1) {
-        dispatch({
-          type: actionTypes.broadcastedTransactionError,
-          data: {
-            error: dryRunResult.data?.errorMessage,
-            transaction,
-          },
-        });
-      }
+    const transactionErrorMessage =
+      error?.message ||
+      (dryRunResult?.data?.result === 0
+        ? dryRunResult?.data?.events.map((e) => e.name).join(', ')
+        : dryRunResult?.data?.errorMessage);
 
-      if (dryRunResult.data?.result === 0) {
-        // @TODO: Prepare error message by parsing the events based on each transaction type
-        // https://github.com/LiskHQ/lisk-desktop/issues/4698 should resolve all the dry run related logic along with feedback
-        const temporaryError = dryRunResult.data?.events.map((e) => e.name).join(', ');
-        dispatch({
-          type: actionTypes.broadcastedTransactionError,
-          data: {
-            error: temporaryError,
-            transaction,
-          },
-        });
-      }
-    }
+    dispatch({
+      type: actionTypes.broadcastedTransactionError,
+      data: {
+        error: transactionErrorMessage,
+        transaction,
+      },
+    });
 
     return false;
   };

--- a/src/modules/transaction/store/actions.js
+++ b/src/modules/transaction/store/actions.js
@@ -4,6 +4,7 @@ import { getTransactionSignatureStatus } from '@wallet/components/signMultisigVi
 import { selectActiveTokenAccount } from 'src/redux/selectors';
 import { loadingStarted, loadingFinished } from 'src/modules/common/store/actions';
 import { selectCurrentApplicationChainID } from '@blockchainApplication/manage/store/selectors';
+import { TransactionExecutionResult } from '@transaction/constants';
 import actionTypes from './actionTypes';
 import { getTransactions, broadcast, dryRun, signTransaction } from '../api';
 import { joinModuleAndCommand, signMultisigTransaction } from '../utils';
@@ -99,7 +100,7 @@ export const transactionBroadcasted =
 
     const [error, dryRunResult] = await to(dryRun({ transaction, serviceUrl, paramsSchema }));
 
-    if (dryRunResult?.data?.result === 1) {
+    if (dryRunResult?.data?.result === TransactionExecutionResult.OK) {
       broadcastResult = await broadcast({ transaction, serviceUrl, moduleCommandSchemas });
 
       if (!broadcastResult.data?.error) {
@@ -118,7 +119,7 @@ export const transactionBroadcasted =
 
     const transactionErrorMessage =
       error?.message ||
-      (dryRunResult?.data?.result === 0
+      (dryRunResult?.data?.result === TransactionExecutionResult.FAIL
         ? dryRunResult?.data?.events.map((e) => e.name).join(', ')
         : dryRunResult?.data?.errorMessage);
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5037

### How was it solved?

Check if dryrun endpoint returns an error and in that case show the error dialog when sending an transaction

### How to test?
1. Force dryrun to fail by adding an additional param
![image](https://github.com/LiskHQ/lisk-desktop/assets/8784876/2b52f0e3-6a7a-4775-b51a-300efbe46ed3)
2. Open a dialog to perform a transaction, for example send token
3. Try to send token
4. It should fail and show a retry button in the last step, Click the retry button.

