### PR TITLE
Account name should be saved on enter key press

### DIFF
--- a/setup/react/app/ApplicationBootstrap.js
+++ b/setup/react/app/ApplicationBootstrap.js
@@ -119,6 +119,7 @@ const ApplicationBootstrap = ({ children }) => {
   return (
     <ApplicationBootstrapContext.Provider
       value={{
+        queryClient,
         hasNetworkError: isError && !blockchainAppsMeta.isFetching,
         isLoadingNetwork:
           (blockchainAppsMeta.isFetching && !blockchainAppsMeta.data) ||

--- a/src/modules/blockchainApplication/manage/components/UserApplicationSelector/UserApplicationSelector.js
+++ b/src/modules/blockchainApplication/manage/components/UserApplicationSelector/UserApplicationSelector.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useApplicationManagement } from '@blockchainApplication/manage/hooks';
@@ -7,6 +7,8 @@ import { addSearchParamsToUrl } from 'src/utils/searchParams';
 import ApplicationManagementRow from '@blockchainApplication/manage/components/ApplicationManagementRow';
 import { OutlineButton } from '@theme/buttons';
 import Icon from '@theme/Icon';
+import useSettings from '@settings/hooks/useSettings';
+import { Client } from 'src/utils/api/client';
 import Skeleton from 'src/modules/common/components/skeleton';
 import classNames from 'classnames';
 import styles from './UserApplicationSelector.css';
@@ -14,7 +16,10 @@ import styles from './UserApplicationSelector.css';
 const UserApplicationSelector = ({ className }) => {
   const history = useHistory();
   const { t } = useTranslation();
-  const { applications, isLoading } = useApplicationManagement();
+  const { mainChainNetwork } = useSettings('mainChainNetwork');
+  const queryClient = useRef(new Client({ http: mainChainNetwork.serviceUrl }));
+  const { applications, isLoading } = useApplicationManagement({ queryClient });
+
   const { hasNetworkError, isLoadingNetwork } = useContext(ApplicationBootstrapContext);
 
   const handleAddApplication = useCallback(() => {

--- a/src/modules/blockchainApplication/manage/hooks/useApplicationManagement.js
+++ b/src/modules/blockchainApplication/manage/hooks/useApplicationManagement.js
@@ -8,10 +8,12 @@ import { usePinBlockchainApplication } from './usePinBlockchainApplication';
 import { useApplicationExploreAndMetaData } from './useApplicationExploreAndMetaData';
 
 // eslint-disable-next-line max-statements
-export function useApplicationManagement() {
+export function useApplicationManagement({ queryClient }) {
   const dispatch = useDispatch();
   const [currentApplication, setCurrentApplication] = useCurrentApplication();
-  const { applications: defaultApplications, isLoading } = useApplicationExploreAndMetaData();
+  const { applications: defaultApplications, isLoading } = useApplicationExploreAndMetaData({
+    options: { ...(queryClient && { client: queryClient }) },
+  });
   const { mainChainNetwork = {} } = useSettings('mainChainNetwork');
 
   const { checkPinByChainId, pins } = usePinBlockchainApplication();

--- a/src/modules/blockchainApplication/manage/hooks/useApplicationManagement.js
+++ b/src/modules/blockchainApplication/manage/hooks/useApplicationManagement.js
@@ -8,7 +8,7 @@ import { usePinBlockchainApplication } from './usePinBlockchainApplication';
 import { useApplicationExploreAndMetaData } from './useApplicationExploreAndMetaData';
 
 // eslint-disable-next-line max-statements
-export function useApplicationManagement({ queryClient }) {
+export function useApplicationManagement({ queryClient } = {}) {
   const dispatch = useDispatch();
   const [currentApplication, setCurrentApplication] = useCurrentApplication();
   const { applications: defaultApplications, isLoading } = useApplicationExploreAndMetaData({

--- a/src/modules/common/constants.js
+++ b/src/modules/common/constants.js
@@ -117,3 +117,13 @@ export const INSUFFICENT_TOKEN_BALANCE_MESSAGE = {
   sendToken: i18next.t('There are no tokens to send at this moment.'),
   stakeValidator: i18next.t('Token balance is not enough to stake a validator.'),
 };
+
+export const shouldShowBookmark = (bookmarks, account, transactionJSON, token) => {
+  if (account.summary.address === transactionJSON.params.recipientAddress) {
+    return false;
+  }
+
+  return !bookmarks[token].find(
+    (bookmark) => bookmark.address === transactionJSON.params.recipientAddress
+  );
+};

--- a/src/modules/token/fungible/components/SendStatus/Status.js
+++ b/src/modules/token/fungible/components/SendStatus/Status.js
@@ -12,17 +12,8 @@ import { PrimaryButton } from '@theme/buttons';
 import DialogLink from '@theme/dialog/link';
 import { useValidators } from '@pos/validator/hooks/queries';
 import { selectModuleCommandSchemas } from 'src/redux/selectors';
+import { shouldShowBookmark } from 'src/modules/common/constants';
 import styles from './status.css';
-
-const shouldShowBookmark = (bookmarks, account, transactionJSON, token) => {
-  if (account.summary.address === transactionJSON.params.recipientAddress) {
-    return false;
-  }
-
-  return !bookmarks[token].find(
-    (bookmark) => bookmark.address === transactionJSON.params.recipientAddress
-  );
-};
 
 const getMessagesDetails = (transactions, status, t) => {
   const messages = statusMessages(t);

--- a/src/modules/transaction/components/Multisignature/Multisignature.js
+++ b/src/modules/transaction/components/Multisignature/Multisignature.js
@@ -126,6 +126,9 @@ const Multisignature = ({
   moduleCommandSchemas,
   application,
   reset,
+  children,
+  account,
+  illustration,
 }) => {
   const [copied, setCopied] = useState(false);
   const ref = useRef();
@@ -175,11 +178,21 @@ const Multisignature = ({
   useEffect(() => resetTransactionResult, []);
   useEffect(() => () => clearTimeout(ref.current), []);
 
+  const getChildrentToRender = () => {
+    if (status.code !== txStatusTypes.broadcastSuccess) return null;
+
+    if (typeof children === 'function')
+      children({ transactions, network, account, status, illustration });
+
+    return children;
+  };
+
   return (
     <div className={`${styles.wrapper} ${className}`}>
       <Illustration name={getIllustration(status.code, 'signMultisignature')} />
       <h6 className="result-box-header">{title}</h6>
       {!nextAccountToSign && <p className="transaction-status body-message">{message}</p>}
+      {getChildrentToRender()}
       {nextAccountToSign && status.code !== txStatusTypes.multisigSignatureSuccess && (
         <div className={styles.requiredAccountSection}>
           <WarningNotification

--- a/src/modules/wallet/components/AccountDetails/index.js
+++ b/src/modules/wallet/components/AccountDetails/index.js
@@ -225,6 +225,7 @@ const AccountDetails = () => {
                       onClick={updateAccountName}
                       className={`account-cancel-button ${styles.cancelBtn}`}
                       size="m"
+                      type="button"
                     >
                       {t('Cancel')}
                     </TertiaryButton>

--- a/src/modules/wallet/components/signMultisigStatus/index.js
+++ b/src/modules/wallet/components/signMultisigStatus/index.js
@@ -2,12 +2,14 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { withTranslation } from 'react-i18next';
 import { withRouter } from 'react-router';
-import { selectActiveTokenAccount } from 'src/redux/selectors';
+import { selectActiveToken, selectActiveTokenAccount } from 'src/redux/selectors';
 import Status from './status';
 
 const mapStateToProps = (state) => ({
   transactions: state.transactions,
   account: selectActiveTokenAccount(state),
+  bookmarks: state.bookmarks,
+  token: selectActiveToken(state),
 });
 
 export default compose(connect(mapStateToProps), withRouter, withTranslation())(Status);

--- a/src/modules/wallet/components/signMultisigStatus/share.test.js
+++ b/src/modules/wallet/components/signMultisigStatus/share.test.js
@@ -6,6 +6,8 @@ import { mockAuth } from '@auth/__fixtures__';
 import useTxInitiatorAccount from '@transaction/hooks/useTxInitiatorAccount';
 import { useValidators } from '@pos/validator/hooks/queries';
 import { mockValidators } from '@pos/validator/__fixtures__';
+import DialogLink from '@theme/dialog/link';
+import { mockAppsTokens } from '@token/fungible/__fixtures__';
 import Status from './status';
 
 jest.mock('@libs/wcm/hooks/useSession', () => ({
@@ -107,6 +109,37 @@ describe('Sign Multisignature Tx Status component', () => {
       title: 'Transaction submitted',
       className: 'content',
     });
+  });
+
+  it('should shows bookmark', () => {
+    const propsSuccess = {
+      ...props,
+      transactions: {
+        txBroadcastError: null,
+        txSignatureError: null,
+        signedTransaction: {},
+      },
+      transactionJSON: {
+        senderPublicKey: accounts.genesis.summary.publicKey,
+        signatures: [accounts.genesis.summary.publicKey],
+        nonce: '20',
+        fee: '164000',
+        module: 'token',
+        command: 'transfer',
+        params: {
+          tokenID: mockAppsTokens.data[0].tokenID,
+          amount: 1000000,
+          recipientAddress: accounts.genesis.summary.address,
+          data: '',
+        },
+      },
+      bookmarks: {
+        LSK: [],
+      },
+    };
+
+    const wrapper = shallow(<Status {...propsSuccess} />);
+    expect(wrapper.find(DialogLink));
   });
 
   it('passes correct props to TxBroadcaster when transaction broadcast fails', () => {

--- a/src/modules/wallet/components/signMultisigStatus/share.test.js
+++ b/src/modules/wallet/components/signMultisigStatus/share.test.js
@@ -4,14 +4,18 @@ import TxBroadcaster from '@transaction/components/TxBroadcaster';
 import accounts from '@tests/constants/wallets';
 import { mockAuth } from '@auth/__fixtures__';
 import useTxInitiatorAccount from '@transaction/hooks/useTxInitiatorAccount';
+import { useValidators } from '@pos/validator/hooks/queries';
+import { mockValidators } from '@pos/validator/__fixtures__';
 import Status from './status';
 
 jest.mock('@libs/wcm/hooks/useSession', () => ({
   respond: jest.fn(),
 }));
 jest.mock('@transaction/hooks/useTxInitiatorAccount');
+jest.mock('@pos/validator/hooks/queries/useValidators');
 
 describe('Sign Multisignature Tx Status component', () => {
+  const mockFetchNextValidators = jest.fn();
   const props = {
     t: (str, dict) => (dict ? str.replace('{{errorMessage}}', dict.errorMessage) : str),
     sender: { data: accounts.multiSig },
@@ -34,6 +38,9 @@ describe('Sign Multisignature Tx Status component', () => {
         signatures: [],
       },
     },
+    account: accounts.multiSig,
+    bookmarks: { LSK: [] },
+    token: 'LSK',
   };
 
   const signedTransaction = {
@@ -54,6 +61,12 @@ describe('Sign Multisignature Tx Status component', () => {
   useTxInitiatorAccount.mockReturnValue({
     txInitiatorAccount: { ...mockAuth.data, ...mockAuth.meta, keys: { ...mockAuth.data } },
     isLoading: false,
+  });
+  useValidators.mockReturnValue({
+    data: mockValidators,
+    isFetching: false,
+    fetchNextPage: mockFetchNextValidators,
+    hasNextPage: false,
   });
 
   // @todo reinstate by #4506.
@@ -110,16 +123,19 @@ describe('Sign Multisignature Tx Status component', () => {
     };
 
     const wrapper = shallow(<Status {...propsWithError} />);
-    expect(wrapper.find(TxBroadcaster).props()).toEqual({
-      illustration: 'signMultisignature',
-      status: {
-        code: 'BROADCAST_ERROR',
-        message: JSON.stringify({ transaction: {}, error: 'error:test' }),
-      },
-      title: 'Transaction failed',
-      message: 'An error occurred while sending your transaction to the network. Please try again.',
-      className: 'content',
-    });
+    expect(wrapper.find(TxBroadcaster).props()).toEqual(
+      expect.objectContaining({
+        illustration: 'signMultisignature',
+        status: {
+          code: 'BROADCAST_ERROR',
+          message: JSON.stringify({ transaction: {}, error: 'error:test' }),
+        },
+        title: 'Transaction failed',
+        message:
+          'An error occurred while sending your transaction to the network. Please try again.',
+        className: 'content',
+      })
+    );
   });
 
   it('passes correct props to TxBroadcaster when partial signed transaction', () => {
@@ -134,14 +150,16 @@ describe('Sign Multisignature Tx Status component', () => {
     };
 
     const wrapper = shallow(<Status {...propsWithSignedTx} />);
-    expect(wrapper.find(TxBroadcaster).props()).toEqual({
-      illustration: 'signMultisignature',
-      status: { code: 'MULTISIG_SIGNATURE_PARTIAL_SUCCESS' },
-      title: 'The transaction is partially signed',
-      message:
-        'Your signature has been successfully included in the transaction. Kindly copy or download the partially signed transaction and share it with the remaining members to collect all required signatures before broadcasting.',
-      className: 'content',
-    });
+    expect(wrapper.find(TxBroadcaster).props()).toEqual(
+      expect.objectContaining({
+        illustration: 'signMultisignature',
+        status: { code: 'MULTISIG_SIGNATURE_PARTIAL_SUCCESS' },
+        title: 'The transaction is partially signed',
+        message:
+          'Your signature has been successfully included in the transaction. Kindly copy or download the partially signed transaction and share it with the remaining members to collect all required signatures before broadcasting.',
+        className: 'content',
+      })
+    );
   });
 
   // @todo reinstate by #4506.
@@ -164,13 +182,15 @@ describe('Sign Multisignature Tx Status component', () => {
     };
 
     const wrapper = shallow(<Status {...propsWithSignedTx} />);
-    expect(wrapper.find(TxBroadcaster).props()).toEqual({
-      illustration: 'signMultisignature',
-      status: { code: 'MULTISIG_SIGNATURE_SUCCESS' },
-      title: 'The transaction is now fully signed',
-      message:
-        'Now you can send it to the network. You may also copy or download it, if you wish to send the transaction using another device later.',
-      className: 'content',
-    });
+    expect(wrapper.find(TxBroadcaster).props()).toEqual(
+      expect.objectContaining({
+        illustration: 'signMultisignature',
+        status: { code: 'MULTISIG_SIGNATURE_SUCCESS' },
+        title: 'The transaction is now fully signed',
+        message:
+          'Now you can send it to the network. You may also copy or download it, if you wish to send the transaction using another device later.',
+        className: 'content',
+      })
+    );
   });
 });

--- a/src/modules/wallet/components/signMultisigStatus/status.js
+++ b/src/modules/wallet/components/signMultisigStatus/status.js
@@ -12,6 +12,8 @@ import {
   isTxStatusError,
 } from '@transaction/configuration/statusConfig';
 import useTxInitiatorAccount from '@transaction/hooks/useTxInitiatorAccount';
+import { joinModuleAndCommand } from '@transaction/utils';
+import { MODULE_COMMANDS_NAME_MAP } from '@transaction/configuration/moduleCommand';
 import { selectModuleCommandSchemas } from 'src/redux/selectors';
 import { shouldShowBookmark } from 'src/modules/common/constants';
 import { PrimaryButton } from 'src/theme/buttons';
@@ -58,9 +60,13 @@ const Status = ({ transactions, t, transactionJSON, reset, bookmarks, account, t
     canSenderSignTx,
   });
 
+  const moduleCommand = joinModuleAndCommand(transactionJSON);
+
   const isBroadcastError = isTxStatusError(status.code);
   const showBookmark =
-    !isBroadcastError && shouldShowBookmark(bookmarks, account, transactionJSON, token);
+    !isBroadcastError &&
+    shouldShowBookmark(bookmarks, account, transactionJSON, token) &&
+    moduleCommand === MODULE_COMMANDS_NAME_MAP.transfer;
   const template = statusMessages(t)[status.code];
   return (
     <section>

--- a/src/modules/wallet/components/signMultisigStatus/status.js
+++ b/src/modules/wallet/components/signMultisigStatus/status.js
@@ -4,16 +4,23 @@ import Box from 'src/theme/box';
 import BoxContent from 'src/theme/box/content';
 import TxBroadcaster from '@transaction/components/TxBroadcaster';
 import { useCurrentAccount } from '@account/hooks';
-import { statusMessages, getTransactionStatus } from '@transaction/configuration/statusConfig';
+import DialogLink from '@theme/dialog/link';
+import { useValidators } from '@pos/validator/hooks/queries';
+import {
+  statusMessages,
+  getTransactionStatus,
+  isTxStatusError,
+} from '@transaction/configuration/statusConfig';
 import useTxInitiatorAccount from '@transaction/hooks/useTxInitiatorAccount';
 import { selectModuleCommandSchemas } from 'src/redux/selectors';
-
+import { shouldShowBookmark } from 'src/modules/common/constants';
+import { PrimaryButton } from 'src/theme/buttons';
 import ProgressBar from '../signMultisigView/progressBar';
 import styles from './styles.css';
 import { useMultiSignatureStatus } from '../../hooks/useMultiSignatureStatus';
 
 // eslint-disable-next-line max-statements
-const Status = ({ transactions, t, transactionJSON, reset }) => {
+const Status = ({ transactions, t, transactionJSON, reset, bookmarks, account, token }) => {
   const [currentAccount] = useCurrentAccount();
   const moduleCommandSchemas = useSelector(selectModuleCommandSchemas);
 
@@ -24,6 +31,10 @@ const Status = ({ transactions, t, transactionJSON, reset }) => {
   const { mandatoryKeys, optionalKeys, numberOfSignatures, publicKey } = txInitiatorAccount;
   const isMultisignature =
     transactions.signedTransaction.params?.numberOfSignatures > 0 || numberOfSignatures > 0;
+  const { data: validators } = useValidators({
+    config: { params: { address: transactionJSON.params.recipientAddress } },
+  });
+  const validator = validators?.data?.[0];
 
   const { canSenderSignTx } = useMultiSignatureStatus({
     transactions,
@@ -47,6 +58,9 @@ const Status = ({ transactions, t, transactionJSON, reset }) => {
     canSenderSignTx,
   });
 
+  const isBroadcastError = isTxStatusError(status.code);
+  const showBookmark =
+    !isBroadcastError && shouldShowBookmark(bookmarks, account, transactionJSON, token);
   const template = statusMessages(t)[status.code];
   return (
     <section>
@@ -68,7 +82,24 @@ const Status = ({ transactions, t, transactionJSON, reset }) => {
             className={styles.content}
             status={status}
             reset={reset}
-          />
+          >
+            {showBookmark ? (
+              <div className={`${styles.bookmarkBtn} bookmark-container`}>
+                <DialogLink
+                  component="addBookmark"
+                  data={{
+                    formAddress: transactionJSON.params.recipientAddress,
+                    label: validator?.name ?? '',
+                    isValidator: !!validator,
+                  }}
+                >
+                  <PrimaryButton className={`${styles.btn} bookmark-btn`}>
+                    {t('Add address to bookmarks')}
+                  </PrimaryButton>
+                </DialogLink>
+              </div>
+            ) : null}
+          </TxBroadcaster>
         </BoxContent>
       </Box>
     </section>

--- a/src/modules/wallet/components/signMultisigStatus/status.js
+++ b/src/modules/wallet/components/signMultisigStatus/status.js
@@ -68,6 +68,7 @@ const Status = ({ transactions, t, transactionJSON, reset, bookmarks, account, t
     shouldShowBookmark(bookmarks, account, transactionJSON, token) &&
     moduleCommand === MODULE_COMMANDS_NAME_MAP.transfer;
   const template = statusMessages(t)[status.code];
+
   return (
     <section>
       <Box className={styles.boxContainer}>

--- a/src/modules/wallet/components/signMultisigStatus/styles.css
+++ b/src/modules/wallet/components/signMultisigStatus/styles.css
@@ -22,3 +22,15 @@
     }
   }
 }
+
+.boxContainer {
+  & .bookmarkBtn {
+    position: relative;
+    margin-top: 20px;
+
+    & > div:first-child {
+      display: flex;
+      justify-content: center;
+    }
+  }
+}


### PR DESCRIPTION
### What was the problem?

This PR resolves #5501, #5490, #5516

### How was it solved?

- [x] Add type button to the cancel button.
- [x] Introduce bookmark button to muti-signature status modal.
- [x] Fix unit test

### How was it tested?

How to test change account name fix
- Navigate to account details modal
- Try changing the name of the account and hit the enter key
- The account name should be saved

How to test bookmarking on muti-signature transaction status
- Initiate a send token transaction to a non-bookmarked address from a multi-signature account.
- Collect all signatures and send the finialise the transaction.
- It should be seen that on the status page, the add to bookmark button is shown.