### PR TITLE
Refactor request token link generation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,6 +6,7 @@
     "ipc": true,
     "LISK_ENABLE_DEV_TOOL": true,
     "PRODUCTION": true,
+    "LISK_DOMAIN": true,
     "REACT_APP_DEFAULT_NETWORK": true
   },
   "env": {

--- a/e2e/features/requestToken/RequestToken.feature
+++ b/e2e/features/requestToken/RequestToken.feature
@@ -27,7 +27,7 @@ Feature: Request Token
     Then button with text "Copy link" should be enabled
     And Element 'qrContainer' should not contain class 'disabled'
     Given I click on a button with text "Copy link"
-    Then Clipboard should contain "lisk://wallet?modal=send&recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&token=0400000000000000&recipientChain=04000000"
+    Then Clipboard should contain "https://lisk.com/send?recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&token=0400000000000000&recipientChain=04000000"
 
   Scenario: Request token should generate a copy link with message
     Given I type "10" in "amount"
@@ -36,7 +36,7 @@ Feature: Request Token
     Given I click on a button with text "Add message (Optional)"
     And I type "hello" in "reference-field"
     And I click on a button with text "Copy link"
-    Then Clipboard should contain "lisk://wallet?modal=send&recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&reference=hello&token=0400000000000000&recipientChain=04000000"
+    Then Clipboard should contain "https://lisk.com/send?recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&reference=hello&token=0400000000000000&recipientChain=04000000"
 
   Scenario: Request token should not generate a copy link if message exceeds 64 characters
     Given I type "10" in "amount"
@@ -55,4 +55,4 @@ Feature: Request Token
     And I type "hello&(&*#(@))*!#@$^%#@&@)world!@&$^#message*@)#*)@$$@&^!(@#)~~@" in "reference-field"
     Then I should possibly see "0 bytes left"
     And I click on a button with text "Copy link"
-    Then Clipboard should contain "lisk://wallet?modal=send&recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&reference=hello%26(%26*%23(%40))*!%23%40%24%5E%25%23%40%26%40)world!%40%26%24%5E%23message*%40)%23*)%40%24%24%40%26%5E!(%40%23)~~%40&token=0400000000000000&recipientChain=04000000"
+    Then Clipboard should contain "https://lisk.com/send?recipient=lskm9syv4wrjcjczpegz65zqxhk2cp9dkejs5wbjb&amount=10&reference=hello(*%23(%40))*!%23%40%24%5E%25%23%40%40)world!%40%24%5E%23message*%40)%23*)%40%24%24%40%5E!(%40%23)~~%40test1&token=0400000000000000&recipientChain=04000000"

--- a/setup/config/webpack.config.react.js
+++ b/setup/config/webpack.config.react.js
@@ -103,6 +103,7 @@ const config = {
     }),
     new DefinePlugin({
       VERSION: `"${bundleVersion}"`,
+      LISK_DOMAIN: '"https://lisk.com/send"',
       REACT_APP_DEFAULT_NETWORK: `"${process.env.DEFAULT_NETWORK}"`,
     }),
     new StyleLintPlugin({

--- a/setup/config/webpack.config.react.js
+++ b/setup/config/webpack.config.react.js
@@ -103,7 +103,7 @@ const config = {
     }),
     new DefinePlugin({
       VERSION: `"${bundleVersion}"`,
-      LISK_DOMAIN: '"https://staging.lisk.com"',
+      LISK_DOMAIN: '"https://lisk.com"',
       REACT_APP_DEFAULT_NETWORK: `"${process.env.DEFAULT_NETWORK}"`,
     }),
     new StyleLintPlugin({

--- a/setup/config/webpack.config.react.js
+++ b/setup/config/webpack.config.react.js
@@ -103,7 +103,7 @@ const config = {
     }),
     new DefinePlugin({
       VERSION: `"${bundleVersion}"`,
-      LISK_DOMAIN: '"https://lisk.com/send"',
+      LISK_DOMAIN: '"https://lisk.com"',
       REACT_APP_DEFAULT_NETWORK: `"${process.env.DEFAULT_NETWORK}"`,
     }),
     new StyleLintPlugin({

--- a/setup/config/webpack.config.react.js
+++ b/setup/config/webpack.config.react.js
@@ -103,7 +103,7 @@ const config = {
     }),
     new DefinePlugin({
       VERSION: `"${bundleVersion}"`,
-      LISK_DOMAIN: '"https://lisk.com"',
+      LISK_DOMAIN: '"https://staging.lisk.com"',
       REACT_APP_DEFAULT_NETWORK: `"${process.env.DEFAULT_NETWORK}"`,
     }),
     new StyleLintPlugin({

--- a/setup/jest.config.js
+++ b/setup/jest.config.js
@@ -346,7 +346,7 @@ module.exports = {
     VERSION: '',
     REACT_APP_DEFAULT_NETWORK: 'undefined',
     LISK_ENABLE_DEV_TOOL: false,
-    LISK_DOMAIN: 'https://lisk-test.com',
+    LISK_DOMAIN: 'https://staging.lisk.com',
   },
   coverageReporters: process.env.ON_JENKINS ? ['text', 'lcov', 'cobertura'] : ['html', 'json'],
   reporters: [

--- a/setup/jest.config.js
+++ b/setup/jest.config.js
@@ -346,7 +346,7 @@ module.exports = {
     VERSION: '',
     REACT_APP_DEFAULT_NETWORK: 'undefined',
     LISK_ENABLE_DEV_TOOL: false,
-    LISK_DOMAIN: 'https://staging.lisk.com',
+    LISK_DOMAIN: 'https://lisk.com',
   },
   coverageReporters: process.env.ON_JENKINS ? ['text', 'lcov', 'cobertura'] : ['html', 'json'],
   reporters: [

--- a/setup/jest.config.js
+++ b/setup/jest.config.js
@@ -346,6 +346,7 @@ module.exports = {
     VERSION: '',
     REACT_APP_DEFAULT_NETWORK: 'undefined',
     LISK_ENABLE_DEV_TOOL: false,
+    LISK_DOMAIN: 'https://lisk-test.com',
   },
   coverageReporters: process.env.ON_JENKINS ? ['text', 'lcov', 'cobertura'] : ['html', 'json'],
   reporters: [

--- a/src/modules/wallet/components/request/request.js
+++ b/src/modules/wallet/components/request/request.js
@@ -101,7 +101,7 @@ const Request = () => {
               fieldName === 'recipientChain' ? field.value.chainID : field.value
             )}`
           : link;
-      }, `lisk://wallet?modal=send&recipient=${address}`),
+      }, `${LISK_DOMAIN}?recipient=${address}`),
     [address, state]
   );
 

--- a/src/modules/wallet/components/request/request.js
+++ b/src/modules/wallet/components/request/request.js
@@ -101,7 +101,7 @@ const Request = () => {
               fieldName === 'recipientChain' ? field.value.chainID : field.value
             )}`
           : link;
-      }, `${LISK_DOMAIN}?recipient=${address}`),
+      }, `${LISK_DOMAIN}/send?recipient=${address}`),
     [address, state]
   );
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #5481

### How was it solved?

- [x] Change link generated on request token from using the `lisk:` domain to the lisk `https:` domain.
- [x] Fix failing tests

### How was it tested?

- Request token
- `https://lisk.com/send?<reset of the required query params>` should be copied to the clip board.
