### PR TITLE
Bugfix: Fix electron renderer permission checks

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -14,6 +14,7 @@ import updateChecker from './modules/autoUpdater';
 import server from '../server';
 import i18nSetup from '../../src/utils/i18n/i18n-setup';
 import { storage, setConfig, readConfig } from './modules/storage';
+import { setRendererPermissions } from './utils';
 
 i18nSetup();
 
@@ -71,6 +72,7 @@ const handleProtocol = () => {
 app.on('ready', () => {
   appIsReady = true;
   createWindow();
+  setRendererPermissions(win);
   if (process.platform === 'win32') {
     app.setAppUserModelId('io.lisk.hub');
   }

--- a/app/src/utils.js
+++ b/app/src/utils.js
@@ -1,6 +1,8 @@
 import { ipcMain } from 'electron'; // eslint-disable-line import/no-extraneous-dependencies
 import { cryptography } from '@liskhq/lisk-client'; // eslint-disable-line
 
+const PERMISSION_WHITE_LIST = ['clipboard-read', 'notifications', 'openExternal'];
+
 export const createCommand = (command, fn) => {
   ipcMain.on(`${command}.request`, (event, ...args) => {
     fn(...args)
@@ -16,3 +18,9 @@ export const isValidAddress = (address) =>
 export const getBufferToHex = (buffer) => cryptography.utils.bufferToHex(buffer);
 
 export const getTransactionBytes = (transaction) => transaction.getBytes(transaction);
+
+export const setRendererPermissions = (win) => {
+  win.browser.webContents.session.setPermissionRequestHandler((_, permission, callback) => {
+    callback(PERMISSION_WHITE_LIST.includes(permission));
+  });
+};


### PR DESCRIPTION
### What was the problem?

This PR resolves #5118

### How was it solved?

- [x] Added permission to be whitelisted (i.e allowed)

### How was it tested?

- Run `yarn dev`
- Run `yarn build:electron && yarn start`
- In the dev tool of the resulting electron browser request media permissions by executing the below snippet in the browser's console

```
navigator.getUserMedia ( {
      video: true,
      audio: true
   },
   function(localMediaStream) { console.log("Permission granted") },
   function(err) { console.log("Permission rejected") }
);
```
(Permissions should be rejected)

- Also try to read clipboard text by executing `navigator.clipboard.readText()` in the electron browser's console, permission should be granted.
