### PR TITLE
Prevent crash when a transaction is pending in a row

### DIFF
--- a/src/modules/transaction/__fixtures__/mockTransactions.js
+++ b/src/modules/transaction/__fixtures__/mockTransactions.js
@@ -33,7 +33,7 @@ const transaction = (index) => ({
     isFinal: true,
   },
   confirmations: 22 + index,
-  executionStatus: 'pending',
+  executionStatus: 'Final',
   meta: {
     recipient: {
       address: 'lsktk7bj2yadx5vq3f87gh5cwca7ptpk5djpxhhc3',

--- a/src/modules/transaction/__fixtures__/mockTransactions.js
+++ b/src/modules/transaction/__fixtures__/mockTransactions.js
@@ -33,7 +33,7 @@ const transaction = (index) => ({
     isFinal: true,
   },
   confirmations: 22 + index,
-  executionStatus: 'Final',
+  executionStatus: 'Successful',
   meta: {
     recipient: {
       address: 'lsktk7bj2yadx5vq3f87gh5cwca7ptpk5djpxhhc3',

--- a/src/modules/transaction/components/TransactionRow/components.js
+++ b/src/modules/transaction/components/TransactionRow/components.js
@@ -39,9 +39,15 @@ export const ID = ({ isWallet }) => {
   );
 };
 
-export const Height = () => {
+export const Height = ({ t }) => {
   const { data } = useContext(TransactionRowContext);
-  return <span>{data.block.height}</span>;
+
+  const isPending = data.executionStatus === 'pending';
+  if (isPending || !data.block?.height) {
+    return <Spinner completed={isPending || data.block.isFinal} label={t('Pending...')} />;
+  }
+
+  return <span>{data.block?.height || '-'}</span>;
 };
 
 export const Round = () => {
@@ -133,9 +139,10 @@ export const Counterpart = () => {
 
 export const Date = ({ t }) => {
   const { data } = useContext(TransactionRowContext);
+  const isPending = data.executionStatus === 'pending';
 
-  if (!data.block.timestamp) {
-    return <Spinner completed={data.block.isFinal} label={t('Pending...')} />;
+  if (isPending || !data.block?.timestamp) {
+    return <Spinner completed={isPending || data.block.isFinal} label={t('Pending...')} />;
   }
 
   return (

--- a/src/modules/transaction/components/TransactionRow/components.js
+++ b/src/modules/transaction/components/TransactionRow/components.js
@@ -44,7 +44,7 @@ export const Height = ({ t }) => {
 
   const isPending = data.executionStatus === 'pending';
   if (isPending || !data.block?.height) {
-    return <Spinner completed={isPending || data.block.isFinal} label={t('Pending...')} />;
+    return <Spinner completed={isPending || data.block?.isFinal} label={t('Pending...')} />;
   }
 
   return <span>{data.block?.height || '-'}</span>;
@@ -142,7 +142,7 @@ export const Date = ({ t }) => {
   const isPending = data.executionStatus === 'pending';
 
   if (isPending || !data.block?.timestamp) {
-    return <Spinner completed={isPending || data.block.isFinal} label={t('Pending...')} />;
+    return <Spinner completed={isPending || data.block?.isFinal} label={t('Pending...')} />;
   }
 
   return (


### PR DESCRIPTION
### What was the problem?

This PR resolves #5526 

### How was it solved?

Check if a transaction is pending before trying to access its block. If it is pending the `block` object is undefined.

### How was it tested?
Doesnt always happen, need to make a transaction pending and keep it pending. Currently testnet has such a transaction so the above how to test works while it is still pending. 

1. Go to /transactions page.
2. Expected Not crash: Height and Date (which comes from `block` object) should display a pending symbo, check first row.
<img width="2145" alt="image" src="https://github.com/LiskHQ/lisk-desktop/assets/8784876/46c11c3c-ee07-44a6-9ecf-88333a4f596d">

