### PR TITLE
Bugfix: Electron local server is exposed on all interfaces

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -20,7 +20,7 @@ const server = {
       err.status = 404;
       next(err);
     });
-    app.listen(port);
+    app.listen(port, '127.0.0.1');
     return `http://localhost:${port}/`;
   },
 };

--- a/app/server.js
+++ b/app/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 
 const server = {
-  init: (port) => {
+  init: (host, port) => {
     if (process.env.LISK_DESKTOP_URL) {
       return process.env.LISK_DESKTOP_URL;
     }
@@ -20,8 +20,9 @@ const server = {
       err.status = 404;
       next(err);
     });
-    app.listen(port, '127.0.0.1');
-    return `http://localhost:${port}/`;
+    app.listen(port, host);
+
+    return `http://${host}:${port}/`;
   },
 };
 

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -17,11 +17,13 @@ import { storage, setConfig, readConfig } from './modules/storage';
 
 i18nSetup();
 
-const defaultServerPort = 5659;
+const DESKTOP_HOST = process.env.LISK_DESKTOP_HOST || '127.0.0.1';
+const DESKTOP_PORT = process.env.LISK_DESKTOP_PORT || 5659;
+
 let serverUrl;
 const startServer = () =>
-  getPort({ port: defaultServerPort }).then((port) => {
-    serverUrl = server.init(port);
+  getPort({ port: DESKTOP_PORT }).then((port) => {
+    serverUrl = server.init(DESKTOP_HOST, port);
   });
 
 startServer();


### PR DESCRIPTION
### What was the problem?

This PR resolves #5114

### How was it solved?

- Updating the server config

### How was it tested?

- `yarn run dev`
- New terminal `DEBUG=true yarn run start`

Check the host and port
open a new terminal and 
- `lsof -i :5659`

You can also check the electron app network tab `127.0.0.1` headers