### PR TITLE
Commission should keep precision

### DIFF
--- a/src/modules/pos/validator/utils/getValidatorCommission.js
+++ b/src/modules/pos/validator/utils/getValidatorCommission.js
@@ -2,4 +2,7 @@ import { VALIDATOR_COMMISSION_DIVISOR } from '../consts/validators';
 
 export const convertCommissionToPercentage = (val = 0) =>
   Math.abs(val / VALIDATOR_COMMISSION_DIVISOR).toFixed(2);
-export const convertCommissionToNumber = (val = '0') => parseInt(val.replace('.', ''), 10);
+export const convertCommissionToNumber = (val = '0') => {
+  const floatString = parseFloat(val).toFixed(2);
+  return parseFloat(floatString.replace('.', ''))
+};

--- a/src/modules/pos/validator/utils/getValidatorCommission.js
+++ b/src/modules/pos/validator/utils/getValidatorCommission.js
@@ -2,5 +2,4 @@ import { VALIDATOR_COMMISSION_DIVISOR } from '../consts/validators';
 
 export const convertCommissionToPercentage = (val = 0) =>
   Math.abs(val / VALIDATOR_COMMISSION_DIVISOR).toFixed(2);
-export const convertCommissionToNumber = (val = 0) =>
-  Math.trunc(Math.floor(val * VALIDATOR_COMMISSION_DIVISOR));
+export const convertCommissionToNumber = (val = '0') => parseInt(val.replace('.', ''), 10);

--- a/src/modules/pos/validator/utils/getValidatorCommission.test.js
+++ b/src/modules/pos/validator/utils/getValidatorCommission.test.js
@@ -18,6 +18,10 @@ describe('convertCommissionToPercentage', () => {
     expect(convertCommissionToNumber()).not.toEqual('0');
   });
 
+  it('Should convert 16.40 to 1640', () => {
+    expect(convertCommissionToNumber('16.40')).toEqual(1640);
+  });
+
   it('Should convert any number to percentage', () => {
     expect(convertCommissionToNumber('100.00')).toEqual(10000);
     expect(convertCommissionToNumber('100.00')).not.toEqual('10000');

--- a/src/modules/pos/validator/utils/getValidatorCommission.test.js
+++ b/src/modules/pos/validator/utils/getValidatorCommission.test.js
@@ -22,6 +22,14 @@ describe('convertCommissionToPercentage', () => {
     expect(convertCommissionToNumber('16.40')).toEqual(1640);
   });
 
+  it('Should convert 12 to 1200', () => {
+    expect(convertCommissionToNumber('12')).toEqual(1200);
+  });
+
+  it('Should convert 12.1 to 1210', () => {
+    expect(convertCommissionToNumber('12.1')).toEqual(1210);
+  });
+
   it('Should convert any number to percentage', () => {
     expect(convertCommissionToNumber('100.00')).toEqual(10000);
     expect(convertCommissionToNumber('100.00')).not.toEqual('10000');


### PR DESCRIPTION
### What was the problem?

This PR resolves #5124

### How was it solved?

Use replace to get rid of the dot (.)

### How to  test?
1. Go to your validator profile
2. Change permission to `16.40` 
3. Click confirm
4. Expected: In the next step you should see the change as `16.40`

