### PR TITLE
Dont pass transaction in URL in multi signature continuous flow

### DIFF
--- a/src/modules/account/hooks/useCurrentAccount.js
+++ b/src/modules/account/hooks/useCurrentAccount.js
@@ -22,6 +22,8 @@ export function useCurrentAccount() {
   // eslint-disable-next-line max-statements
   const setAccount = (encryptedAccount, referrer, redirect = true, urlState) => {
     // clear stakes list during login or accounts switch
+    const relativeUrlPath = referrer || routes.wallet.path;
+
     if (pendingStakes.length) {
       const onCancel = /* istanbul ignore next */ () =>
         removeSearchParamsFromUrl(history, ['modal']);
@@ -29,7 +31,7 @@ export function useCurrentAccount() {
         dispatch(setCurrentAccount(encryptedAccount));
 
         dispatch(stakesReset());
-        history.push(referrer || routes.wallet.path);
+        history.push(relativeUrlPath);
       };
       const state = createConfirmSwitchState({
         mode: 'pendingStakes',
@@ -42,7 +44,6 @@ export function useCurrentAccount() {
       dispatch(setCurrentAccount(encryptedAccount));
       if (redirect) {
         if (urlState) {
-          const relativeUrlPath = referrer || routes.wallet.path;
           const { pathname, search } = new URL(relativeUrlPath, window.location.origin);
           history.push({
             pathname,
@@ -50,7 +51,7 @@ export function useCurrentAccount() {
             state: urlState,
           });
         } else {
-          history.push(referrer || routes.wallet.path);
+          history.push(relativeUrlPath);
         }
       }
     }

--- a/src/modules/account/hooks/useCurrentAccount.js
+++ b/src/modules/account/hooks/useCurrentAccount.js
@@ -19,7 +19,8 @@ export function useCurrentAccount() {
     (stake) => stake.confirmed !== stake.unconfirmed
   );
 
-  const setAccount = (encryptedAccount, referrer, redirect = true) => {
+  // eslint-disable-next-line max-statements
+  const setAccount = (encryptedAccount, referrer, redirect = true, urlState) => {
     // clear stakes list during login or accounts switch
     if (pendingStakes.length) {
       const onCancel = /* istanbul ignore next */ () =>
@@ -40,7 +41,17 @@ export function useCurrentAccount() {
     } else {
       dispatch(setCurrentAccount(encryptedAccount));
       if (redirect) {
-        history.push(referrer || routes.wallet.path);
+        if (urlState) {
+          const relativeUrlPath = referrer || routes.wallet.path;
+          const { pathname, search } = new URL(relativeUrlPath, window.location.origin);
+          history.push({
+            pathname,
+            search,
+            state: urlState,
+          });
+        } else {
+          history.push(referrer || routes.wallet.path);
+        }
       }
     }
   };

--- a/src/modules/transaction/components/Multisignature/Multisignature.js
+++ b/src/modules/transaction/components/Multisignature/Multisignature.js
@@ -17,6 +17,7 @@ import WarningNotification from '@common/components/warningNotification';
 import AccountRow from '@account/components/AccountRow';
 import classNames from 'classnames';
 import { getNextAccountToSign } from '@transaction/utils/multisignatureUtils';
+import generateUniqueId from 'src/utils/generateUniqueId';
 import getIllustration from '../TxBroadcaster/illustrationsMap';
 import styles from './Multisignature.css';
 import useTxInitiatorAccount from '../../hooks/useTxInitiatorAccount';
@@ -28,15 +29,18 @@ export const PartiallySignedActions = ({
   transactionJSON,
   reset,
 }) => {
-  const [, setCurrentAccount] = useCurrentAccount();
+  const [currentAccount, setCurrentAccount] = useCurrentAccount();
 
   const handleSwitchAccount = () => {
     const stringifiedTransaction = encodeURIComponent(JSON.stringify(transactionJSON));
+    const uniqueUrlIdToPreventHashError = generateUniqueId();
     setCurrentAccount(
       nextAccountToSign,
-      `/wallet?modal=signMultiSignTransaction&stringifiedTransaction=${stringifiedTransaction}`,
+      `/wallet?modal=signMultiSignTransaction&prevAccount=${currentAccount.metadata.address}&uniqueId=${uniqueUrlIdToPreventHashError}`,
       true,
-      { stringifiedTransaction }
+      {
+        stringifiedTransaction,
+      }
     );
     reset?.();
   };

--- a/src/modules/transaction/configuration/statusConfig.js
+++ b/src/modules/transaction/configuration/statusConfig.js
@@ -157,7 +157,7 @@ export const getTransactionStatus = (account, transactions, options = {}) => {
 
     const hasRemainingMandatorySignatures = getHasRemainingMandatorySignatures(
       transactions.signedTransaction,
-      account.keys
+      account?.keys
     );
 
     let nonEmptySignatures = transactions.signedTransaction.signatures.filter(

--- a/src/modules/wallet/components/signMultisigView/index.js
+++ b/src/modules/wallet/components/signMultisigView/index.js
@@ -16,8 +16,7 @@ import Status from '../signMultisigStatus';
 const SignMultisigView = ({ history }) => {
   const [currentStep, setCurrentStep] = useState();
   const location = useLocation();
-  const queryParams = new URLSearchParams(location.search);
-  const stringifiedTransaction = queryParams.get('stringifiedTransaction');
+  const stringifiedTransaction = location.state?.stringifiedTransaction;
 
   const onMultiStepChange = useCallback(({ step: { current } }) => {
     setCurrentStep(current);


### PR DESCRIPTION
### What was the problem?

This PR resolves #5374 #5388

### How was it solved?

- Moving transaction string to url state since its max size is 640k characters compared to url params max size of 2k characters.
- Since URL is no longer unique between certain switches i also had to add a `generateUniqueId` in the url.
- Check for required remaining members to determine if a transaction is complete

### How was it tested?
Because of issue #5388 we unfortunately need to test all edge cases again to prevent regression in another state.
So please test the cases from [this PR](https://github.com/LiskHQ/lisk-desktop/pull/5366)
As well as the issue raised in this issue  #5388
