### PR TITLE
Fix nonce undefined in certain state

### DIFF
--- a/src/modules/account/hooks/useAccounts.js
+++ b/src/modules/account/hooks/useAccounts.js
@@ -23,18 +23,18 @@ export function useAccounts() {
   const getAccountByPublicKey = (pubkey) =>
     accounts.find((account) => account.metadata.pubkey === pubkey);
 
-  const setNonceByAccount = (address, nonce, transactionHex) =>
-    dispatch(setAccountNonce(address, nonce, transactionHex));
+  const setNonceByAccount = (address, nonce, transactionHex, networkChainIDKey) =>
+    dispatch(setAccountNonce(address, nonce, transactionHex, networkChainIDKey));
 
-  const getNonceByAccount = (address) => {
-    const accountNonceMap = nonceMap[address] ?? {};
+  const getNonceByAccount = (address, networkChainIDKey) => {
+    const accountNonceMap = nonceMap[address]?.[networkChainIDKey] ?? {};
     const accountNonceValues = Object.values(accountNonceMap);
     const nonceList = accountNonceValues.length ? accountNonceValues : [0];
     return Math.max(...nonceList);
   };
 
-  const resetNonceByAccount = (address, onChainNonce) =>
-    dispatch(resetAccountNonce(address, onChainNonce));
+  const resetNonceByAccount = (address, onChainNonce, networkChainIDKey) =>
+    dispatch(resetAccountNonce(address, onChainNonce, networkChainIDKey));
 
   return {
     accounts,

--- a/src/modules/account/hooks/useAccounts.test.js
+++ b/src/modules/account/hooks/useAccounts.test.js
@@ -1,10 +1,14 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import mockSavedAccounts from '@tests/fixtures/accounts';
 import actionTypes from '@account/store/actionTypes';
+import mockApplications from '@tests/fixtures/blockchainApplicationsManage';
 import { useAccounts } from './useAccounts';
 
 const txHex = 'a24f94966cf213deb90854c41cf1f27906135b7001a49e53a9722ebf5fc67481';
 const accountNonce = 2;
+const { chainID, chainName } = mockApplications[0];
+const networkChainIDKey = `${chainName}:${chainID}`;
+
 const mockDispatch = jest.fn();
 const accountStateObject = { [mockSavedAccounts[0].metadata.address]: mockSavedAccounts[0] };
 const mockState = {
@@ -12,7 +16,9 @@ const mockState = {
     list: accountStateObject,
     localNonce: {
       [mockSavedAccounts[0].metadata.address]: {
-        [txHex]: accountNonce,
+        [networkChainIDKey]: {
+          [txHex]: accountNonce,
+        },
       },
     },
   },
@@ -85,9 +91,10 @@ describe('useAccount hook', () => {
       address: mockSavedAccounts[0].metadata.address,
       nonce: 2,
       transactionHex: txHex,
+      networkChainIDKey,
     };
     act(() => {
-      setNonceByAccount(mockSavedAccounts[0].metadata.address, 2, txHex);
+      setNonceByAccount(mockSavedAccounts[0].metadata.address, 2, txHex, networkChainIDKey);
     });
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockDispatch).toHaveBeenCalledWith(expectedAction);
@@ -95,13 +102,13 @@ describe('useAccount hook', () => {
 
   it('getNonceByAccount should retrieve stored nonce', async () => {
     const { getNonceByAccount } = result.current;
-    const storedNonce = getNonceByAccount(mockSavedAccounts[0].metadata.address);
+    const storedNonce = getNonceByAccount(mockSavedAccounts[0].metadata.address, networkChainIDKey);
     expect(storedNonce).toEqual(accountNonce);
   });
 
   it('getNonceByAccount should retrieve 0 if no stored nonce', async () => {
     const { getNonceByAccount } = result.current;
-    const storedNonce = getNonceByAccount(mockSavedAccounts[1].metadata.address);
+    const storedNonce = getNonceByAccount(mockSavedAccounts[1].metadata.address, networkChainIDKey);
     expect(storedNonce).toEqual(0);
   });
 });

--- a/src/modules/account/store/action.js
+++ b/src/modules/account/store/action.js
@@ -21,17 +21,19 @@ export const addAccount = (encryptedAccount) => ({
   encryptedAccount,
 });
 
-export const setAccountNonce = (address, nonce, transactionHex) => ({
+export const setAccountNonce = (address, nonce, transactionHex, networkChainIDKey) => ({
   type: actionTypes.setAccountNonce,
   address,
   nonce,
   transactionHex,
+  networkChainIDKey,
 });
 
-export const resetAccountNonce = (address, onChainNonce) => ({
+export const resetAccountNonce = (address, onChainNonce, networkChainIDKey) => ({
   type: actionTypes.resetAccountNonce,
   address,
   nonce: onChainNonce,
+  networkChainIDKey,
 });
 
 export const updateAccount = ({ encryptedAccount, accountDetail }) => ({

--- a/src/modules/account/store/reducer.js
+++ b/src/modules/account/store/reducer.js
@@ -58,26 +58,35 @@ export const list = (state = {}, { type, encryptedAccount, accountDetail, addres
   }
 };
 
-export const localNonce = (state = {}, { type, address, nonce, transactionHex }) => {
+export const localNonce = (
+  state = {},
+  { type, address, nonce, transactionHex, networkChainIDKey }
+) => {
   switch (type) {
-    case actionTypes.setAccountNonce:
-      if (state[address]?.[transactionHex]) {
+    case actionTypes.setAccountNonce: {
+      const pendingTransactions = state[address]?.[networkChainIDKey];
+      if (pendingTransactions?.[transactionHex]) {
         return state;
       }
+
       return {
         ...state,
         [address]: {
-          ...state[address],
-          [transactionHex]: nonce,
+          [networkChainIDKey]: {
+            ...pendingTransactions,
+            [transactionHex]: nonce,
+          },
         },
       };
-
-    case actionTypes.resetAccountNonce:
+    }
+    case actionTypes.resetAccountNonce: {
       return {
         ...state,
-        [address]: { defaultNonce: nonce },
+        [address]: {
+          [networkChainIDKey]: { defaultNonce: nonce },
+        },
       };
-
+    }
     default:
       return state;
   }

--- a/src/modules/account/store/reducer.test.js
+++ b/src/modules/account/store/reducer.test.js
@@ -1,6 +1,10 @@
 import mockSavedAccounts from '@tests/fixtures/accounts';
+import mockApplications from '@tests/fixtures/blockchainApplicationsManage';
 import actionTypes from './actionTypes';
 import { list, current, localNonce } from './reducer';
+
+const { chainID, chainName } = mockApplications[0];
+const networkChainIDKey = `${chainName}:${chainID}`;
 
 describe('Auth reducer', () => {
   it('Should return encryptedAccount if setCurrentAccount action type is triggered', async () => {
@@ -90,10 +94,13 @@ describe('Auth reducer', () => {
       address: mockSavedAccounts[1].metadata.address,
       nonce: 1,
       transactionHex: txHex,
+      networkChainIDKey,
     };
     const expectedState = {
       [mockSavedAccounts[1].metadata.address]: {
-        [txHex]: 1,
+        [networkChainIDKey]: {
+          [txHex]: 1,
+        },
       },
     };
     expect(localNonce({}, actionData)).toEqual(expectedState);
@@ -106,15 +113,21 @@ describe('Auth reducer', () => {
       address: mockSavedAccounts[1].metadata.address,
       nonce: 1,
       transactionHex: txHex,
+      networkChainIDKey,
     };
     const expectedState = {
       [mockSavedAccounts[1].metadata.address]: {
-        [txHex]: 1,
+        [networkChainIDKey]: {
+          [txHex]: 1,
+        },
       },
     };
+
     const existingState = {
       [mockSavedAccounts[1].metadata.address]: {
-        [txHex]: 1,
+        [networkChainIDKey]: {
+          [txHex]: 1,
+        },
       },
     };
     expect(localNonce(existingState, actionData)).toEqual(expectedState);

--- a/src/modules/auth/hooks/useNonceSync.js
+++ b/src/modules/auth/hooks/useNonceSync.js
@@ -1,13 +1,15 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAccounts, useCurrentAccount } from '@account/hooks';
+import { useCurrentApplication } from '@blockchainApplication/manage/hooks';
 import { useAuth } from './queries';
 
 // eslint-disable-next-line max-statements
 const useNonceSync = () => {
   const { setNonceByAccount, getNonceByAccount, resetNonceByAccount } = useAccounts();
+  const [{ chainID, chainName }] = useCurrentApplication();
+  const networkChainIDKey = `${chainName}:${chainID}`;
   const [currentAccount] = useCurrentAccount();
   const currentAccountAddress = currentAccount.metadata.address;
-  const currentAccountNonce = getNonceByAccount(currentAccountAddress);
 
   const { data: authData } = useAuth({
     config: { params: { address: currentAccountAddress } },
@@ -20,34 +22,36 @@ const useNonceSync = () => {
 
   // Store nonce by address in accounts store
   const handleLocalNonce = (currentNonce) => {
+    const currentAccountNonce = getNonceByAccount(currentAccountAddress, networkChainIDKey);
     const storedNonce = BigInt(currentAccountNonce || 0);
     const localNonce = storedNonce < currentNonce ? currentNonce : storedNonce;
     const localNonceStr = localNonce.toString();
-    setNonceByAccount(currentAccountAddress, localNonceStr, 'defaultNonce');
+    setNonceByAccount(currentAccountAddress, localNonceStr, 'defaultNonce', networkChainIDKey);
 
     setAccountNonce(localNonceStr);
   };
 
   useEffect(() => {
     if (isMultiSig) {
-      handleLocalNonce(onChainNonce);
+      handleLocalNonce(onChainNonce, networkChainIDKey);
     }
-  }, [onChainNonce, isMultiSig]);
+  }, [onChainNonce, isMultiSig, networkChainIDKey]);
 
   // Increment nonce after transaction signing
   const incrementNonce = useCallback(
     (transactionHex) => {
       if (isMultiSig) {
+        const currentAccountNonce = getNonceByAccount(currentAccountAddress, networkChainIDKey);
         const localNonce = BigInt(Math.max(currentAccountNonce, Number(accountNonce))) + BigInt(1);
-        setNonceByAccount(currentAccountAddress, localNonce.toString(), transactionHex);
+        setNonceByAccount(currentAccountAddress, localNonce.toString(), transactionHex, networkChainIDKey);
       }
     },
-    [isMultiSig]
+    [isMultiSig, networkChainIDKey]
   );
 
   const resetNonce = () => {
     if (isMultiSig) {
-      resetNonceByAccount(currentAccountAddress, authNonce);
+      resetNonceByAccount(currentAccountAddress, authNonce, networkChainIDKey);
     }
   };
 

--- a/src/modules/auth/hooks/useNonceSync.js
+++ b/src/modules/auth/hooks/useNonceSync.js
@@ -33,7 +33,7 @@ const useNonceSync = () => {
 
   useEffect(() => {
     if (isMultiSig) {
-      handleLocalNonce(onChainNonce, networkChainIDKey);
+      handleLocalNonce(onChainNonce);
     }
   }, [onChainNonce, isMultiSig, networkChainIDKey]);
 

--- a/src/modules/auth/hooks/useNonceSync.test.js
+++ b/src/modules/auth/hooks/useNonceSync.test.js
@@ -1,14 +1,13 @@
 import { renderHook } from '@testing-library/react-hooks';
-import * as ReactQuery from '@tanstack/react-query';
 import { queryWrapper as wrapper } from 'src/utils/test/queryWrapper';
 import mockSavedAccounts from '@tests/fixtures/accounts';
+import { useAuth } from '@auth/hooks/queries';
 import { useAccounts } from 'src/modules/account/hooks';
-import { mockAuth } from '@auth/__fixtures__';
+import { mockAuthMultiSig } from '@auth/__fixtures__';
 import useNonceSync from './useNonceSync';
 
 const mockedCurrentAccount = mockSavedAccounts[0];
 const mockSetNonceByAccount = jest.fn();
-const mockModifiedMockAuth = { ...mockAuth, data: { ...mockAuth.data, nonce: '2' } };
 
 jest.mock('@account/hooks/useCurrentAccount', () => ({
   useCurrentAccount: jest.fn(() => [mockedCurrentAccount, jest.fn()]),
@@ -18,9 +17,8 @@ jest.mock('@auth/hooks/queries/useAuth');
 
 describe('useNonceSync', () => {
   it('renders properly', async () => {
-    jest
-      .spyOn(ReactQuery, 'useQueryClient')
-      .mockReturnValue({ getQueryData: () => mockModifiedMockAuth });
+    const mockModifiedMockAuth = { data: { ...mockAuthMultiSig.data, nonce: '3' } };
+    useAuth.mockReturnValue({ data: mockModifiedMockAuth });
     useAccounts.mockReturnValue({
       accounts: mockedCurrentAccount,
       setNonceByAccount: mockSetNonceByAccount,
@@ -33,7 +31,8 @@ describe('useNonceSync', () => {
   });
 
   it('renders properly if auth nonce is undefined and no local nonce has been previously stored', () => {
-    jest.spyOn(ReactQuery, 'useQueryClient').mockReturnValue({ getQueryData: () => {} });
+    useAuth.mockReturnValue({});
+
     useAccounts.mockReturnValue({
       accounts: mockedCurrentAccount,
       setNonceByAccount: mockSetNonceByAccount,
@@ -44,9 +43,8 @@ describe('useNonceSync', () => {
   });
 
   it("updates local nonce if it's less than on-chain nonce", () => {
-    jest
-      .spyOn(ReactQuery, 'useQueryClient')
-      .mockReturnValue({ getQueryData: () => mockModifiedMockAuth });
+    const mockModifiedMockAuth = { data: { ...mockAuthMultiSig.data, nonce: '2' } };
+    useAuth.mockReturnValue({ data: mockModifiedMockAuth });
     useAccounts.mockReturnValue({
       accounts: mockedCurrentAccount,
       setNonceByAccount: mockSetNonceByAccount,

--- a/src/modules/auth/hooks/useNonceSync.test.js
+++ b/src/modules/auth/hooks/useNonceSync.test.js
@@ -8,6 +8,7 @@ import useNonceSync from './useNonceSync';
 
 const mockedCurrentAccount = mockSavedAccounts[0];
 const mockSetNonceByAccount = jest.fn();
+const mockResetNonceByAccount = jest.fn();
 
 jest.mock('@account/hooks/useCurrentAccount', () => ({
   useCurrentAccount: jest.fn(() => [mockedCurrentAccount, jest.fn()]),
@@ -56,6 +57,20 @@ describe('useNonceSync', () => {
     });
     const { result } = renderHook(() => useNonceSync(), { wrapper });
     expect(result.current.accountNonce).toEqual('2');
+  });
+
+  it("updates local nonce if it's less than on-chain nonce", () => {
+    const mockModifiedMockAuth = { data: { ...mockAuthMultiSig.data, nonce: '2' } };
+    useAuth.mockReturnValue({ data: mockModifiedMockAuth });
+    useAccounts.mockReturnValue({
+      accounts: mockedCurrentAccount,
+      setNonceByAccount: mockSetNonceByAccount,
+      resetNonceByAccount: mockResetNonceByAccount,
+      getNonceByAccount: jest.fn().mockReturnValue(3),
+    });
+    const { result } = renderHook(() => useNonceSync(), { wrapper });
+    result.current.resetNonce();
+    expect(mockResetNonceByAccount).toHaveBeenCalled();
   });
 
   it("updates local nonce if it's less than on-chain nonce", () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves https://github.com/LiskHQ/lisk-desktop/issues/5411, https://github.com/LiskHQ/lisk-desktop/issues/5412

### How was it solved?

Use our regular auth hook to make sure we send correct nonce. Code is also much less and easier to follow. I think a possible extra network call is worth it to always guarantee that we send with a correct nonce.

### How was it tested?

#### Prerequisite
If you have tested this feature before. Clean your redux first (since structure was wrong before)
1. Go to `src/modules/account/store/reducer.js`
2. Remove `localNonce` from whitelist
3. Go back to running application and make a page refresh. 
4. Add `localNonce` back to whitelist

#### How to test
1. Create a new multi sig account
5. Try sending from that account right after successfully creating it
6. Expected: Should work without reseting the nonce
