### PR TITLE
Implement error state on all tables

### DIFF
--- a/src/modules/transaction/components/TransactionEvents/TransactionEvents.js
+++ b/src/modules/transaction/components/TransactionEvents/TransactionEvents.js
@@ -50,6 +50,7 @@ const TransactionEvents = ({ address, transactionID = '', blockID = '', isWallet
     error,
     hasNextPage,
     fetchNextPage,
+    refetch,
   } = useTransactionEvents({
     config: { params },
   });
@@ -97,6 +98,7 @@ const TransactionEvents = ({ address, transactionID = '', blockID = '', isWallet
             isWallet,
           }}
           error={error}
+          retry={refetch}
           emptyState={{
             message: t('There are no events for this account.'),
             illustration: 'emptyEventsIllustration',

--- a/src/modules/transaction/components/TransactionEvents/TransactionEvents.test.js
+++ b/src/modules/transaction/components/TransactionEvents/TransactionEvents.test.js
@@ -86,17 +86,19 @@ describe('TransactionEvents', () => {
     });
   });
 
-  it('should display empty state text', async () => {
+  it('should display error state', async () => {
     useTransactionEvents.mockReturnValue({
-      isLoading: true,
-      error: { response: { status: 404 } },
+      isLoading: false,
+      error: 'error',
       hasNextPage: false,
       isFetching: false,
       fetchNextPage: mockFetchNextPage,
+      refetch: jest.fn(),
     });
     wrapper.rerender(<TransactionEvents {...props} />);
 
-    expect(wrapper.getByText('There are no events for this account.')).toBeTruthy();
+    expect(wrapper.getByText('error')).toBeTruthy();
+    expect(wrapper.getByText('Retry')).toBeTruthy();
   });
 
   it('should display filter fields', async () => {

--- a/src/theme/QueryTable/QueryTable.js
+++ b/src/theme/QueryTable/QueryTable.js
@@ -12,6 +12,7 @@ export const QueryTable = ({
   onFetched,
   ...props
 }) => {
+  const data = queryHook(queryConfig);
   const {
     data: response,
     error,
@@ -22,7 +23,8 @@ export const QueryTable = ({
     hasUpdate,
     addUpdate,
     isFetched,
-  } = queryHook(queryConfig);
+    refetch,
+  } = data;
 
   const handleClick = () => {
     // When the header is fixed at the top, the position is 50px
@@ -57,6 +59,7 @@ export const QueryTable = ({
       canLoadMore={hasNextPage}
       error={error}
       subHeader={subHeader}
+      retry={refetch}
       {...props}
     />
   );

--- a/src/theme/box/emptyState.css
+++ b/src/theme/box/emptyState.css
@@ -33,4 +33,10 @@
   & img {
     max-width: 245px;
   }
+
+  & > button {
+    color: var(--color-ultramarine-blue);
+    height: fit-content !important;
+    margin-top: 5px;
+  }
 }

--- a/src/theme/table/empty.js
+++ b/src/theme/table/empty.js
@@ -4,8 +4,9 @@ import { isReactComponent } from 'src/utils/helpers';
 import Illustration from 'src/modules/common/components/illustration';
 import styles from '../box/emptyState.css';
 
-const Empty = ({ isListEmpty, isLoading, data, error, className, message }) => {
-  if (isLoading || (error && error.response?.status !== 404) || !isListEmpty) return null;
+const Empty = ({ isListEmpty, isLoading, error, data, className, message }) => {
+  if (isLoading || !isListEmpty || error) return null;
+
   if (isReactComponent(data)) {
     const Element = data;
     return <Element />;
@@ -14,7 +15,7 @@ const Empty = ({ isListEmpty, isLoading, data, error, className, message }) => {
   return (
     <div className={`${styles.wrapper} ${className} empty-state`}>
       <Illustration name={data?.illustration ?? 'emptyWallet'} />
-      <h3>{message || data?.message || error?.message || 'Nothing found.'}</h3>
+      <h3>{message || data?.message || 'Nothing found.'}</h3>
     </div>
   );
 };

--- a/src/theme/table/error.js
+++ b/src/theme/table/error.js
@@ -9,7 +9,7 @@ const Error = ({ error, handleRetry, isLoading }) => {
   return (
     <div className={`${styles.wrapper} error-state`}>
       <Illustration name="emptyWallet" />
-      <h3>{typeof data === 'string' ? error : error.message}</h3>
+      <h3>{typeof error === 'string' ? error : error.message}</h3>
       {handleRetry && <TertiaryButton onClick={handleRetry}>Retry</TertiaryButton>}
     </div>
   );

--- a/src/theme/table/error.js
+++ b/src/theme/table/error.js
@@ -1,21 +1,16 @@
 import React from 'react';
 import Illustration from 'src/modules/common/components/illustration';
 import styles from '../box/emptyState.css';
+import { TertiaryButton } from '../buttons';
 
-const Error = ({ data, isLoading }) => {
-  const notFoundReg = /not\sfound/gi;
-  if (
-    isLoading ||
-    !data ||
-    data.response?.status === 404 ||
-    (typeof data === 'string' ? notFoundReg.test(data) : notFoundReg.test(data.message))
-  ) {
-    return null;
-  }
+const Error = ({ error, handleRetry, isLoading }) => {
+  if (isLoading || !error) return null;
+
   return (
     <div className={`${styles.wrapper} error-state`}>
       <Illustration name="emptyWallet" />
-      <h3>{typeof data === 'string' ? data : data.message}</h3>
+      <h3>{typeof data === 'string' ? error : error.message}</h3>
+      {handleRetry && <TertiaryButton onClick={handleRetry}>Retry</TertiaryButton>}
     </div>
   );
 };

--- a/src/theme/table/index.js
+++ b/src/theme/table/index.js
@@ -81,6 +81,7 @@ const Table = ({
   showHeader,
   isFetching,
   customLoader,
+  retry,
 }) => (
   <>
     <List
@@ -102,7 +103,7 @@ const Table = ({
       isListEmpty={data.length === 0}
       className={styles.emptyState}
     />
-    <Error data={error} isLoading={isLoading} />
+    <Error handleRetry={retry} error={error} isLoading={isLoading} />
     <LoadMoreButton
       onClick={loadData}
       isFetching={isFetching}

--- a/src/theme/table/table.test.js
+++ b/src/theme/table/table.test.js
@@ -17,6 +17,24 @@ describe('Table', () => {
     it('should render a loader if data is loading', () => {
       const wrapper = mount(<Table {...props} />);
       expect(wrapper.find('.skeletonRowWrapper').at(0)).toBeTruthy();
+      expect(wrapper.find('img[alt="emptyWallet"]').at(0)).toBeTruthy();
+    });
+  });
+
+  describe('Error', () => {
+    const props = {
+      data: [],
+      canLoadMore: false,
+      isLoading: true,
+      isFetching: true,
+      row: () => <div />,
+      header: [],
+      error: 'error',
+    };
+
+    it.only('should render an error state', () => {
+      const wrapper = mount(<Table {...props} />);
+      expect(wrapper.find('.error-state').at(0)).toBeTruthy();
     });
   });
 

--- a/src/theme/table/table.test.js
+++ b/src/theme/table/table.test.js
@@ -54,21 +54,32 @@ describe('Table', () => {
     });
 
     it('should render an empty template if data is empty with custom config', () => {
-      const emptyState = {
-        message: 'custom_message',
-        illustration: 'emptyBookmarksList',
+      const customProps = {
+        data: [],
+        canLoadMore: false,
+        isLoading: false,
+        row: () => <div />,
+        header: [],
+        emptyState: {
+          message: 'custom_message',
+          illustration: 'emptyBookmarksList',
+        },
       };
-      const wrapper = mount(
-        <Table {...props} error={{ response: { status: 404 } }} emptyState={emptyState} />
-      );
+      const wrapper = mount(<Table {...customProps} />);
       expect(wrapper).toHaveText('custom_message');
     });
 
     it('should render an empty template if data is empty with custom template', () => {
-      const emptyState = () => <div>custom_empty_template</div>;
-      const wrapper = mount(
-        <Table {...props} emptyState={emptyState} error={{ response: { status: 404 } }} />
-      );
+      const customProps = {
+        data: [],
+        canLoadMore: false,
+        isLoading: false,
+        row: () => <div />,
+        header: [],
+        emptyState: () => <div>custom_empty_template</div>,
+      };
+
+      const wrapper = mount(<Table {...customProps} />);
       expect(wrapper).toHaveText('custom_empty_template');
     });
   });

--- a/src/theme/table/table.test.js
+++ b/src/theme/table/table.test.js
@@ -32,7 +32,7 @@ describe('Table', () => {
       error: 'error',
     };
 
-    it.only('should render an error state', () => {
+    it('should render an error state', () => {
       const wrapper = mount(<Table {...props} />);
       expect(wrapper.find('.error-state').at(0)).toBeTruthy();
     });


### PR DESCRIPTION
### What was the problem?

This PR resolves #5100

### How was it solved?

- [x] Fix table to display error on api failure
- [x] Fix failing unit test
- [x] Add retry functionality error states on tables 

#### How to test #5100
- Change the api URL on any of the api query hook you would want to test in code.
- Navigate to the table invoking the above altered hook.
- You should see an error state with a retry button.


