### PR TITLE
Fix transactions page update

### DIFF
--- a/src/modules/transaction/components/Explorer/ExplorerTransactions.js
+++ b/src/modules/transaction/components/Explorer/ExplorerTransactions.js
@@ -35,6 +35,9 @@ const Transactions = ({ activeToken, address }) => {
     amountTo: (value) => `< ${value}`,
   };
 
+  const shouldRefetchTransactions = (data) =>
+    data?.data?.some((queryData) => queryData.block.executionStatus === 'pending');
+
   return (
     <Box main className={`${styles.wrapper} transactions-box`}>
       <BoxHeader>
@@ -69,6 +72,7 @@ const Transactions = ({ activeToken, address }) => {
           header={header(t, activeToken, toggleSort)}
           headerClassName={styles.tableHeader}
           currentSort={sort}
+          checkRefetch={shouldRefetchTransactions}
           emptyState={{
             message: t('There are no transactions for this account.'),
             illustration: 'emptyTransactionsIllustration',

--- a/src/modules/transaction/components/TransactionMonitor/TransactionMonitorList.js
+++ b/src/modules/transaction/components/TransactionMonitor/TransactionMonitorList.js
@@ -109,6 +109,9 @@ const Transactions = () => {
     clearFilters();
   };
 
+  const shouldRefetchTransactions = (data) =>
+    data?.data?.some((queryData) => queryData.block.executionStatus === 'pending');
+
   return (
     <Box main className="transactions-box">
       <StickyHeader
@@ -154,6 +157,7 @@ const Transactions = () => {
           header={removeSortOnAmount(header(toggleSort, t), filters)}
           headerClassName={styles.tableHeader}
           currentSort={sort}
+          checkRefetch={shouldRefetchTransactions}
           emptyState={{
             message: t('There are no transactions for this chain.'),
             illustration: 'emptyTransactionsIllustration',

--- a/src/theme/QueryTable/QueryTable.js
+++ b/src/theme/QueryTable/QueryTable.js
@@ -11,6 +11,7 @@ export const QueryTable = ({
   transformResponse,
   onFetched,
   onQueryChange,
+  checkRefetch,
   ...props
 }) => {
   const data = queryHook(queryConfig);
@@ -52,6 +53,11 @@ export const QueryTable = ({
       </LoadNewButton>
     ));
 
+  const tableUpdate = (queryData, dataRefetch) => {
+    const shouldRefetch = checkRefetch?.(queryData);
+    if (shouldRefetch) dataRefetch();
+  };
+
   useEffect(() => {
     if (isFetched && typeof onFetched === 'function') {
       onFetched(response);
@@ -61,6 +67,10 @@ export const QueryTable = ({
   useEffect(() => {
     onQueryChange?.(data);
   }, [data]);
+
+  useEffect(() => {
+    tableUpdate(response, refetch);
+  }, [response]);
 
   return (
     <Table


### PR DESCRIPTION
### What was the problem?

This PR resolves #5550

### How was it solved?

Implemented refetch for pending transactions

### How was it tested?

- Make a POS transaction
- Quickly switch to wallet or transactions page
- Check if the new transaction has date and height pending
- If so, then it should update shortly after with the right details
