### PR TITLE
Remove chrome warning closeToast on html node

### DIFF
--- a/src/modules/common/components/notification/rewardsNotification/index.js
+++ b/src/modules/common/components/notification/rewardsNotification/index.js
@@ -5,6 +5,8 @@ import { ApplicationBootstrapContext } from '@setup/react/app/ApplicationBootstr
 import DialogLink from '@theme/dialog/link';
 import styles from './styles.css';
 
+const CloseButton = () => <span className={`${styles.closeBtn} dialog-close-button`} />;
+
 const RewardsNotification = () => {
   const { t } = useTranslation();
   const {
@@ -26,7 +28,7 @@ const RewardsNotification = () => {
         {
           autoClose: false,
           draggable: false,
-          closeButton: <span className={`${styles.closeBtn} dialog-close-button`} />,
+          closeButton: <CloseButton />,
           toastId: 'claimRewards',
         }
       );


### PR DESCRIPTION
### What was the problem?

react-toastify requires a react dom node as a CloseButton. This will remove the chrome warning.

