### PR TITLE
Stake page should update by itself

### DIFF
--- a/src/modules/pos/validator/components/SentStakes/SentStakes.js
+++ b/src/modules/pos/validator/components/SentStakes/SentStakes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Heading from 'src/modules/common/components/Heading';
 import DialogLink from 'src/theme/dialog/link';
@@ -12,6 +12,8 @@ import { useCurrentAccount } from '@account/hooks';
 import routes from 'src/routes/routes';
 import StakesCount from '@pos/validator/components/StakesCount';
 import { useRewardsClaimable } from '@pos/reward/hooks/queries';
+import { useMyTransactions } from '@transaction/hooks/queries';
+import { MODULE_COMMANDS_NAME_MAP } from '@transaction/configuration/moduleCommand';
 import styles from './SentStakes.css';
 import header from './tableHeaderMap';
 import SentStakesRow from '../SentStakesRow';
@@ -55,6 +57,26 @@ const SentStakes = ({ history }) => {
   const { t } = useTranslation();
   const stakerAddress = useStakerAddress(history.location.search);
   const { token } = usePosToken({ address: stakerAddress });
+  const { refetch } = useSentStakes({
+    config: { params: { address: stakerAddress } },
+  });
+
+  const { data: pooledTransactionsData } = useMyTransactions({
+    config: {
+      params: {
+        address: stakerAddress,
+        sort: 'timestamp:desc',
+        moduleCommand: MODULE_COMMANDS_NAME_MAP.stake,
+        limit: 1,
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (pooledTransactionsData?.meta?.total > 1) {
+      refetch();
+    }
+  }, [pooledTransactionsData?.meta?.total]);
 
   const handleGoToValidators = () => {
     history.push(routes.validators.path);

--- a/src/modules/pos/validator/components/SentStakes/SentStakes.test.js
+++ b/src/modules/pos/validator/components/SentStakes/SentStakes.test.js
@@ -5,7 +5,7 @@ import { convertFromBaseDenom } from '@token/fungible/utils/helpers';
 import { getMockValidators, mockSentStakes, mockUnlocks } from '@pos/validator/__fixtures__';
 import { mockTokensBalance } from '@token/fungible/__fixtures__/mockTokens';
 import { truncateAddress } from '@wallet/utils/account';
-import { renderWithRouter } from 'src/utils/testHelpers';
+import { renderWithRouterAndQueryClient} from 'src/utils/testHelpers';
 import { useRewardsClaimable } from '@pos/reward/hooks/queries';
 import { mockRewardsClaimable } from '@pos/reward/__fixtures__';
 import { mockAppsTokens } from '@token/fungible/__fixtures__';
@@ -43,7 +43,7 @@ describe('SentStakes', () => {
   usePosConstants.mockReturnValue({ data: mockPosConstants });
 
   it('should display properly', async () => {
-    renderWithRouter(SentStakes, props);
+    renderWithRouterAndQueryClient(SentStakes, props);
 
     expect(screen.getByText('Stakes')).toBeTruthy();
     expect(screen.getByText(10 - mockSentStakes.meta.count)).toBeTruthy();
@@ -71,7 +71,7 @@ describe('SentStakes', () => {
     useSentStakes.mockReturnValue({});
     useTokenBalances.mockReturnValue({});
 
-    renderWithRouter(SentStakes, props);
+    renderWithRouterAndQueryClient(SentStakes, props);
 
     mockSentStakes.data.stakes.forEach(({ address, amount, name }, index) => {
       expect(screen.queryAllByText(name)[0]).toBeFalsy();

--- a/src/modules/pos/validator/components/SentStakes/SentStakes.test.js
+++ b/src/modules/pos/validator/components/SentStakes/SentStakes.test.js
@@ -1,15 +1,16 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import mockSavedAccounts from '@tests/fixtures/accounts';
 import { useTokenBalances } from '@token/fungible/hooks/queries';
 import { convertFromBaseDenom } from '@token/fungible/utils/helpers';
 import { getMockValidators, mockSentStakes, mockUnlocks } from '@pos/validator/__fixtures__';
 import { mockTokensBalance } from '@token/fungible/__fixtures__/mockTokens';
 import { truncateAddress } from '@wallet/utils/account';
-import { renderWithRouterAndQueryClient} from 'src/utils/testHelpers';
+import { renderWithRouterAndQueryClient } from 'src/utils/testHelpers';
 import { useRewardsClaimable } from '@pos/reward/hooks/queries';
 import { mockRewardsClaimable } from '@pos/reward/__fixtures__';
 import { mockAppsTokens } from '@token/fungible/__fixtures__';
 import usePosToken from '@pos/validator/hooks/usePosToken';
+import routes from 'src/routes/routes';
 import SentStakes from './SentStakes';
 import tableHeaderMap from './tableHeaderMap';
 import { usePosConstants, useSentStakes, useUnlocks, useValidators } from '../../hooks/queries';
@@ -28,8 +29,9 @@ jest.mock('../../hooks/queries');
 jest.mock('@pos/validator/hooks/usePosToken');
 
 describe('SentStakes', () => {
+  const historyPush = jest.fn();
   const props = {
-    history: { location: { search: '' } },
+    history: { location: { search: '' }, push: historyPush },
   };
 
   useRewardsClaimable.mockReturnValue({ data: mockRewardsClaimable });
@@ -81,5 +83,11 @@ describe('SentStakes', () => {
       ).toBeFalsy();
       expect(screen.queryAllByAltText('edit')[index]).toBeFalsy();
     });
+  });
+
+  it('should navigate to /validators when arrow left is clicked', async () => {
+    renderWithRouterAndQueryClient(SentStakes, props);
+    fireEvent.click(screen.getByAltText('arrowLeftTailed'));
+    expect(historyPush).toHaveBeenCalledWith(routes.validators.path);
   });
 });

--- a/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.css
+++ b/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.css
@@ -40,7 +40,7 @@
       font-size: var(--font-size-h6);
       transition-property: color;
       transition-timing-function: steps(8, end);
-      transition-duration: 0.5s;
+      transition-duration: 1.5s;
     }
 
     &.animateRed {

--- a/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.css
+++ b/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.css
@@ -28,6 +28,31 @@
   &:hover .pinWrapper {
     display: block;
   }
+
+  & .balance {
+    padding: 0px 10px 0px 10px;
+    display: flex;
+    align-items: center;
+    font-size: var(--paragraph-font-size-s);
+    color: var(--color-content-light);
+
+    &.amountCell {
+      font-size: var(--font-size-h6);
+      transition-property: color;
+      transition-timing-function: steps(8, end);
+      transition-duration: 0.5s;
+    }
+
+    &.animateRed {
+      color: var(--color-red);
+      transition-duration: 0s;
+    }
+
+    &.animateGreen {
+      color: var(--color-deep-green);
+      transition-duration: 0s;
+    }
+  }
 }
 
 .action {
@@ -94,18 +119,6 @@
     @mixin contentLarge;
 
     color: var(--color-slate-gray);
-  }
-}
-
-.balance {
-  padding: 0px 10px 0px 10px;
-  display: flex;
-  align-items: center;
-  font-size: var(--paragraph-font-size-s);
-  color: var(--color-content-light) !important;
-
-  &.amountCell {
-    font-size: var(--font-size-h6);
   }
 }
 

--- a/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.js
+++ b/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.js
@@ -28,8 +28,8 @@ const SentStakesRow = ({ data: stakes, stakeEdited, token }) => {
         <Balance
           className={classNames({
             [styles.amountCell]: true,
-            [styles.animateGreen]: prevAmount && parseInt(prevAmount, 10) < parseInt(amount, 10),
-            [styles.animateRed]: prevAmount && parseInt(prevAmount, 10) > parseInt(amount, 10),
+            [styles.animateGreen]: prevAmount && BigInt(prevAmount) < BigInt(amount),
+            [styles.animateRed]: prevAmount && BigInt(prevAmount) > BigInt(amount),
           })}
           value={<TokenAmount val={amount} token={token} />}
         />

--- a/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.js
+++ b/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import TokenAmount from '@token/fungible/components/tokenAmount';
+import classNames from 'classnames';
 import { useValidators } from '@pos/validator/hooks/queries';
+import { usePrevious } from 'src/utils/usePrevious';
 import { Actions, Balance, ValidatorWalletVisual } from './components';
 import styles from './SentStakesRow.css';
 
@@ -9,6 +11,8 @@ const SentStakesRow = ({ data: stakes, stakeEdited, token }) => {
   const { data: validators, isLoading: isLoadingValidators } = useValidators({
     config: { params: { address: validatorAddress } },
   });
+
+  const prevAmount = usePrevious(amount);
 
   const { name, rank, validatorWeight, commission } = !isLoadingValidators
     ? validators.data[0]
@@ -21,7 +25,14 @@ const SentStakesRow = ({ data: stakes, stakeEdited, token }) => {
         <Balance colSpanXs={1} value={`#${rank}`} />
         <Balance value={<TokenAmount val={validatorWeight} token={token} />} />
         <Balance value={`${commission / 100}%`} />
-        <Balance className={styles.amountCell} value={<TokenAmount val={amount} token={token} />} />
+        <Balance
+          className={classNames({
+            [styles.amountCell]: true,
+            [styles.animateGreen]: prevAmount && parseInt(prevAmount, 10) < parseInt(amount, 10),
+            [styles.animateRed]: prevAmount && parseInt(prevAmount, 10) > parseInt(amount, 10),
+          })}
+          value={<TokenAmount val={amount} token={token} />}
+        />
         <Actions address={validatorAddress} name={name} stakeEdited={stakeEdited} />
       </div>
     </div>

--- a/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.test.js
+++ b/src/modules/pos/validator/components/SentStakesRow/SentStakesRow.test.js
@@ -1,11 +1,13 @@
+import React from 'react';
 import { renderWithRouter } from 'src/utils/testHelpers';
 import { screen } from '@testing-library/react';
 import { convertFromBaseDenom } from '@token/fungible/utils/helpers';
 import { mockAppsTokens, mockTokensBalance } from '@token/fungible/__fixtures__/mockTokens';
 import { truncateAddress } from '@wallet/utils/account';
 import { useValidators } from '@pos/validator/hooks/queries';
-import SentStakesRow from './SentStakesRow';
+import { MemoryRouter } from 'react-router';
 import { getMockValidators, mockSentStakes } from '../../__fixtures__';
+import SentStakesRow from './SentStakesRow';
 
 jest.mock('@pos/validator/hooks/queries');
 
@@ -34,6 +36,22 @@ describe('SentStakesRow', () => {
       )
     );
     expect(screen.getByAltText('edit')).toBeTruthy();
+  });
+
+  it('should rerender with new value', async () => {
+    const container = renderWithRouter(SentStakesRow, props);
+    const updatedProps = { ...props, data: mockSentStakes.data.stakes[2] };
+    container.rerender(
+      <MemoryRouter initialEntries={[]}>
+        <SentStakesRow {...updatedProps} />
+      </MemoryRouter>
+    );
+    const { amount } = updatedProps.data;
+    expect(
+      screen.queryByText(
+        `${convertFromBaseDenom(amount, mockAppsTokens.data[0])} ${props.token.symbol}`
+      )
+    );
   });
 
   it('should display properly when loading validators', async () => {

--- a/src/modules/transaction/hooks/useTransactionUpdate.js
+++ b/src/modules/transaction/hooks/useTransactionUpdate.js
@@ -72,7 +72,6 @@ export const useTransactionUpdate = (isLoading) => {
 
       const token = tokens?.data.length ? tokens?.data[0] : {};
       showNotificationsForIncomingTransactions(newTransactions.data, currentAccount, token);
-      client.socket.off('new.transactions');
     });
   }, [chainID, isLoading, currentAccount, tokens]);
 

--- a/src/modules/transaction/store/actions.js
+++ b/src/modules/transaction/store/actions.js
@@ -96,14 +96,17 @@ export const transactionBroadcasted =
     const serviceUrl = network.networks[activeToken].serviceUrl;
     const moduleCommand = joinModuleAndCommand(transaction);
     const paramsSchema = moduleCommandSchemas[moduleCommand];
-    let broadcastResult;
+    let broadcastErrorMessage;
 
     const [error, dryRunResult] = await to(dryRun({ transaction, serviceUrl, paramsSchema }));
 
     if (dryRunResult?.data?.result === TransactionExecutionResult.OK) {
-      broadcastResult = await broadcast({ transaction, serviceUrl, moduleCommandSchemas });
+      const [broadcastError, broadcastResult] = await to(
+        broadcast({ transaction, serviceUrl, moduleCommandSchemas })
+      );
+      broadcastErrorMessage = broadcastError?.message;
 
-      if (!broadcastResult.data?.error) {
+      if (!broadcastResult?.data?.error && !broadcastError) {
         const transactionJSON = toTransactionJSON(transaction, paramsSchema);
         dispatch({
           type: actionTypes.broadcastedTransactionSuccess,
@@ -119,6 +122,7 @@ export const transactionBroadcasted =
 
     const transactionErrorMessage =
       error?.message ||
+      broadcastErrorMessage ||
       (dryRunResult?.data?.result === TransactionExecutionResult.FAIL
         ? dryRunResult?.data?.events.map((e) => e.name).join(', ')
         : dryRunResult?.data?.errorMessage);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5074

### How was it solved?

- Listen for a users pos transactions and update stakes page for each new transaction.
- Show error status modal if broadcast fails.

### How to test?
1. Use an account with stakes and go to http://0.0.0.0:8080/#/validators/profile/stakes
2. Edit a stake successfully higher
3. Wait ~10 sec (Note: out socket works pretty bad so if nothing happens refresh page and redo the previous steps)
4. Expected: That stake amount should update and flash green briefly
