### PR TITLE
Fixed dark  mode issues

### DIFF
--- a/setup/react/app/app.css
+++ b/setup/react/app/app.css
@@ -37,7 +37,7 @@ body {
   transform: translateZ(0);
   backface-visibility: hidden;
 
-  & > section {
+  &>section {
     margin-top: var(--header-height);
     width: 100%;
     opacity: 0;
@@ -51,13 +51,13 @@ body {
     background-color: var(--color-body-bg);
   }
 
-  &.loaded > section {
+  &.loaded>section {
     opacity: 1;
   }
 }
 
 :global(.expanded) {
-  & + .bodyWrapper {
+  &+.bodyWrapper {
     padding-left: var(--side-bar-expanded-size);
   }
 }
@@ -104,7 +104,7 @@ body {
 }
 
 .toastText {
-  color: var(--color-strong-mystic);
+  color: var(--color-white);
   font-family: var(--content-font);
 }
 
@@ -117,7 +117,7 @@ body {
 
 @media (max-width: 1600px) {
   :global(.expanded) {
-    & + .bodyWrapper {
+    &+.bodyWrapper {
       & .mainBox {
         box-sizing: border-box;
       }
@@ -142,13 +142,13 @@ body {
     align-items: center;
     display: flex;
 
-    & > section {
+    &>section {
       padding: 0;
     }
   }
 
   :global(.expanded) {
-    & + .bodyWrapper {
+    &+.bodyWrapper {
       padding-left: var(--side-bar-shrunk-size);
     }
   }
@@ -156,7 +156,7 @@ body {
   html[data-useragent*='Windows'],
   html[data-useragent*='Linux'] {
     & :global(.expanded) {
-      & + .bodyWrapper {
+      &+.bodyWrapper {
         padding-left: calc(var(--side-bar-shrunk-size));
       }
     }

--- a/setup/react/app/app.css
+++ b/setup/react/app/app.css
@@ -37,7 +37,7 @@ body {
   transform: translateZ(0);
   backface-visibility: hidden;
 
-  &>section {
+  & > section {
     margin-top: var(--header-height);
     width: 100%;
     opacity: 0;
@@ -51,13 +51,13 @@ body {
     background-color: var(--color-body-bg);
   }
 
-  &.loaded>section {
+  &.loaded > section {
     opacity: 1;
   }
 }
 
 :global(.expanded) {
-  &+.bodyWrapper {
+  & + .bodyWrapper {
     padding-left: var(--side-bar-expanded-size);
   }
 }
@@ -117,7 +117,7 @@ body {
 
 @media (max-width: 1600px) {
   :global(.expanded) {
-    &+.bodyWrapper {
+    & + .bodyWrapper {
       & .mainBox {
         box-sizing: border-box;
       }
@@ -142,13 +142,13 @@ body {
     align-items: center;
     display: flex;
 
-    &>section {
+    & > section {
       padding: 0;
     }
   }
 
   :global(.expanded) {
-    &+.bodyWrapper {
+    & + .bodyWrapper {
       padding-left: var(--side-bar-shrunk-size);
     }
   }
@@ -156,7 +156,7 @@ body {
   html[data-useragent*='Windows'],
   html[data-useragent*='Linux'] {
     & :global(.expanded) {
-      &+.bodyWrapper {
+      & + .bodyWrapper {
         padding-left: calc(var(--side-bar-shrunk-size));
       }
     }

--- a/src/modules/common/components/bars/sideBar/index.js
+++ b/src/modules/common/components/bars/sideBar/index.js
@@ -24,7 +24,9 @@ const Inner = ({ data, pathname, hasNotification, sideBarExpanded }) => {
     <span className={styles.holder}>
       <span className={styles.iconWrapper}>
         <Icon name={`${data.icon}${status}`} className={styles.icon} />
-        {!sideBarExpanded && <Badge className={`${className} ${styles.collapsedNotification}`} />}
+        {!sideBarExpanded && !!hasNotification && (
+          <Badge className={`${className} ${styles.collapsedNotification}`} />
+        )}
       </span>
       {sideBarExpanded && <span className={styles.label}>{data.label}</span>}
       {sideBarExpanded && !!hasNotification && <Badge className={className} />}

--- a/src/modules/common/components/bars/sideBar/index.js
+++ b/src/modules/common/components/bars/sideBar/index.js
@@ -18,18 +18,17 @@ const Inner = ({ data, pathname, hasNotification, sideBarExpanded }) => {
   if (pathname && pathname === data.path) {
     status = 'Active';
   }
-  const className = hasNotification ? styles.badge : '';
 
   return (
     <span className={styles.holder}>
       <span className={styles.iconWrapper}>
         <Icon name={`${data.icon}${status}`} className={styles.icon} />
         {!sideBarExpanded && !!hasNotification && (
-          <Badge className={`${className} ${styles.collapsedNotification}`} />
+          <Badge className={`${styles.badge} ${styles.collapsedNotification}`} />
         )}
       </span>
       {sideBarExpanded && <span className={styles.label}>{data.label}</span>}
-      {sideBarExpanded && !!hasNotification && <Badge className={className} />}
+      {sideBarExpanded && !!hasNotification && <Badge className={styles.badge} />}
     </span>
   );
 };

--- a/src/modules/common/components/bars/sideBar/index.test.js
+++ b/src/modules/common/components/bars/sideBar/index.test.js
@@ -1,10 +1,12 @@
+import React from 'react';
 import { useSelector } from 'react-redux';
 import routes from 'src/routes/routes';
 import { useCurrentAccount } from '@account/hooks';
 import mockSavedAccounts from '@tests/fixtures/accounts';
 import { useRewardsClaimable } from '@pos/reward/hooks/queries';
 import { mockRewardsClaimable } from '@pos/reward/__fixtures__';
-import { mountWithRouter } from 'src/utils/testHelpers';
+import { ApplicationBootstrapContext } from '@setup/react/app/ApplicationBootstrap';
+import { mountWithRouter, mountWithRouterAndStore } from 'src/utils/testHelpers';
 import SideBar from './index';
 
 const mockCurrentAccount = mockSavedAccounts[0];
@@ -110,5 +112,47 @@ describe('SideBar', () => {
     expect(wrapper.find('a').at(4)).toHaveClassName('disabled');
     expect(wrapper.find('a').at(5)).toHaveClassName('disabled');
     expect(wrapper.find('a').at(6)).toHaveClassName('disabled');
+  });
+
+  it('should render notification when there is a reward and the side bar is shrunk', () => {
+    const Component = (props) => (
+      <ApplicationBootstrapContext.Provider
+        value={{ appEvents: { transactions: { rewards: [{ reward: 10000 }] } } }}
+      >
+        <SideBar {...props} />
+      </ApplicationBootstrapContext.Provider>
+    );
+
+    wrapper = mountWithRouterAndStore(
+      Component,
+      {
+        ...myProps,
+        isUserLogout: false,
+        location: { pathname: routes.reclaim.path },
+      },
+      { settings: { sideBarExpanded: false } }
+    );
+    expect(wrapper.find('Badge.badge')).toExist();
+  });
+  
+  it('should render notification when there is a reward and the side bar is collapsed', () => {
+    const Component = (props) => (
+      <ApplicationBootstrapContext.Provider
+        value={{ appEvents: { transactions: { rewards: [{ reward: 10000 }] } } }}
+      >
+        <SideBar {...props} />
+      </ApplicationBootstrapContext.Provider>
+    );
+
+    wrapper = mountWithRouterAndStore(
+      Component,
+      {
+        ...myProps,
+        isUserLogout: false,
+        location: { pathname: routes.reclaim.path },
+      },
+      { settings: { sideBarExpanded: true } }
+    );
+    expect(wrapper.find('Badge.badge')).toExist();
   });
 });

--- a/src/modules/common/components/bars/sideBar/sideBar.css
+++ b/src/modules/common/components/bars/sideBar/sideBar.css
@@ -144,5 +144,6 @@
 
 .collapsedNotification {
   position: absolute;
-  right: -4px;
+  right: -11px;
+  top: 23px;
 }

--- a/src/modules/wallet/components/AccountDetails/index.js
+++ b/src/modules/wallet/components/AccountDetails/index.js
@@ -301,7 +301,7 @@ const AccountDetails = () => {
                 <div className={styles.row}>
                   <div className={styles.detailsWrapper}>
                     <span className={styles.title}>{t('Rank')}: </span>
-                    <span>#{validatorData?.data[0].rank}</span>
+                    <span>#{validatorData?.data[0]?.rank}</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### What was the problem?

This PR resolves #5372

### How was it solved?

- [x] Fix dark mode style on toast
- [x] Fix crash on account details
- [x] Fix badge notification on shrunk sidebar

### How was it tested?

**Test Fix badge notification on shrunk sidebar**
- Shrink the side bar the malfunction on the badge should be gone.
- On an account with rewards notification badge should be properly seen

**Test fix dark mode style on toast**
- Toggle a setting parameter, on dark mode the toast shown should be properly shown

**Test fix crash on account details**
- Register a validator, navigate to the account details page, there should be no crash.
