### PR TITLE
Resolve distorted pagination and navigation on banners

### DIFF
--- a/setup/config/webpack.config.react.js
+++ b/setup/config/webpack.config.react.js
@@ -143,11 +143,11 @@ const config = {
         use: [MiniCssExtractPluginLoader, reactToastifyLoader, postCssLoader],
       },
       {
-        test: /(swiper\.min|modules\/(pagination\/pagination|navigation\/navigation)\.min)\.css$/,
+        test: /(swiper\.min|modules[/|\\](pagination[/|\\]pagination|navigation[/|\\]navigation)\.min)\.css$/,
         use: [MiniCssExtractPluginLoader, reactToastifyLoader],
       },
       {
-        test: /^((?!(styles\.head|ReactToastify|(swiper\.min)|(modules\/(pagination\/pagination|navigation\/navigation)\.min))).)*\.css$/,
+        test: /^((?!(styles\.head|ReactToastify|(swiper\.min)|(modules[/|\\](pagination[/|\\]pagination|navigation[/|\\]navigation)\.min))).)*\.css$/,
         use: [MiniCssExtractPluginLoader, cssLoader, postCssLoader],
       },
     ],


### PR DESCRIPTION
### What was the problem?

This PR resolves #5228

### How was it solved?

- [x] Fix regex pattern matcher on webpack loader

### How was it tested?

- Navigate to the wallet  and/or applications page, the pagination dots and navigation buttons should be properly visible
