### PR TITLE
Change commission summary modal width

### DIFF
--- a/src/modules/pos/validator/components/ChangeCommission/Dialog/ChangeCommissionDialog.js
+++ b/src/modules/pos/validator/components/ChangeCommission/Dialog/ChangeCommissionDialog.js
@@ -20,7 +20,7 @@ export const ChangeCommission = () => {
   };
 
   return (
-    <Dialog hasClose size={currentStep === 1 && 'sm'}>
+    <Dialog hasClose size={currentStep === 1 ? 'md' : 'sm'}>
       <MultiStep prevPage={history.goBack} onChange={onMultiStepChange} backButtonLabel={t('Back')}>
         <Form />
         <Summary />

--- a/src/modules/pos/validator/components/ChangeCommission/Dialog/ChangeCommissionDialog.js
+++ b/src/modules/pos/validator/components/ChangeCommission/Dialog/ChangeCommissionDialog.js
@@ -1,5 +1,5 @@
 /* istanbul ignore file */
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -13,10 +13,15 @@ import Status from '../Status';
 export const ChangeCommission = () => {
   const history = useHistory();
   const { t } = useTranslation();
+  const [currentStep, setCurrentStep] = useState(0);
+
+  const onMultiStepChange = ({ step: { current } }) => {
+    setCurrentStep(current);
+  };
 
   return (
-    <Dialog hasClose size="sm">
-      <MultiStep prevPage={history.goBack} backButtonLabel={t('Back')}>
+    <Dialog hasClose size={currentStep === 1 && 'sm'}>
+      <MultiStep prevPage={history.goBack} onChange={onMultiStepChange} backButtonLabel={t('Back')}>
         <Form />
         <Summary />
         <TxSignatureCollector confirmText={t('Confirm and sign')} />

--- a/src/modules/pos/validator/hooks/useCurrentCommissionPercentage.js
+++ b/src/modules/pos/validator/hooks/useCurrentCommissionPercentage.js
@@ -8,7 +8,7 @@ export const useCurrentCommissionPercentage = (address) => {
   const config = { params: { address: address ?? currentAccount?.metadata?.address } };
   const { data, ...others } = useValidators({ config });
   const currentCommission = useMemo(
-    () => convertCommissionToPercentage(data?.data[0].commission),
+    () => convertCommissionToPercentage(data?.data[0]?.commission),
     [data]
   );
 

--- a/src/theme/dialog/dialog.css
+++ b/src/theme/dialog/dialog.css
@@ -212,3 +212,8 @@
   max-width: 520px;
   min-width: 450px;
 }
+
+.md {
+  min-width: 520px;
+  max-width: 600px;
+}


### PR DESCRIPTION
### What was the problem?

This PR resolves #5512

### How was it solved?

Dont use small modal on Transaction Summary step

### How was it tested?

1. Go to changeCommission modal with a multi sig account
2. Expected: Should not cut pubkey
