### PR TITLE
Bug fix transaction details, staking and transaction filtering

### DIFF
--- a/src/modules/account/hooks/useCurrentAccount.js
+++ b/src/modules/account/hooks/useCurrentAccount.js
@@ -24,32 +24,42 @@ export function useCurrentAccount() {
     // clear stakes list during login or accounts switch
     const relativeUrlPath = referrer || routes.wallet.path;
 
-    if (pendingStakes.length) {
-      const onCancel = /* istanbul ignore next */ () =>
-        removeSearchParamsFromUrl(history, ['modal']);
-      const onConfirm = /* istanbul ignore next */ () => {
-        dispatch(setCurrentAccount(encryptedAccount));
-
-        dispatch(stakesReset());
-        history.push(relativeUrlPath);
-      };
-      const state = createConfirmSwitchState({
-        mode: 'pendingStakes',
-        type: 'account',
-        onCancel,
-        onConfirm,
+    function pushUrlState() {
+      const { pathname, search } = new URL(relativeUrlPath, window.location.origin);
+      history.push({
+        pathname,
+        search,
+        state: urlState,
       });
-      removeThenAppendSearchParamsToUrl(history, { modal: 'confirmationDialog' }, ['modal'], state);
+    }
+
+    if (pendingStakes.length) {
+      if (urlState) {
+        dispatch(setCurrentAccount(encryptedAccount));
+        dispatch(stakesReset());
+        pushUrlState();
+      }else {
+        const onCancel = /* istanbul ignore next */ () =>
+          removeSearchParamsFromUrl(history, ['modal']);
+        const onConfirm = /* istanbul ignore next */ () => {
+          dispatch(setCurrentAccount(encryptedAccount));
+
+          dispatch(stakesReset());
+          history.push(relativeUrlPath);
+        };
+        const state = createConfirmSwitchState({
+          mode: 'pendingStakes',
+          type: 'account',
+          onCancel,
+          onConfirm,
+        });
+        removeThenAppendSearchParamsToUrl(history, { modal: 'confirmationDialog' }, ['modal'], state);
+      }
     } else {
       dispatch(setCurrentAccount(encryptedAccount));
       if (redirect) {
         if (urlState) {
-          const { pathname, search } = new URL(relativeUrlPath, window.location.origin);
-          history.push({
-            pathname,
-            search,
-            state: urlState,
-          });
+          pushUrlState();
         } else {
           history.push(relativeUrlPath);
         }

--- a/src/modules/blockchainApplication/explore/components/BlockchainApplicationDetails/BlockchainApplicationDetails.js
+++ b/src/modules/blockchainApplication/explore/components/BlockchainApplicationDetails/BlockchainApplicationDetails.js
@@ -50,7 +50,7 @@ const BlockchainApplicationDetails = ({ history, location }) => {
     lastCertificateHeight,
     lastUpdated,
     logo,
-    depositedLsk = 0,
+    escrowedLSK = '0',
   } = aggregatedApplicationData;
   const { setApplication } = useApplicationManagement();
 
@@ -145,7 +145,7 @@ const BlockchainApplicationDetails = ({ history, location }) => {
           ) : (
             <ValueAndLabel label={t('Deposited:')} direction="horizontal">
               <span className={styles.value}>
-                <TokenAmount val={depositedLsk} isLsk />
+                <TokenAmount val={escrowedLSK} isLsk />
               </span>
             </ValueAndLabel>
           )}

--- a/src/modules/blockchainApplication/explore/components/BlockchainApplicationRow/BlockchainApplicationRow.js
+++ b/src/modules/blockchainApplication/explore/components/BlockchainApplicationRow/BlockchainApplicationRow.js
@@ -68,7 +68,7 @@ const BlockchainApplicationRow = ({ data, className, t }) => {
         <ChainName title={application.chainName} logo={getLogo(application)} />
         <ChainId id={application.chainID} />
         <ChainStatus status={application.status} t={t} />
-        <DepositAmount amount={application.depositedLsk} />
+        <DepositAmount amount={application.escrowedLSK} />
       </DialogLink>
     </div>
   );

--- a/src/modules/blockchainApplication/manage/components/AddApplicationRow/AddApplicationRow.js
+++ b/src/modules/blockchainApplication/manage/components/AddApplicationRow/AddApplicationRow.js
@@ -26,7 +26,7 @@ const AddApplicationRow = ({ data, className }) => (
       data={{ chainId: data.chainID, mode: 'addApplication' }}
     >
       <ChainName title={data.chainName} logo={getLogo(data)} />
-      <DepositAmount amount={data.depositedLsk} />
+      <DepositAmount amount={data.escrowedLSK} />
     </DialogLink>
   </div>
 );

--- a/src/modules/blockchainApplication/manage/components/AddApplicationRow/AddApplicationRow.test.js
+++ b/src/modules/blockchainApplication/manage/components/AddApplicationRow/AddApplicationRow.test.js
@@ -5,7 +5,7 @@ import AddApplicationRow from './AddApplicationRow';
 const props = {
   data: {
     chainName: 'Sample app',
-    depositedLsk: 50000000,
+    escrowedLSK: 50000000,
   },
 };
 

--- a/src/modules/blockchainApplication/manage/components/RemoveApplicationDetails/RemoveApplicationDetails.js
+++ b/src/modules/blockchainApplication/manage/components/RemoveApplicationDetails/RemoveApplicationDetails.js
@@ -51,7 +51,7 @@ const RemoveApplicationDetails = ({ location, onCancel, nextStep, history }) => 
     lastCertificateHeight,
     lastUpdated,
     projectPage,
-    depositedLsk = 0,
+    escrowedLSK = "0",
   } = application;
 
   const reloadAppDetails = () => {
@@ -182,7 +182,7 @@ const RemoveApplicationDetails = ({ location, onCancel, nextStep, history }) => 
             <div className={styles.balanceRow}>
               <span>{t('Deposited:')}</span>
               <span>
-                <TokenAmount isLsk val={depositedLsk} />
+                <TokenAmount isLsk val={escrowedLSK} />
               </span>
             </div>
           )}

--- a/src/modules/common/components/filterDropdownButton/selectFilter.js
+++ b/src/modules/common/components/filterDropdownButton/selectFilter.js
@@ -19,10 +19,12 @@ const SelectFilter = ({
 
   if (isLoading) return null;
 
-  const options = Object.keys(moduleCommandSchemas).map((key) => ({
-    value: key,
-    label: getModuleCommandTitle()[key],
-  }));
+  const options = Object.keys(moduleCommandSchemas)
+    .map((key) => ({
+      value: key,
+      label: getModuleCommandTitle()[key],
+    }))
+    .filter((option) => option.label);
 
   options.unshift({ value: '', label: placeholder });
 

--- a/src/modules/transaction/components/TransactionDetailsView/index.js
+++ b/src/modules/transaction/components/TransactionDetailsView/index.js
@@ -1,10 +1,10 @@
 /* eslint-disable max-statements */
-import React, { useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useHistory } from 'react-router-dom';
 import ReactJson from 'react-json-view';
 import { useTranslation } from 'react-i18next';
 import { isEmpty } from 'src/utils/helpers';
-import { parseSearchParams } from 'src/utils/searchParams';
+import { parseSearchParams, removeSearchParamsFromUrl } from 'src/utils/searchParams';
 import Box from 'src/theme/box';
 import BoxContent from 'src/theme/box/content';
 import Heading from 'src/modules/common/components/Heading';
@@ -20,10 +20,12 @@ import TransactionEvents from '../TransactionEvents';
 import { useFees, useTransactions } from '../../hooks/queries';
 import TransactionDetailRow from '../TransactionDetailRow';
 import header from './headerMap';
-import { splitModuleAndCommand } from '../../utils';
+import { getTransactionValue, splitModuleAndCommand } from '../../utils';
 
 const TransactionDetails = () => {
   const { search } = useLocation();
+  const history = useHistory();
+  const paramsJsonViewRef = useRef();
   const transactionID = parseSearchParams(search).transactionID;
   const showParams = JSON.parse(parseSearchParams(search).showParams || 'false');
   const { t } = useTranslation();
@@ -83,6 +85,10 @@ const TransactionDetails = () => {
         value: <TokenAmount val={fee} token={feeToken} />,
       },
       {
+        label: t('Value'),
+        value: getTransactionValue(transactionData, token),
+      },
+      {
         label: t('Date'),
         value: <DateTimeFromTimestamp fulltime time={block.timestamp} />,
       },
@@ -126,6 +132,12 @@ const TransactionDetails = () => {
     return <NotFound t={t} />;
   }
 
+  useEffect(() => {
+    if (showParams && paramsJsonViewRef.current) paramsJsonViewRef.current.scrollIntoView();
+
+    setIsParamsCollapsed(showParams);
+  }, [showParams]);
+
   return (
     <div className={styles.wrapper}>
       <Heading title={t('Transaction')} />
@@ -143,11 +155,17 @@ const TransactionDetails = () => {
               headerClassName={styles.tableHeader}
               additionalRowProps={{
                 isParamsCollapsed,
-                onToggleJsonView: () => setIsParamsCollapsed((state) => !state),
+                onToggleJsonView: () => {
+                  setIsParamsCollapsed((state) => {
+                    if (state) removeSearchParamsFromUrl(history, ['showParams']);
+                    return !state;
+                  });
+                },
               }}
             />
             {!isLoading && (
               <div
+                ref={paramsJsonViewRef}
                 data-testid="transaction-param-json-viewer"
                 className={`${styles.jsonContainer} ${!isParamsCollapsed ? styles.shrink : ''}`}
               >

--- a/src/modules/transaction/components/TransactionDetailsView/index.js
+++ b/src/modules/transaction/components/TransactionDetailsView/index.js
@@ -86,7 +86,7 @@ const TransactionDetails = () => {
       },
       {
         label: t('Value'),
-        value: getTransactionValue(transactionData, token),
+        value: getTransactionValue(transactionData, feeToken),
       },
       {
         label: t('Date'),

--- a/src/modules/transaction/components/TransactionDetailsView/styles.css
+++ b/src/modules/transaction/components/TransactionDetailsView/styles.css
@@ -5,6 +5,7 @@
   display: block;
   padding: 0 var(--horizontal-padding-l);
   box-sizing: border-box;
+  scroll-behavior: smooth;
 }
 
 .wrapper {

--- a/tests/fixtures/blockchainApplicationsExplore.js
+++ b/tests/fixtures/blockchainApplicationsExplore.js
@@ -11,7 +11,7 @@ const blockchainApplicationsExplore = [
     },
     lastCertificateHeight: 1000,
     lastUpdated: 1666566000000,
-    depositedLsk: 50000000,
+    escrowedLSK: 50000000,
   },
   {
     chainName: 'Colecti',
@@ -28,7 +28,7 @@ const blockchainApplicationsExplore = [
     },
     lastCertificateHeight: 900,
     lastUpdated: 1666566000000,
-    depositedLsk: 500000000,
+    escrowedLSK: 500000000,
   },
 ];
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5436,  #5435, #5439 and #5434

### How was it solved?

- [x] Filter out non-recognised transaction types on transaction list filter 
- [x] Add value to transaction details page
- [x] Continuous multi sig flow staking transaction. Silently switch to next account, prevent the "Are you sure?" switch. 

### How was it tested?

Transaction filter by types
1. Switch to a side chain
2. Navigate to the wallet or transaction monitor page
3. Try to filter the transaction by transaction type.
4. I should be observed that there are no missing transaction types in the Transaction type filter options.

Continuous flow for multi sig staking
1. Try to stake with a multi sig wallet (you should have the other required wallet in your accounts)
5. Continue to switch to required wallet and sign the transaction
6. Expected: Should work.
