### PR TITLE
Bugfix: Remove unnecessary innerHTML usage

### DIFF
--- a/setup/react/assets/fonts/iconfont/icons.html
+++ b/setup/react/assets/fonts/iconfont/icons.html
@@ -498,7 +498,7 @@
       (function () {
         document.getElementById('icons').onclick = function (e) {
           e = e || window.event;
-          var name =
+          const name =
             e.target.getAttribute('data-name') || e.target.parentNode.getAttribute('data-name');
           document.getElementById('name').innerText = name;
         };

--- a/setup/react/assets/fonts/iconfont/icons.html
+++ b/setup/react/assets/fonts/iconfont/icons.html
@@ -500,7 +500,7 @@
           e = e || window.event;
           var name =
             e.target.getAttribute('data-name') || e.target.parentNode.getAttribute('data-name');
-          document.getElementById('name').innerHTML = name;
+          document.getElementById('name').innerText = name;
         };
       })();
     </script>

--- a/setup/react/index.html
+++ b/setup/react/index.html
@@ -19,15 +19,6 @@
           '<link href="' + href + '" rel="stylesheet">'
         ).join('\n') %>
         <link rel="icon" type="image/png" href="./assets/images/LISK.png" />
-        <script>
-          /* Following comment is a placeholder used by `yarn run build:testnet`, do not remove */
-          var defaultNet = "mainnet";//defaultNetwork
-          (function(targetNet) {
-            if (window.localStorage && !window.localStorage.getItem('defaultNetwork')){
-              window.localStorage.setItem('defaultNetwork', defaultNet);
-            }
-          })(defaultNet);
-        </script>
     </head>
     <body>
         <div id="app"></div>


### PR DESCRIPTION
### What was the problem?

This PR resolves #5115

### How was it solved?

- [x] Replace innerHTML with innerText

### How was it tested?

- Serve this directory `setup/react/assets/fonts/iconfont/icons.html` (you can use Live server for ease)
- Clicking on any of the icons doesn't change its behaviour after `innerHTML` is changed to  `innerText`
